### PR TITLE
Fix undefined Plane::Distance() method

### DIFF
--- a/src/Geometry/Plane.h
+++ b/src/Geometry/Plane.h
@@ -152,8 +152,7 @@ public:
 			of this plane. See the SignedDistance() function to produce a distance value that differentiates between the
 			front and back sides of this plane.
 		@see SignedDistance(), Intersects(), Contains(). */
-	float Distance(const float3 &point) const;
-	float Distance(const float4 &point) const;
+	float Distance(const vec &point) const;
 	float Distance(const LineSegment &lineSegment) const;
 	float Distance(const Sphere &sphere) const;
 	float Distance(const Capsule &capsule) const;


### PR DESCRIPTION
Hi,
Got a linking error after enabling SSE due to the Plane::Distance() method having float3/float4 versions in the headers and a vec3 version in the implementation file.