### PR TITLE
Fix Sphere/LineSegment intersection not returning the intersection count

### DIFF
--- a/src/Geometry/Sphere.cpp
+++ b/src/Geometry/Sphere.cpp
@@ -612,7 +612,7 @@ int Sphere::Intersects(const LineSegment &l, vec *intersectionPoint, vec *inters
 	if (d2)
 		*d2 = t2 / lineLength;
 
-	return true;
+	return numIntersections;
 }
 
 bool Sphere::Intersects(const Plane &plane) const


### PR DESCRIPTION
Found an error while doing Sphere/LineSegment intersection tests.

True was always returned in case of intersections, which converted silently to 1 even if there are actually two intersection points.