### PR TITLE
fixed compilation error when defining MATH_BULLET_INTEROP

### DIFF
--- a/src/Math/Quat.h
+++ b/src/Math/Quat.h
@@ -37,6 +37,10 @@
 #include <OgreQuaternion.h>
 #endif
 
+#ifdef MATH_BULLET_INTEROP
+#include <LinearMath/btQuaternion.h>
+#endif
+
 MATH_BEGIN_NAMESPACE
 
 /// Represents a rotation or an orientation of a 3D object.


### PR DESCRIPTION
The file **Quat.h** doesn't include **btQuaternion.h** when **MATH_BULLET_INTEROP** is defined, resulting in a compilation error in Quat.h:401 "error: 'btQuaternion' does not name a type" (g++ 4.8.2).
