### PR TITLE
Overload Pow2 functions to do 64-bit ints

### DIFF
--- a/src/Math/MathFunc.cpp
+++ b/src/Math/MathFunc.cpp
@@ -142,6 +142,11 @@ bool IsPow2(unsigned int number)
 	return (number & (number-1)) == 0;
 }
 
+bool IsPow2(u64 number)
+{
+    return (number & (number-1)) == 0;
+}
+
 unsigned int RoundUpPow2(unsigned int x)
 {
 	assert(sizeof(unsigned int) <= 4);
@@ -151,6 +156,21 @@ unsigned int RoundUpPow2(unsigned int x)
 	x |= x >> 4;
 	x |= x >> 8;
 	x |= x >> 16;
+	++x;
+
+	return x;
+}
+
+u64 RoundUpPow2(u64 x)
+{
+	assert(sizeof(u64) <= 8);
+	--x;
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
+	x |= x >> 32;
 	++x;
 
 	return x;
@@ -167,9 +187,27 @@ unsigned int RoundDownPow2(unsigned int x)
 	return x - (x >> 1);
 }
 
+u64 RoundDownPow2(u64 x)
+{
+	assert(sizeof(u64) <= 8);
+	x |= x >> 1;
+	x |= x >> 2;
+	x |= x >> 4;
+	x |= x >> 8;
+	x |= x >> 16;
+	x |= x >> 32;
+	return x - (x >> 1);
+}
+
 int RoundIntUpToMultipleOfPow2(int x, int n)
 {
-	assert(IsPow2(n));
+	assert(IsPow2((unsigned int)n));
+	return (x + n-1) & ~(n-1);
+}
+
+s64 RoundIntUpToMultipleOfPow2(s64 x, s64 n)
+{
+	assert(IsPow2((u64)n));
 	return (x + n-1) & ~(n-1);
 }
 

--- a/src/Math/MathFunc.h
+++ b/src/Math/MathFunc.h
@@ -158,17 +158,21 @@ float Tanh(float x);
 /// Returns true if the given number is a power of 2.
 /** @see RoundUpPow2(), RoundDownPow2(). */
 bool IsPow2(unsigned int number);
+bool IsPow2(u64 number);
 /// Returns the smallest power-of-2 number (1,2,4,8,16,32,...) greater or equal than the given number.
 /** @see IsPow2(), RoundDownPow2(). */
 unsigned int RoundUpPow2(unsigned int number);
+u64 RoundUpPow2(u64 number);
 /// Returns the largest power-of-2 number (1,2,4,8,16,32,...) smaller or equal than the given number.
 /** @see IsPow2(), RoundUpPow2(). */
 unsigned int RoundDownPow2(unsigned int number);
+u64 RoundUpPow2(u64 number);
 
 /// Returns the given number rounded up to the next multiple of n.
 /** @param x The number to round up.
 	@param n The multiple to round x to. The value n must be a power-of-2. */
 int RoundIntUpToMultipleOfPow2(int x, int n);
+s64 RoundIntUpToMultipleOfPow2(s64 x, s64 n);
 
 /// Raises the given base to an integral exponent.
 /** @see Pow(), Exp(). */


### PR DESCRIPTION
While not immediately useful for MathGeoLib the functions in MathFunc
are convenient for projects that end up depending on MathGeoLib anyway.

In such projects, 64-bit versions of the Pow2 family of functions are
useful.
