### PR TITLE
Prefix assume & assert definitions to prevent name clashes

### DIFF
--- a/src/Algorithm/GJK.cpp
+++ b/src/Algorithm/GJK.cpp
@@ -47,12 +47,12 @@ vec UpdateSimplex(vec *s, int &n)
 		float d0 = s[0].DistanceSq(vec::zero);
 		float d1 = s[1].DistanceSq(vec::zero);
 		float d2 = LineSegment(s[0], s[1]).DistanceSq(vec::zero);
-		assert2(d2 <= d0, d2, d0);
-		assert2(d2 <= d1, d2, d1);
+		mgl_assert2(d2 <= d0, d2, d0);
+		mgl_assert2(d2 <= d1, d2, d1);
 		// Cannot be in case 0: the step 0 -> 1 must have been toward the zero direction:
-		assert(Dot(s[1]-s[0], -s[0]) >= 0.f);
+		mgl_assert(Dot(s[1]-s[0], -s[0]) >= 0.f);
 		// Cannot be in case 1: the zero direction cannot be in the voronoi region of vertex s[1].
-		assert(Dot(s[1]-s[0], -s[1]) <= 0.f);
+		mgl_assert(Dot(s[1]-s[0], -s[1]) <= 0.f);
 #endif
 
 		vec d01 = s[1] - s[0];
@@ -105,10 +105,10 @@ vec UpdateSimplex(vec *s, int &n)
 				minDistIndex = i;
 			}
 
-		assert4(isContainedInTriangle || dist <= d[0] + 1e-4f, d[0], dist, isContainedInTriangle, minDistIndex);
-		assert4(isContainedInTriangle || dist <= d[1] + 1e-4f, d[1], dist, isContainedInTriangle, minDistIndex);
-		assert4(isContainedInTriangle || dist <= d[2] + 1e-4f, d[2], dist, isContainedInTriangle, minDistIndex);
-		assert4(isContainedInTriangle || dist <= d[3] + 1e-4f, d[3], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[0] + 1e-4f, d[0], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[1] + 1e-4f, d[1], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[2] + 1e-4f, d[2], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[3] + 1e-4f, d[3], dist, isContainedInTriangle, minDistIndex);
 #endif
 		vec d12 = s[2]-s[1];
 		vec d02 = s[2]-s[0];
@@ -120,7 +120,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 4: Edge 1->2 is closest.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(d[4] <= dist + 1e-3f * Max(1.f, d[4], dist), d[4], dist, isContainedInTriangle, minDistIndex);
+			mgl_assert4(d[4] <= dist + 1e-3f * Max(1.f, d[4], dist), d[4], dist, isContainedInTriangle, minDistIndex);
 #endif
 			vec newDir = Cross(d12, Cross(d12, s[1]));
 			s[0] = s[1];
@@ -134,7 +134,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 5: Edge 0->2 is closest.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(d[5] <= dist + 1e-3f * Max(1.f, d[5], dist), d[5], dist, isContainedInTriangle, minDistIndex);
+			mgl_assert4(d[5] <= dist + 1e-3f * Max(1.f, d[5], dist), d[5], dist, isContainedInTriangle, minDistIndex);
 #endif
 			vec newDir = Cross(d02, Cross(d02, s[0]));
 			s[1] = s[2];
@@ -143,7 +143,7 @@ vec UpdateSimplex(vec *s, int &n)
 		}
 		// Cases 6)-8):
 #ifdef MATH_ASSERT_CORRECTNESS
-		assert4(d[6] <= dist + 1e-3f * Max(1.f, d[6], dist), d[6], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(d[6] <= dist + 1e-3f * Max(1.f, d[6], dist), d[6], dist, isContainedInTriangle, minDistIndex);
 #endif
 		float scaledSignedDistToTriangle = triNormal.Dot(s[2]);
 		float distSq = scaledSignedDistToTriangle*scaledSignedDistToTriangle;
@@ -216,7 +216,7 @@ vec UpdateSimplex(vec *s, int &n)
 		vec Tri023Normal = Cross(s[3]-s[0], s[2]-s[0]);
 		vec Tri123Normal = Cross(s[2]-s[1], s[3]-s[1]);
 		vec Tri012Normal = Cross(s[2] - s[0], s[1] - s[0]);
-		assert(Dot(Tri012Normal, s[3] - s[0]) <= 0.f);
+		mgl_assert(Dot(Tri012Normal, s[3] - s[0]) <= 0.f);
 		float InTri012 = Dot(-s[0], Tri012Normal);
 		float InTri013 = Dot(-s[3], Tri013Normal);
 		float InTri023 = Dot(-s[3], Tri023Normal);
@@ -232,13 +232,13 @@ vec UpdateSimplex(vec *s, int &n)
 					dist = d[i];
 					minDistIndex = i;
 				}
-		assert4(insideSimplex || dist <= d[0] + 1e-4 * Max(1.0, d[0], dist), d[0], dist, insideSimplex, minDistIndex);
-		assert4(insideSimplex || dist <= d[1] + 1e-4 * Max(1.0, d[1], dist), d[1], dist, insideSimplex, minDistIndex);
-		assert4(insideSimplex || dist <= d[2] + 1e-4 * Max(1.0, d[2], dist), d[2], dist, insideSimplex, minDistIndex);
-		assert4(insideSimplex || dist <= d[4] + 1e-4 * Max(1.0, d[4], dist), d[4], dist, insideSimplex, minDistIndex);
-		assert4(insideSimplex || dist <= d[5] + 1e-4 * Max(1.0, d[5], dist), d[5], dist, insideSimplex, minDistIndex);
-		assert4(insideSimplex || dist <= d[7] + 1e-4 * Max(1.0, d[7], dist), d[7], dist, insideSimplex, minDistIndex);
-		assert4(insideSimplex || dist <= d[10] + 1e-4 * Max(1.0, d[10], dist), d[10], dist, insideSimplex, minDistIndex);
+		mgl_assert4(insideSimplex || dist <= d[0] + 1e-4 * Max(1.0, d[0], dist), d[0], dist, insideSimplex, minDistIndex);
+		mgl_assert4(insideSimplex || dist <= d[1] + 1e-4 * Max(1.0, d[1], dist), d[1], dist, insideSimplex, minDistIndex);
+		mgl_assert4(insideSimplex || dist <= d[2] + 1e-4 * Max(1.0, d[2], dist), d[2], dist, insideSimplex, minDistIndex);
+		mgl_assert4(insideSimplex || dist <= d[4] + 1e-4 * Max(1.0, d[4], dist), d[4], dist, insideSimplex, minDistIndex);
+		mgl_assert4(insideSimplex || dist <= d[5] + 1e-4 * Max(1.0, d[5], dist), d[5], dist, insideSimplex, minDistIndex);
+		mgl_assert4(insideSimplex || dist <= d[7] + 1e-4 * Max(1.0, d[7], dist), d[7], dist, insideSimplex, minDistIndex);
+		mgl_assert4(insideSimplex || dist <= d[10] + 1e-4 * Max(1.0, d[10], dist), d[10], dist, insideSimplex, minDistIndex);
 #endif
 
 		vec d01 = s[1] - s[0];
@@ -253,8 +253,8 @@ vec UpdateSimplex(vec *s, int &n)
 		float4d D03 = POINT_TO_FLOAT4(s[3]) - POINT_TO_FLOAT4(s[0]);
 		float4d tri013NormalD = D01.Cross(D03);
 		float4d tri023NormalD = D03.Cross(D02);
-		assert3(tri013NormalD.Dot(D02) <= 0.f, tri013NormalD, D02, tri013NormalD.Dot(D02));
-		assert3(tri023NormalD.Dot(D01) <= 0.f, tri023NormalD, D01, tri023NormalD.Dot(D01));
+		mgl_assert3(tri013NormalD.Dot(D02) <= 0.f, tri013NormalD, D02, tri013NormalD.Dot(D02));
+		mgl_assert3(tri023NormalD.Dot(D01) <= 0.f, tri023NormalD, D01, tri023NormalD.Dot(D01));
 #endif
 
 		vec e03_1 = Cross(tri013Normal, d03); // The normal of edge 0->3 on triangle 013.
@@ -265,7 +265,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 6) Edge 0->3 is closest. Simplex degenerates to a line segment.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(!insideSimplex && d[6] <= dist + 1e-3f * Max(1.0, d[6], dist), d[6], dist, insideSimplex, minDistIndex);
+			mgl_assert4(!insideSimplex && d[6] <= dist + 1e-3f * Max(1.0, d[6], dist), d[6], dist, insideSimplex, minDistIndex);
 #endif
 			vec newDir = Cross(d03, Cross(d03, s[3]));
 			s[1] = s[3];
@@ -276,7 +276,7 @@ vec UpdateSimplex(vec *s, int &n)
 		vec d12 = s[2] - s[1];
 		vec d13 = s[3] - s[1];
 		vec tri123Normal = Cross(d12, d13);
-		assert(Dot(tri123Normal, -d02) <= 0.f);
+		mgl_assert(Dot(tri123Normal, -d02) <= 0.f);
 		vec e13_0 = Cross(d13, tri013Normal);
 		vec e13_2 = Cross(tri123Normal, d13);
 		float inE13_0 = Dot(e13_0, s[3]);
@@ -285,7 +285,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 8) Edge 1->3 is closest. Simplex degenerates to a line segment.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(!insideSimplex && d[8] <= dist + 1e-3f * Max(1.0, d[8], dist), d[8], dist, insideSimplex, minDistIndex);
+			mgl_assert4(!insideSimplex && d[8] <= dist + 1e-3f * Max(1.0, d[8], dist), d[8], dist, insideSimplex, minDistIndex);
 #endif
 			vec newDir = Cross(d13, Cross(d13, s[3]));
 			s[0] = s[1];
@@ -303,7 +303,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 9) Edge 2->3 is closest. Simplex degenerates to a line segment.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(!insideSimplex && d[9] <= dist + 1e-3f * Max(1.0, d[9], dist), d[9], dist, insideSimplex, minDistIndex);
+			mgl_assert4(!insideSimplex && d[9] <= dist + 1e-3f * Max(1.0, d[9], dist), d[9], dist, insideSimplex, minDistIndex);
 #endif
 			vec newDir = Cross(d23, Cross(d23, s[3]));
 			s[0] = s[2];
@@ -317,7 +317,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 11) Triangle 0->1->3 is closest.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(!insideSimplex && d[11] <= dist + 1e-3f * Max(1.0, d[11], dist), d[11], dist, insideSimplex, minDistIndex);
+			mgl_assert4(!insideSimplex && d[11] <= dist + 1e-3f * Max(1.0, d[11], dist), d[11], dist, insideSimplex, minDistIndex);
 #endif
 			s[2] = s[3];
 			n = 3;
@@ -328,7 +328,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 12) Triangle 0->2->3 is closest.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(!insideSimplex && d[12] <= dist + 1e-3f * Max(1.0, d[12], dist), d[12], dist, insideSimplex, minDistIndex);
+			mgl_assert4(!insideSimplex && d[12] <= dist + 1e-3f * Max(1.0, d[12], dist), d[12], dist, insideSimplex, minDistIndex);
 #endif
 			s[1] = s[0];
 			s[0] = s[2];
@@ -341,7 +341,7 @@ vec UpdateSimplex(vec *s, int &n)
 		{
 			// Case 13) Triangle 1->2->3 is closest.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(!insideSimplex && d[13] <= dist + 1e-3f * Max(1.0, d[13], dist), d[13], dist, insideSimplex, minDistIndex);
+			mgl_assert4(!insideSimplex && d[13] <= dist + 1e-3f * Max(1.0, d[13], dist), d[13], dist, insideSimplex, minDistIndex);
 #endif
 			s[0] = s[1];
 			s[1] = s[2];

--- a/src/Algorithm/GJK.h
+++ b/src/Algorithm/GJK.h
@@ -44,23 +44,23 @@ bool GJKIntersect(const A &a, const B &b)
 		float maxS, minS;
 		vec newSupport = SUPPORT(d, minS, maxS);
 #ifdef MATH_VEC_IS_FLOAT4
-		assume(newSupport.w == 0.f);
+		mgl_assume(newSupport.w == 0.f);
 #endif
 		// If the most extreme point in that search direction did not walk past the origin, then the origin cannot be contained in the Minkowski
 		// convex shape, and the two convex objects a and b do not share a common point - no intersection!
 		if (minS + maxS < 0.f)
 			return false;
 		// Add the newly evaluated point to the search simplex.
-		assert(n < 4);
+		mgl_assert(n < 4);
 		support[n++] = newSupport;
 		// Examine the current simplex, prune a redundant part of it, and produce the next search direction.
 		d = UpdateSimplex(support, n);
 		if (n == 0) // Was the origin contained in the current simplex? If so, then the convex shapes a and b do share a common point - intersection!
 			return true;
 	}
-	assume(false && "GJK intersection test did not converge to a result!");
+	mgl_assume(false && "GJK intersection test did not converge to a result!");
 	// TODO: enable
-	//assume2(false && "GJK intersection test did not converge to a result!", a.SerializeToString(), b.SerializeToString());
+	//mgl_assume2(false && "GJK intersection test did not converge to a result!", a.SerializeToString(), b.SerializeToString());
 	return false; // Report no intersection.
 }
 

--- a/src/Algorithm/GJK2D.cpp
+++ b/src/Algorithm/GJK2D.cpp
@@ -33,7 +33,7 @@ MATH_BEGIN_NAMESPACE
 	@return The new search direction vector. */
 vec2d UpdateSimplex2D(vec2d *s, int &n)
 {
-	assert1(n == 2 || n == 3, n);
+	mgl_assert1(n == 2 || n == 3, n);
 
 	if (n == 2)
 	{
@@ -50,12 +50,12 @@ vec2d UpdateSimplex2D(vec2d *s, int &n)
 		float d0 = s[0].DistanceSq(vec2d::zero);
 		float d1 = s[1].DistanceSq(vec2d::zero);
 		float d2 = LineSegment2D(s[0], s[1]).DistanceSq(vec2d::zero);
-		assert2(d2 <= d0, d2, d0);
-		assert2(d2 <= d1, d2, d1);
+		mgl_assert2(d2 <= d0, d2, d0);
+		mgl_assert2(d2 <= d1, d2, d1);
 		// Cannot be in case 0: the step 0 -> 1 must have been toward the zero direction:
-		assert(Dot(s[1]-s[0], -s[0]) >= 0.f);
+		mgl_assert(Dot(s[1]-s[0], -s[0]) >= 0.f);
 		// Cannot be in case 1: the zero direction cannot be in the voronoi region of vertex s[1].
-		assert(Dot(s[1]-s[0], -s[1]) <= 0.f);
+		mgl_assert(Dot(s[1]-s[0], -s[1]) <= 0.f);
 #endif
 
 		vec2d d01 = s[1] - s[0];
@@ -73,7 +73,7 @@ vec2d UpdateSimplex2D(vec2d *s, int &n)
 	}
 	else
 	{
-		assert(n == 3);
+		mgl_assert(n == 3);
 		// Seven voronoi regions:
 		// 0) closest to vertex s[0].
 		// 1) closest to vertex s[1].
@@ -109,10 +109,10 @@ vec2d UpdateSimplex2D(vec2d *s, int &n)
 				minDistIndex = i;
 			}
 
-		assert4(isContainedInTriangle || dist <= d[0] + 1e-4f, d[0], dist, isContainedInTriangle, minDistIndex);
-		assert4(isContainedInTriangle || dist <= d[1] + 1e-4f, d[1], dist, isContainedInTriangle, minDistIndex);
-		assert4(isContainedInTriangle || dist <= d[2] + 1e-4f, d[2], dist, isContainedInTriangle, minDistIndex);
-		assert4(isContainedInTriangle || dist <= d[3] + 1e-4f, d[3], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[0] + 1e-4f, d[0], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[1] + 1e-4f, d[1], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[2] + 1e-4f, d[2], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(isContainedInTriangle || dist <= d[3] + 1e-4f, d[3], dist, isContainedInTriangle, minDistIndex);
 #endif
 		vec2d d12 = s[2]-s[1];
 		vec2d d02 = s[2]-s[0];
@@ -124,7 +124,7 @@ vec2d UpdateSimplex2D(vec2d *s, int &n)
 		{
 			// Case 4: Edge 1->2 is closest.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(d[4] <= dist + 1e-3f * Max(1.f, d[4], dist), d[4], dist, isContainedInTriangle, minDistIndex);
+			mgl_assert4(d[4] <= dist + 1e-3f * Max(1.f, d[4], dist), d[4], dist, isContainedInTriangle, minDistIndex);
 #endif
 			vec2d newDir = e12;
 			s[0] = s[1];
@@ -139,7 +139,7 @@ vec2d UpdateSimplex2D(vec2d *s, int &n)
 		{
 			// Case 5: Edge 0->2 is closest.
 #ifdef MATH_ASSERT_CORRECTNESS
-			assert4(d[5] <= dist + 1e-3f * Max(1.f, d[5], dist), d[5], dist, isContainedInTriangle, minDistIndex);
+			mgl_assert4(d[5] <= dist + 1e-3f * Max(1.f, d[5], dist), d[5], dist, isContainedInTriangle, minDistIndex);
 #endif
 			vec2d newDir = e02;
 			s[1] = s[2];
@@ -148,7 +148,7 @@ vec2d UpdateSimplex2D(vec2d *s, int &n)
 		}
 		// Case 6) The origin lies directly inside the triangle. For robustness, terminate the search here immediately with success.
 #ifdef MATH_ASSERT_CORRECTNESS
-		assert4(d[6] <= dist + 1e-3f * Max(1.f, d[6], dist), d[6], dist, isContainedInTriangle, minDistIndex);
+		mgl_assert4(d[6] <= dist + 1e-3f * Max(1.f, d[6], dist), d[6], dist, isContainedInTriangle, minDistIndex);
 #endif
 		n = 0;
 		return vec2d::zero;

--- a/src/Algorithm/GJK2D.h
+++ b/src/Algorithm/GJK2D.h
@@ -48,24 +48,24 @@ bool GJKIntersect2D(const A &a, const B &b)
 		float maxS, minS;
 		vec2d newSupport = SUPPORT2D(d, minS, maxS);
 #ifdef MATH_VEC_IS_FLOAT4
-		assume(newSupport.z == 0.f);
-		assume(newSupport.w == 0.f);
+		mgl_assume(newSupport.z == 0.f);
+		mgl_assume(newSupport.w == 0.f);
 #endif
 		// If the most extreme point in that search direction did not walk past the origin, then the origin cannot be contained in the Minkowski
 		// convex shape, and the two convex objects a and b do not share a common point - no intersection!
 		if (minS + maxS < 0.f)
 			return false;
 		// Add the newly evaluated point to the search simplex.
-		assert(n < 3);
+		mgl_assert(n < 3);
 		support[n++] = newSupport;
 		// Examine the current simplex, prune a redundant part of it, and produce the next search direction.
 		d = UpdateSimplex2D(support, n);
 		if (n == 0) // Was the origin contained in the current simplex? If so, then the convex shapes a and b do share a common point - intersection!
 			return true;
 	}
-	assume(false && "GJK2D intersection test did not converge to a result!");
+	mgl_assume(false && "GJK2D intersection test did not converge to a result!");
 	// TODO: enable this on Polygon2DRef
-//	assume2(false && "GJK2D intersection test did not converge to a result!", a.SerializeToString(), b.SerializeToString());
+//	mgl_assume2(false && "GJK2D intersection test did not converge to a result!", a.SerializeToString(), b.SerializeToString());
 	return false; // Report no intersection.
 }
 

--- a/src/Algorithm/Random/LCG.cpp
+++ b/src/Algorithm/Random/LCG.cpp
@@ -53,8 +53,8 @@ void LCG::Seed(u32 seed, u32 mul, u32 inc, u32 mod)
 	if (inc == 0 && (mul % mod == 0 || mod % mul == 0))
 		LOGW("Warning: Multiplier %u and modulus %u are not compatible since one is a multiple of the other and the increment == 0!", mul, mod);
 #endif
-	assume(mul != 0);
-	assume(mod > 1);
+	mgl_assume(mul != 0);
+	mgl_assume(mod > 1);
 
 	lastNumber = seed;
 	multiplier = mul;
@@ -64,12 +64,12 @@ void LCG::Seed(u32 seed, u32 mul, u32 inc, u32 mod)
 
 u32 LCG::IntFast()
 {
-	assert(increment == 0);
-	assert(multiplier % 2 == 1 && "Multiplier should be odd for LCG::IntFast(), since modulus==2^32 is even!");
+	mgl_assert(increment == 0);
+	mgl_assert(multiplier % 2 == 1 && "Multiplier should be odd for LCG::IntFast(), since modulus==2^32 is even!");
 // The configurable modulus and increment are not used by this function.
 	u32 mul = lastNumber * multiplier;
 	lastNumber = mul + (mul <= lastNumber?1:0); // Whenever we overflow, flip by one to avoid even multiplier always producing even results, since modulus is even.
-	assert(lastNumber != 0); // We don't use an adder in IntFast(), so must never degenerate to zero.
+	mgl_assert(lastNumber != 0); // We don't use an adder in IntFast(), so must never degenerate to zero.
 	return lastNumber;
 }
 
@@ -79,7 +79,7 @@ u32 LCG::Int()
 #warning Because of code size and performance issues, on Emscripten LCG::Int() is currently routed to LCG::IntFast() (TODO: Check if this is still needed for Wasm and rem64?)
 	return IntFast();
 #else
-	assert(modulus != 0);
+	mgl_assert(modulus != 0);
 	/// \todo Convert to using Schrage's method for approximate factorization. (Numerical Recipes in C)
 
 	// Currently we cast everything to 64-bit to avoid overflow, which is quite dumb.
@@ -98,7 +98,7 @@ u32 LCG::Int()
 //#endif
 	// Save the newly generated random number to use as seed for the next one.
 //	lastNumber = m;//(u32)newNum;
-	assert4((((u32)newNum) != 0 || increment != 0) && "LCG degenerated to producing a stream of zeroes!", lastNumber, multiplier, increment, modulus);
+	mgl_assert4((((u32)newNum) != 0 || increment != 0) && "LCG degenerated to producing a stream of zeroes!", lastNumber, multiplier, increment, modulus);
 	lastNumber = (u32)newNum;
 	return lastNumber;
 #endif
@@ -106,12 +106,12 @@ u32 LCG::Int()
 
 int LCG::Int(int a, int b)
 {
-	assert(a <= b && "Error in range!");
+	mgl_assert(a <= b && "Error in range!");
 
 //	return a + (int)(Int() * Max()/(b-a));
 	int num = a + (int)(Float() * (b-a+1));
-//	assert(num >= a);
-//	assert(num <= b);
+//	mgl_assert(num >= a);
+//	mgl_assert(num <= b);
 	///\todo Some bug here - the result is not necessarily in the proper range.
 	if (num < a)
 		num = a;
@@ -125,8 +125,8 @@ float LCG::Float()
 	u32 i = ((u32)Int() & 0x007FFFFF /* random mantissa */) | 0x3F800000 /* fixed exponent */;
 	float f = ReinterpretAsFloat(i); // f is now in range [1, 2[
 	f -= 1.f; // Map to range [0, 1[
-	assert1(f >= 0.f, f);
-	assert1(f < 1.f, f);
+	mgl_assert1(f >= 0.f, f);
+	mgl_assert1(f < 1.f, f);
 	return f;
 }
 
@@ -143,8 +143,8 @@ float LCG::Float01Incl()
 		{
 			val |= 0x3F800000;
 			float f = ReinterpretAsFloat(val) - 1.f;
-			assert1(f >= 0.f, f);
-			assert1(f <= 1.f, f);
+			mgl_assert1(f >= 0.f, f);
+			mgl_assert1(f <= 1.f, f);
 			return f;
 		}
 	}
@@ -159,14 +159,14 @@ float LCG::FloatNeg1_1()
 	float f = ReinterpretAsFloat(i); // f is now in range ]-2, -1[ union [1, 2].
 	float fone = ReinterpretAsFloat(one); // +/- 1, of same sign as f.
 	f -= fone;
-	assert1(f > -1.f, f);
-	assert1(f < 1.f, f);
+	mgl_assert1(f > -1.f, f);
+	mgl_assert1(f < 1.f, f);
 	return f;
 }
 
 float LCG::Float(float a, float b)
 {
-	assume2(a <= b && "LCG::Float(a,b): Error in range: b < a!", a, b);
+	mgl_assume2(a <= b && "LCG::Float(a,b): Error in range: b < a!", a, b);
 
 	if (a == b)
 		return a;
@@ -176,8 +176,8 @@ float LCG::Float(float a, float b)
 		float f = a + Float() * (b-a);
 		if (f != b)
 		{
-			assume2(a <= f, a, b);
-			assume2(f < b || a == b, f, b);
+			mgl_assume2(a <= f, a, b);
+			mgl_assume2(f < b || a == b, f, b);
 			return f;
 		}
 	}
@@ -186,11 +186,11 @@ float LCG::Float(float a, float b)
 
 float LCG::FloatIncl(float a, float b)
 {
-	assume(a <= b && "LCG::Float(a,b): Error in range: b < a!");
+	mgl_assume(a <= b && "LCG::Float(a,b): Error in range: b < a!");
 
 	float f = a + Float() * (b-a);
-	assume2(a <= f, a, b);
-	assume2(f <= b, f, b);
+	mgl_assume2(a <= f, a, b);
+	mgl_assume2(f <= b, f, b);
 	return f;
 }
 

--- a/src/Algorithm/SAT.cpp
+++ b/src/Algorithm/SAT.cpp
@@ -19,10 +19,10 @@ bool HasCcwWindingOrder(const float2 *poly, int numVertices)
 
 bool SATCollide2D(const float2 *a, int numA, const float2 *b, int numB)
 {
-	assert(numA > 0 && a);
-	assert(numB > 0 && b);
-	assert(HasCcwWindingOrder(a, numA));
-	assert(HasCcwWindingOrder(b, numB));
+	mgl_assert(numA > 0 && a);
+	mgl_assert(numB > 0 && b);
+	mgl_assert(HasCcwWindingOrder(a, numA));
+	mgl_assert(HasCcwWindingOrder(b, numB));
 
 	float2 edge;
 
@@ -67,10 +67,10 @@ bool SATCollide2D(const float2 *a, int numA, const float2 *b, int numB)
 float SATCollide2D_CollisionPoint(const float2 *a, int numA, const float2 *b, int numB,
                                  float2 &outCollisionPoint, float2 &outCollisionNormal)
 {
-	assert(numA > 0 && a);
-	assert(numB > 0 && b);
-	assert(HasCcwWindingOrder(a, numA));
-	assert(HasCcwWindingOrder(b, numB));
+	mgl_assert(numA > 0 && a);
+	mgl_assert(numB > 0 && b);
+	mgl_assert(HasCcwWindingOrder(a, numA));
+	mgl_assert(HasCcwWindingOrder(b, numB));
 
 	float2 edge;
 

--- a/src/Algorithm/SAT.h
+++ b/src/Algorithm/SAT.h
@@ -32,7 +32,7 @@ bool SATIntersect(const A &a, const B &b)
 {
 	vec normals[16];
 	int n = a.UniqueFaceNormals(normals);
-	assert(n <= 16); ///\todo Make this API safe.
+	mgl_assert(n <= 16); ///\todo Make this API safe.
 	for(int i = 0; i < n; ++i)
 	{
 		float amin, amax, bmin, bmax;
@@ -42,7 +42,7 @@ bool SATIntersect(const A &a, const B &b)
 			return false;
 	}
 	n = b.UniqueFaceNormals(normals);
-	assert(n <= 16); ///\todo Make this API safe.
+	mgl_assert(n <= 16); ///\todo Make this API safe.
 	for(int i = 0; i < n; ++i)
 	{
 		float amin, amax, bmin, bmax;

--- a/src/Geometry/AABB.cpp
+++ b/src/Geometry/AABB.cpp
@@ -93,7 +93,7 @@ void AABB::SetFrom(const Sphere &s)
 
 void AABB::SetFrom(const vec *pointArray, int numPoints)
 {
-	assume(pointArray || numPoints == 0);
+	mgl_assume(pointArray || numPoints == 0);
 	SetNegativeInfinity();
 	if (!pointArray)
 		return;
@@ -138,12 +138,12 @@ Polyhedron AABB::ToPolyhedron() const
 		p.f.push_back(face);
 	}
 	
-	assume(p.IsClosed());
-	assume(p.IsConvex());
-	assume(p.EulerFormulaHolds());
-	assume(p.FaceIndicesValid());
-	assume(p.FacesAreNondegeneratePlanar());
-	assume(p.Contains(this->CenterPoint()));
+	mgl_assume(p.IsClosed());
+	mgl_assume(p.IsConvex());
+	mgl_assume(p.EulerFormulaHolds());
+	mgl_assume(p.FaceIndicesValid());
+	mgl_assume(p.FacesAreNondegeneratePlanar());
+	mgl_assume(p.Contains(this->CenterPoint()));
 	return p;
 }
 
@@ -187,9 +187,9 @@ vec AABB::CenterPoint() const
 
 vec AABB::PointInside(float x, float y, float z) const
 {
-	assume(0.f <= x && x <= 1.f);
-	assume(0.f <= y && y <= 1.f);
-	assume(0.f <= z && z <= 1.f);
+	mgl_assume(0.f <= x && x <= 1.f);
+	mgl_assume(0.f <= y && y <= 1.f);
+	mgl_assume(0.f <= z && z <= 1.f);
 
 	vec d = maxPoint - minPoint;
 	return minPoint + d.Mul(POINT_VEC(x, y, z));
@@ -197,7 +197,7 @@ vec AABB::PointInside(float x, float y, float z) const
 
 LineSegment AABB::Edge(int edgeIndex) const
 {
-	assume(0 <= edgeIndex && edgeIndex <= 11);
+	mgl_assume(0 <= edgeIndex && edgeIndex <= 11);
 	switch(edgeIndex)
 	{
 		default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -233,7 +233,7 @@ LineSegment AABB::Edge(int edgeIndex) const
 
 vec AABB::CornerPoint(int cornerIndex) const
 {
-	assume(0 <= cornerIndex && cornerIndex <= 7);
+	mgl_assume(0 <= cornerIndex && cornerIndex <= 7);
 	switch(cornerIndex)
 	{
 		default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -264,8 +264,8 @@ vec AABB::ExtremePoint(const vec &direction, float &projectionDistance) const
 
 vec AABB::PointOnEdge(int edgeIndex, float u) const
 {
-	assume(0 <= edgeIndex && edgeIndex <= 11);
-	assume(0 <= u && u <= 1.f);
+	mgl_assume(0 <= edgeIndex && edgeIndex <= 11);
+	mgl_assume(0 <= u && u <= 1.f);
 
 	vec d = maxPoint - minPoint;
 	switch(edgeIndex)
@@ -290,7 +290,7 @@ vec AABB::PointOnEdge(int edgeIndex, float u) const
 
 vec AABB::FaceCenterPoint(int faceIndex) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
 
 	vec center = (minPoint + maxPoint) * 0.5f;
 	switch(faceIndex)
@@ -307,9 +307,9 @@ vec AABB::FaceCenterPoint(int faceIndex) const
 
 vec AABB::FacePoint(int faceIndex, float u, float v) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
-	assume(0 <= u && u <= 1.f);
-	assume(0 <= v && v <= 1.f);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= u && u <= 1.f);
+	mgl_assume(0 <= v && v <= 1.f);
 
 	vec d = maxPoint - minPoint;
 	switch(faceIndex)
@@ -326,7 +326,7 @@ vec AABB::FacePoint(int faceIndex, float u, float v) const
 
 vec AABB::FaceNormal(int faceIndex) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
 	switch(faceIndex)
 	{
 	default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -341,20 +341,20 @@ vec AABB::FaceNormal(int faceIndex) const
 
 Plane AABB::FacePlane(int faceIndex) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
 	return Plane(FaceCenterPoint(faceIndex), FaceNormal(faceIndex));
 }
 
 void AABB::GetCornerPoints(vec *outPointArray) const
 {
-	assume(outPointArray);
+	mgl_assume(outPointArray);
 	for(int i = 0; i < 8; ++i)
 		outPointArray[i] = CornerPoint(i);
 }
 
 void AABB::GetFacePlanes(Plane *outPlaneArray) const
 {
-	assume(outPlaneArray);
+	mgl_assume(outPlaneArray);
 	for(int i = 0; i < 6; ++i)
 		outPlaneArray[i] = FacePlane(i);
 }
@@ -368,7 +368,7 @@ AABB AABB::MinimalEnclosingAABB(const vec *pointArray, int numPoints)
 
 void AABB::ExtremePointsAlongAABB(const vec *pts, int numPoints, int &minx, int &maxx, int &miny, int &maxy, int &minz, int &maxz)
 {
-	assume(pts || numPoints == 0);
+	mgl_assume(pts || numPoints == 0);
 	if (!pts)
 		return;
 	minx = maxx = miny = maxy = minz = maxz = 0;
@@ -502,25 +502,25 @@ void AABBTransformAsAABB_SIMD(AABB &aabb, const float4x4 &m)
 
 void AABB::TransformAsAABB(const float3x3 &transform)
 {
-	assume(transform.IsColOrthogonal());
-	assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal());
+	mgl_assume(transform.HasUniformScale());
 
 	AABBTransformAsAABB(*this, transform);
 }
 
 void AABB::TransformAsAABB(const float3x4 &transform)
 {
-	assume(transform.IsColOrthogonal());
-	assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal());
+	mgl_assume(transform.HasUniformScale());
 
 	AABBTransformAsAABB(*this, transform);
 }
 
 void AABB::TransformAsAABB(const float4x4 &transform)
 {
-	assume(transform.IsColOrthogonal3());
-	assume(transform.HasUniformScale());
-	assume(transform.Row(3).Equals(0,0,0,1));
+	mgl_assume(transform.IsColOrthogonal3());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(transform.Row(3).Equals(0,0,0,1));
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	AABBTransformAsAABB_SIMD(*this, transform);
@@ -568,9 +568,9 @@ OBB AABB::Transform(const Quat &transform) const
 vec AABB::ClosestPoint(const vec &targetPoint) const
 {
 #ifdef MATH_VEC_IS_FLOAT4
-	assume(EqualAbs(minPoint.w, 1.f));
-	assume(EqualAbs(maxPoint.w, 1.f));
-	assume(EqualAbs(targetPoint.w, 1.f));
+	mgl_assume(EqualAbs(minPoint.w, 1.f));
+	mgl_assume(EqualAbs(maxPoint.w, 1.f));
+	mgl_assume(EqualAbs(targetPoint.w, 1.f));
 #endif
 	return targetPoint.Clamp(minPoint, maxPoint);
 }
@@ -724,8 +724,8 @@ bool AABB::Intersects(const LineSegment &lineSegment) const
 
 bool AABB::IntersectLineAABB_CPP(const vec &linePos, const vec &lineDir, float &tNear, float &tFar) const
 {
-	assume2(lineDir.IsNormalized(), lineDir, lineDir.LengthSq());
-	assume2(tNear <= tFar && "AABB::IntersectLineAABB: User gave a degenerate line as input for the intersection test!", tNear, tFar);
+	mgl_assume2(lineDir.IsNormalized(), lineDir, lineDir.LengthSq());
+	mgl_assume2(tNear <= tFar && "AABB::IntersectLineAABB: User gave a degenerate line as input for the intersection test!", tNear, tFar);
 	// The user should have inputted values for tNear and tFar to specify the desired subrange [tNear, tFar] of the line
 	// for this intersection test.
 	// For a Line-AABB test, pass in
@@ -795,8 +795,8 @@ bool AABB::IntersectLineAABB_CPP(const vec &linePos, const vec &lineDir, float &
 #ifdef MATH_SIMD
 bool AABB::IntersectLineAABB_SSE(const float4 &rayPos, const float4 &rayDir, float tNear, float tFar) const
 {
-	assume(rayDir.IsNormalized4());
-	assume(tNear <= tFar && "AABB::IntersectLineAABB: User gave a degenerate line as input for the intersection test!");
+	mgl_assume(rayDir.IsNormalized4());
+	mgl_assume(tNear <= tFar && "AABB::IntersectLineAABB: User gave a degenerate line as input for the intersection test!");
 	/* For reference, this is the C++ form of the vectorized SSE code below.
 
 	float4 recipDir = rayDir.RecipFast4();
@@ -1105,7 +1105,7 @@ void AABB::Enclose(const Polyhedron &polyhedron)
 
 void AABB::Enclose(const vec *pointArray, int numPoints)
 {
-	assume(pointArray || numPoints == 0);
+	mgl_assume(pointArray || numPoints == 0);
 	if (!pointArray)
 		return;
 	for(int i = 0; i < numPoints; ++i)
@@ -1116,11 +1116,11 @@ void AABB::Triangulate(int numFacesX, int numFacesY, int numFacesZ,
                        vec *outPos, vec *outNormal, float2 *outUV,
                        bool ccwIsFrontFacing) const
 {
-	assume(numFacesX >= 1);
-	assume(numFacesY >= 1);
-	assume(numFacesZ >= 1);
+	mgl_assume(numFacesX >= 1);
+	mgl_assume(numFacesY >= 1);
+	mgl_assume(numFacesZ >= 1);
 
-	assume(outPos);
+	mgl_assume(outPos);
 	if (!outPos)
 		return;
 
@@ -1184,12 +1184,12 @@ void AABB::Triangulate(int numFacesX, int numFacesY, int numFacesZ,
 				i += 6;
 			}
 	}
-	assert(i == NumVerticesInTriangulation(numFacesX, numFacesY, numFacesZ));
+	mgl_assert(i == NumVerticesInTriangulation(numFacesX, numFacesY, numFacesZ));
 }
 
 void AABB::ToEdgeList(vec *outPos) const
 {
-	assume(outPos);
+	mgl_assume(outPos);
 	if (!outPos)
 		return;
 	for(int i = 0; i < 12; ++i)
@@ -1217,7 +1217,7 @@ StringT AABB::SerializeToString() const
 	s = SerializeFloat(maxPoint.x, s); *s = ','; ++s;
 	s = SerializeFloat(maxPoint.y, s); *s = ','; ++s;
 	s = SerializeFloat(maxPoint.z, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -1229,7 +1229,7 @@ StringT AABB::SerializeToCodeString() const
 
 AABB AABB::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return AABB(vec::nan, vec::nan);
 	AABB a;

--- a/src/Geometry/AABB2D.h
+++ b/src/Geometry/AABB2D.h
@@ -126,7 +126,7 @@ public:
 		@see PointInside(), Edge(), PointOnEdge(), FaceCenterPoint(), FacePoint(), GetCornerPoints(). */
 	vec2d CornerPoint(int cornerIndex) const
 	{
-		assume(0 <= cornerIndex && cornerIndex <= 3);
+		mgl_assume(0 <= cornerIndex && cornerIndex <= 3);
 		switch(cornerIndex)
 		{
 			default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.

--- a/src/Geometry/Capsule.cpp
+++ b/src/Geometry/Capsule.cpp
@@ -94,7 +94,7 @@ vec Capsule::Center() const
 vec Capsule::ExtremePoint(const vec &direction) const
 {
 	float len = direction.Length();
-	assume(len > 0.f);
+	mgl_assume(len > 0.f);
 	return (Dot(direction, l.b - l.a) >= 0.f ? l.b : l.a) + direction * (r / len);
 }
 
@@ -114,7 +114,7 @@ void Capsule::ProjectToAxis(const vec &direction, float &outMin, float &outMax) 
 
 	// The following requires that direction is normalized, otherwise we would have to sub/add 'r * direction.Length()', but
 	// don't want to do that for performance reasons.
-	assume(direction.IsNormalized());
+	mgl_assume(direction.IsNormalized());
 	outMin -= r;
 	outMax += r;
 }
@@ -148,8 +148,8 @@ float Capsule::SurfaceArea() const
 
 Circle Capsule::CrossSection(float yPos) const
 {
-	assume(yPos >= 0.f);
-	assume(yPos <= 1.f);
+	mgl_assume(yPos >= 0.f);
+	mgl_assume(yPos <= 1.f);
 	yPos *= Height();
 	vec up = UpDirection();
 	vec centerPos = Bottom() + up * yPos;
@@ -213,7 +213,7 @@ OBB Capsule::MinimalEnclosingOBB() const
 
 vec Capsule::RandomPointInside(LCG &rng) const
 {
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 
 	OBB obb = MinimalEnclosingOBB();
 	for(int i = 0; i < 1000; ++i)
@@ -222,7 +222,7 @@ vec Capsule::RandomPointInside(LCG &rng) const
 		if (Contains(pt))
 			return pt;
 	}
-	assume(false && "Warning: Capsule::RandomPointInside ran out of iterations to perform!");
+	mgl_assume(false && "Warning: Capsule::RandomPointInside ran out of iterations to perform!");
 	return Center(); // Just return some point that is known to be inside.
 }
 
@@ -253,24 +253,24 @@ void Capsule::Scale(const vec &centerPoint, float scaleFactor)
 
 void Capsule::Transform(const float3x3 &transform)
 {
-	assume(transform.HasUniformScale());
-	assume(transform.IsColOrthogonal());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal());
 	l.Transform(transform);
 	r *= transform.Col(0).Length(); // Scale the radius.
 }
 
 void Capsule::Transform(const float3x4 &transform)
 {
-	assume(transform.HasUniformScale());
-	assume(transform.IsColOrthogonal());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal());
 	l.Transform(transform);
 	r *= transform.Col(0).Length(); // Scale the radius.
 }
 
 void Capsule::Transform(const float4x4 &transform)
 {
-	assume(transform.HasUniformScale());
-	assume(transform.IsColOrthogonal3());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal3());
 	l.Transform(transform);
 	r *= transform.Col3(0).Length(); // Scale the radius.
 }
@@ -376,7 +376,7 @@ bool Capsule::Contains(const Frustum &frustum) const
 
 bool Capsule::Contains(const Polyhedron &polyhedron) const
 {
-	assume(polyhedron.IsClosed());
+	mgl_assume(polyhedron.IsClosed());
 	for(int i = 0; i < polyhedron.NumVertices(); ++i)
 		if (!Contains(polyhedron.Vertex(i)))
 			return false;
@@ -468,7 +468,7 @@ StringT Capsule::SerializeToString() const
 	s = SerializeFloat(l.b.y, s); *s = ','; ++s;
 	s = SerializeFloat(l.b.z, s); *s = ','; ++s;
 	s = SerializeFloat(r, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -492,7 +492,7 @@ std::ostream &operator <<(std::ostream &o, const Capsule &capsule)
 
 Capsule Capsule::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return Capsule(vec::nan, vec::nan, FLOAT_NAN);
 	Capsule c;

--- a/src/Geometry/Circle.cpp
+++ b/src/Geometry/Circle.cpp
@@ -87,8 +87,8 @@ void Circle::Translate(const vec &offset)
 
 void Circle::Transform(const float3x3 &transform)
 {
-	assume(transform.HasUniformScale());
-	assume(transform.IsColOrthogonal());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal());
 	pos = transform.Mul(pos);
 	normal = transform.Mul(normal).Normalized();
 	r *= transform.Col(0).Length(); // Scale the radius of the circle.
@@ -96,8 +96,8 @@ void Circle::Transform(const float3x3 &transform)
 
 void Circle::Transform(const float3x4 &transform)
 {
-	assume(transform.HasUniformScale());
-	assume(transform.IsColOrthogonal());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal());
 	pos = transform.MulPos(pos);
 	normal = transform.MulDir(normal).Normalized();
 	r *= transform.Col(0).Length(); // Scale the radius of the circle.
@@ -105,8 +105,8 @@ void Circle::Transform(const float3x4 &transform)
 
 void Circle::Transform(const float4x4 &transform)
 {
-	assume(transform.HasUniformScale());
-	assume(transform.IsColOrthogonal3());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(transform.IsColOrthogonal3());
 	pos = transform.MulPos(pos);
 	normal = transform.MulDir(normal).Normalized();
 	r *= transform.Col3(0).Length(); // Scale the radius of the circle.

--- a/src/Geometry/Circle2D.cpp
+++ b/src/Geometry/Circle2D.cpp
@@ -62,7 +62,7 @@ static Circle2D SmallestCircleSqEnclosing4Points(const float2 &a, const float2 &
 {
 	// Find the smallest circle that encloses each of a, b, c and d.
 	// As prerequisite, we know that a is not contained by smallest circle that encloses b, c and d, enforce that precondition.
-	assert1(!Circle2D::OptimalEnclosingCircle(b, c, d).Contains(a, -1e-1f), Circle2D::OptimalEnclosingCircle(b, c, d).SignedDistance(a));
+	mgl_assert1(!Circle2D::OptimalEnclosingCircle(b, c, d).Contains(a, -1e-1f), Circle2D::OptimalEnclosingCircle(b, c, d).SignedDistance(a));
 
 	// Therefore, the smallest circle that encloses each of a, b, c and d must pass through a. Test
 	// the three possible candidate circles (a,b,c), (a,b,d) and (a,c,d), one of those must enclose
@@ -198,7 +198,7 @@ float Circle2D::SignedDistance(const float2 &point) const
 
 Circle2D Circle2D::OptimalEnclosingCircle(const float2 *pointArray, int numPoints)
 {
-	assert(pointArray || numPoints == 0);
+	mgl_assert(pointArray || numPoints == 0);
 
 	// Special case handling for 0-3 points.
 	switch(numPoints)
@@ -257,9 +257,9 @@ Circle2D Circle2D::OptimalEnclosingCircle(const float2 *pointArray, int numPoint
 		// Start again from scratch: pts[0]-pts[2] now has the new candidate.
 		i = 2;
 
-		mathassert1(minCircle.Contains(pts[0], 1e-3f), minCircle.SignedDistance(pts[0]));
-		mathassert1(minCircle.Contains(pts[1], 1e-3f), minCircle.SignedDistance(pts[1]));
-		mathassert1(minCircle.Contains(pts[2], 1e-3f), minCircle.SignedDistance(pts[2]));
+		mgl_mathassert1(minCircle.Contains(pts[0], 1e-3f), minCircle.SignedDistance(pts[0]));
+		mgl_mathassert1(minCircle.Contains(pts[1], 1e-3f), minCircle.SignedDistance(pts[1]));
+		mgl_mathassert1(minCircle.Contains(pts[2], 1e-3f), minCircle.SignedDistance(pts[2]));
 	}
 	delete[] pts;
 	return minCircle;
@@ -267,7 +267,7 @@ Circle2D Circle2D::OptimalEnclosingCircle(const float2 *pointArray, int numPoint
 
 float2 Circle2D::RandomPointInside(LCG &lcg)
 {
-	assume(r > 1e-3f);
+	mgl_assume(r > 1e-3f);
 	float2 v = float2::zero;
 	// Rejection sampling analysis: The unit circle fills ~78.54% of the area of its enclosing rectangle, so this
 	// loop is expected to take only very few iterations before succeeding.
@@ -279,7 +279,7 @@ float2 Circle2D::RandomPointInside(LCG &lcg)
 		if (v.LengthSq() <= r * r)
 			return pos + v;
 	}
-	assume(false && "Circle2D::RandomPointInside failed!");
+	mgl_assume(false && "Circle2D::RandomPointInside failed!");
 
 	// Failed to generate a point inside this circle. Return the circle center as fallback.
 	return pos;

--- a/src/Geometry/Frustum.cpp
+++ b/src/Geometry/Frustum.cpp
@@ -288,22 +288,22 @@ void Frustum::SetWorldMatrix(const float3x4 &worldTransform)
 	else
 		front = DIR_VEC(worldTransform.Col(2)); // The camera looks towards +Z axis of the given transform.
 	up = DIR_VEC(worldTransform.Col(1)); // The camera up points towards +Y of the given transform.
-	assume1(pos.IsFinite(), pos);
-	assume2(up.IsNormalized(1e-3f), up, up.Length());
-	assume2(front.IsNormalized(1e-3f), front, front.Length());
-	assume3(up.IsPerpendicular(front), up, front, up.Dot(front));
-	assume(worldTransform.IsColOrthogonal3()); // Front and up must be orthogonal to each other.
-	assume1(EqualAbs(worldTransform.Determinant(), 1.f), worldTransform.Determinant()); // The matrix cannot contain mirroring.
+	mgl_assume1(pos.IsFinite(), pos);
+	mgl_assume2(up.IsNormalized(1e-3f), up, up.Length());
+	mgl_assume2(front.IsNormalized(1e-3f), front, front.Length());
+	mgl_assume3(up.IsPerpendicular(front), up, front, up.Dot(front));
+	mgl_assume(worldTransform.IsColOrthogonal3()); // Front and up must be orthogonal to each other.
+	mgl_assume1(EqualAbs(worldTransform.Determinant(), 1.f), worldTransform.Determinant()); // The matrix cannot contain mirroring.
 
 	WorldMatrixChanged();
 }
 
 float3x4 Frustum::ComputeWorldMatrix() const
 {
-	assume1(pos.IsFinite(), pos);
-	assume2(up.IsNormalized(1e-3f), up, up.Length());
-	assume2(front.IsNormalized(1e-3f), front, front.Length());
-	assume3(up.IsPerpendicular(front), up, front, up.Dot(front));
+	mgl_assume1(pos.IsFinite(), pos);
+	mgl_assume2(up.IsNormalized(1e-3f), up, up.Length());
+	mgl_assume2(front.IsNormalized(1e-3f), front, front.Length());
+	mgl_assume3(up.IsPerpendicular(front), up, front, up.Dot(front));
 	float3x4 m;
 	m.SetCol(0, DIR_TO_FLOAT3(WorldRight().Normalized()));
 	m.SetCol(1, DIR_TO_FLOAT3(up));
@@ -312,7 +312,7 @@ float3x4 Frustum::ComputeWorldMatrix() const
 	else
 		m.SetCol(2, DIR_TO_FLOAT3(front)); // In left-handed convention, the +Z axis must map towards the front vector.
 	m.SetCol(3, POINT_TO_FLOAT3(pos));
-	assume(!m.HasNegativeScale());
+	mgl_assume(!m.HasNegativeScale());
 	return m;
 }
 
@@ -332,14 +332,14 @@ float4x4 Frustum::ComputeProjectionMatrix() const
 {
 	if (type == InvalidFrustum || projectiveSpace == FrustumSpaceInvalid)
 		return float4x4::nan;
-	assume(type == PerspectiveFrustum || type == OrthographicFrustum);
-	assume(projectiveSpace == FrustumSpaceGL || projectiveSpace == FrustumSpaceD3D);
-	assume(handedness == FrustumLeftHanded || handedness == FrustumRightHanded);
+	mgl_assume(type == PerspectiveFrustum || type == OrthographicFrustum);
+	mgl_assume(projectiveSpace == FrustumSpaceGL || projectiveSpace == FrustumSpaceD3D);
+	mgl_assume(handedness == FrustumLeftHanded || handedness == FrustumRightHanded);
 	if (type == PerspectiveFrustum)
 	{
 #ifdef __EMSCRIPTEN__
-		assert(projectiveSpace == FrustumSpaceGL && "TODO: D3D style 0..1 Z projection matrices are currently disabled in Emscripten builds due to code size issues");
-		assert(handedness == FrustumRightHanded && "TODO: D3D style left handed matrices are currently disabled in Emscripten builds due to code size issues");
+		mgl_assert(projectiveSpace == FrustumSpaceGL && "TODO: D3D style 0..1 Z projection matrices are currently disabled in Emscripten builds due to code size issues");
+		mgl_assert(handedness == FrustumRightHanded && "TODO: D3D style left handed matrices are currently disabled in Emscripten builds due to code size issues");
 		return float4x4::OpenGLPerspProjRH(nearPlaneDistance, farPlaneDistance, NearPlaneWidth(), NearPlaneHeight());
 #else
 		if (projectiveSpace == FrustumSpaceGL)
@@ -361,8 +361,8 @@ float4x4 Frustum::ComputeProjectionMatrix() const
 	else if (type == OrthographicFrustum)
 	{
 #ifdef __EMSCRIPTEN__
-		assert(projectiveSpace == FrustumSpaceGL && "TODO: D3D style 0..1 Z projection matrices are currently disabled in Emscripten builds due to code size issues");
-		assert(handedness == FrustumRightHanded && "TODO: D3D style left handed matrices are currently disabled in Emscripten builds due to code size issues");
+		mgl_assert(projectiveSpace == FrustumSpaceGL && "TODO: D3D style 0..1 Z projection matrices are currently disabled in Emscripten builds due to code size issues");
+		mgl_assert(handedness == FrustumRightHanded && "TODO: D3D style left handed matrices are currently disabled in Emscripten builds due to code size issues");
 		return float4x4::OpenGLOrthoProjRH(nearPlaneDistance, farPlaneDistance, orthographicWidth, orthographicHeight);
 #else
 		if (projectiveSpace == FrustumSpaceGL)
@@ -389,7 +389,7 @@ float4x4 Frustum::ComputeProjectionMatrix() const
 
 vec Frustum::NearPlanePos(float x, float y) const
 {
-	assume(type == PerspectiveFrustum || type == OrthographicFrustum);
+	mgl_assume(type == PerspectiveFrustum || type == OrthographicFrustum);
 
 	if (type == PerspectiveFrustum)
 	{
@@ -416,7 +416,7 @@ vec Frustum::NearPlanePos(const float2 &point) const
 
 vec Frustum::FarPlanePos(float x, float y) const
 {
-	assume(type == PerspectiveFrustum || type == OrthographicFrustum);
+	mgl_assume(type == PerspectiveFrustum || type == OrthographicFrustum);
 
 	if (type == PerspectiveFrustum)
 	{
@@ -463,10 +463,10 @@ float2 Frustum::ScreenToViewportSpace(const float2 &point, int screenWidth, int 
 
 Ray Frustum::UnProject(float x, float y) const
 {
-	assume1(x >= -1.f, x);
-	assume1(x <= 1.f, x);
-	assume1(y >= -1.f, y);
-	assume1(y <= 1.f, y);
+	mgl_assume1(x >= -1.f, x);
+	mgl_assume1(x <= 1.f, x);
+	mgl_assume1(y >= -1.f, y);
+	mgl_assume1(y <= 1.f, y);
 	if (type == PerspectiveFrustum)
 	{
 		vec nearPlanePos = NearPlanePos(x, y);
@@ -490,8 +490,8 @@ Ray Frustum::UnProjectFromNearPlane(float x, float y) const
 
 vec Frustum::PointInside(float x, float y, float z) const
 {
-	assume(z >= 0.f);
-	assume(z <= 1.f);
+	mgl_assume(z >= 0.f);
+	mgl_assume(z <= 1.f);
 	return UnProjectLineSegment(x, y).GetPoint(z);
 }
 
@@ -628,7 +628,7 @@ bool Frustum::Contains(const Frustum &frustum) const
 
 bool Frustum::Contains(const Polyhedron &polyhedron) const
 {
-	assume(polyhedron.IsClosed());
+	mgl_assume(polyhedron.IsClosed());
 	for(int i = 0; i < polyhedron.NumVertices(); ++i)
 		if (!Contains(polyhedron.Vertex(i)))
 			return false;
@@ -645,7 +645,7 @@ vec Frustum::ClosestPoint(const vec &point) const
 		float halfHeight = orthographicHeight * 0.5f;
 		vec frustumCenter = pos + (frontHalfSize + nearPlaneDistance) * front;
 		vec right = Cross(front, up);
-		assert(right.IsNormalized());
+		mgl_assert(right.IsNormalized());
 		vec d = point - frustumCenter;
 		vec closestPoint = frustumCenter;
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
@@ -688,7 +688,7 @@ bool Frustum::IsFinite() const
 
 Plane Frustum::GetPlane(int faceIndex) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
 	switch(faceIndex)
 	{
 		default: // For release builds where assume() is disabled, always return the first option if out-of-bounds.
@@ -739,7 +739,7 @@ void Frustum::Translate(const vec &offset)
 
 void Frustum::Transform(const float3x3 &transform)
 {
-	assume(transform.HasUniformScale());
+	mgl_assume(transform.HasUniformScale());
 	pos = transform * pos;
 	front = transform * front;
 	float scaleFactor = front.Normalize();
@@ -755,7 +755,7 @@ void Frustum::Transform(const float3x3 &transform)
 
 void Frustum::Transform(const float3x4 &transform)
 {
-	assume(transform.HasUniformScale());
+	mgl_assume(transform.HasUniformScale());
 	pos = transform.MulPos(pos);
 	front = transform.MulDir(front);
 	float scaleFactor = front.Normalize();
@@ -771,7 +771,7 @@ void Frustum::Transform(const float3x4 &transform)
 
 void Frustum::Transform(const float4x4 &transform)
 {
-	assume(transform.Row(3).Equals(0,0,0,1));
+	mgl_assume(transform.Row(3).Equals(0,0,0,1));
 	Transform(transform.Float3x4Part());
 }
 
@@ -782,7 +782,7 @@ void Frustum::Transform(const Quat &transform)
 
 void Frustum::GetPlanes(Plane *outArray) const
 {
-	assume(outArray);
+	mgl_assume(outArray);
 	for(int i = 0; i < 6; ++i)
 		outArray[i] = GetPlane(i);
 }
@@ -794,7 +794,7 @@ vec Frustum::CenterPoint() const
 
 void Frustum::GetCornerPoints(vec *outPointArray) const
 {
-	assume(outPointArray);
+	mgl_assume(outPointArray);
 
 	if (type == PerspectiveFrustum)
 	{
@@ -844,7 +844,7 @@ void Frustum::GetCornerPoints(vec *outPointArray) const
 
 LineSegment Frustum::Edge(int edgeIndex) const
 {
-	assume(0 <= edgeIndex && edgeIndex <= 11);
+	mgl_assume(0 <= edgeIndex && edgeIndex <= 11);
 	switch(edgeIndex)
 	{
 		default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -865,7 +865,7 @@ LineSegment Frustum::Edge(int edgeIndex) const
 
 vec Frustum::CornerPoint(int cornerIndex) const
 {
-	assume(0 <= cornerIndex && cornerIndex <= 7);
+	mgl_assume(0 <= cornerIndex && cornerIndex <= 7);
 	switch(cornerIndex)
 	{
 		default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -964,9 +964,9 @@ AABB Frustum::MinimalEnclosingAABB() const
 
 OBB Frustum::MinimalEnclosingOBB(float expandGuardband) const
 {
-	assume(IsFinite());
-	assume(front.IsNormalized());
-	assume(up.IsNormalized());
+	mgl_assume(IsFinite());
+	mgl_assume(front.IsNormalized());
+	mgl_assume(up.IsNormalized());
 
 	OBB obb;
 	obb.pos = pos + (nearPlaneDistance + farPlaneDistance) * 0.5f * front;

--- a/src/Geometry/KDTree.h
+++ b/src/Geometry/KDTree.h
@@ -52,7 +52,7 @@ struct KdTreeNode
 	};
 
 	/// If true, this leaf does not contain any objects.
-	bool IsEmptyLeaf() const { assert(IsLeaf()); return bucketIndex == 0; }
+	bool IsEmptyLeaf() const { mgl_assert(IsLeaf()); return bucketIndex == 0; }
 	bool IsLeaf() const { return splitAxis == AxisNone; }
 	int LeftChildIndex() const { return (int)childIndex; }
 	int RightChildIndex() const { return (int)childIndex+1; }
@@ -222,7 +222,7 @@ struct TriangleKdTreeRayQueryNearestHitVisitor
 	bool operator()(KdTree<Triangle> &tree, const KdTreeNode &leaf, const Ray &ray, float tNear, float tFar)
 	{
 		u32 *bucket = tree.Bucket(leaf.bucketIndex);
-		assert(bucket);
+		mgl_assert(bucket);
 		while(*bucket != KdTree<Triangle>::BUCKET_SENTINEL)
 		{
 			const Triangle &tri = tree.Object(*bucket);

--- a/src/Geometry/KDTree.inl
+++ b/src/Geometry/KDTree.inl
@@ -1,4 +1,4 @@
-/* Copyright Jukka Jylänki
+/* Copyright Jukka Jylï¿½nki
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
    limitations under the License. */
 
 /** @file KDTree.inl
-	@author Jukka Jylänki
+	@author Jukka Jylï¿½nki
 	@brief Implementation for the KDTree object. */
 #pragma once
 
@@ -48,7 +48,7 @@ void KdTree<T>::FreeBuckets()
 template<typename T>
 AABB KdTree<T>::BoundingAABB(const u32 *bucket) const
 {
-	assert(bucket);
+	mgl_assert(bucket);
 
 	AABB a;
 	a.SetNegativeInfinity();
@@ -66,10 +66,10 @@ void KdTree<T>::SplitLeaf(int nodeIndex, const AABB &nodeAABB, int numObjectsInB
 		return; // Exceeded max depth - disallow splitting.
 
 	KdTreeNode *node = &nodes[nodeIndex];
-	assert(node->IsLeaf());
+	mgl_assert(node->IsLeaf());
 	// Choose the longest axis for the split and convert the node from a leaf to an inner node.
 	int curBucketIndex = node->bucketIndex; // The existing objects.
-	assert(curBucketIndex != 0); // The leaf must contain some objects, otherwise this function should never be called!
+	mgl_assert(curBucketIndex != 0); // The leaf must contain some objects, otherwise this function should never be called!
 	CardinalAxis splitAxis = (CardinalAxis)nodeAABB.Size().MaxElementIndex();
 	float splitPos = nodeAABB.CenterPoint()[splitAxis];
 
@@ -142,7 +142,7 @@ void KdTree<T>::SplitLeaf(int nodeIndex, const AABB &nodeAABB, int numObjectsInB
 	rightChild->bucketIndex = (u32)buckets.size();
 	buckets.push_back(rightBucket);
 
-	assert(numObjectsLeft < numObjectsInBucket && numObjectsRight < numObjectsInBucket);
+	mgl_assert(numObjectsLeft < numObjectsInBucket && numObjectsRight < numObjectsInBucket);
 
 	// Recursively split children.
 	if (numObjectsLeft > 16)
@@ -313,8 +313,8 @@ bool KdTree<T>::IsPartOfThisTree(const KdTreeNode *node) const
 template<typename T>
 bool KdTree<T>::IsPartOfThisTree(const KdTreeNode *root, const KdTreeNode *node) const
 {
-	assert(root);
-	assert(node);
+	mgl_assert(root);
+	mgl_assert(node);
 	if (root == node)
 		return true;
 	if (root->IsLeaf())
@@ -329,10 +329,10 @@ inline void KdTree<T>::RayQuery(const Ray &r, Func &nodeProcessFunc)
 {
 	float tNear = 0.f, tFar = FLOAT_INF;
 
-	assume(rootAABB.IsFinite());
-	assume(!rootAABB.IsDegenerate());
+	mgl_assume(rootAABB.IsFinite());
+	mgl_assume(!rootAABB.IsDegenerate());
 #ifdef _DEBUG
-	assume(!needsBuilding);
+	mgl_assume(!needsBuilding);
 #endif
 
 	if (!rootAABB.IntersectLineAABB(r.pos, r.dir, tNear, tFar))
@@ -418,7 +418,7 @@ inline void KdTree<T>::RayQuery(const Ray &r, Func &nodeProcessFunc)
 			StackPtr tempPtr = exitPoint++;
 			if (exitPoint == entryPoint) // avoid overwriting data on the stack.
 				++exitPoint;
-			assert(exitPoint < cMaxStackItems);
+			mgl_assert(exitPoint < cMaxStackItems);
 
 			stack[exitPoint].prev = tempPtr;
 			stack[exitPoint].t = t;
@@ -472,7 +472,7 @@ inline void KdTree<T>::AABBQuery(const AABB &aabb, Func &leafCallback)
 	while(stackSize > 0)
 	{
 		KdTreeNode *cur = stack[--stackSize];
-		assert(!cur->IsLeaf());
+		mgl_assert(!cur->IsLeaf());
 
 		// We know that aabb intersects with the AABB of the current node, which allows
 		// most of the AABB-AABB intersection tests to be ignored.
@@ -531,7 +531,7 @@ inline void KdTree<T>::KdTreeQuery(KdTree<T> &tree2, const float3x4 &thisWorldTr
 	stack[0].thisNode = Root();
 	stack[0].thisAABB = BoundingAABB();
 	stack[0].tree2Node = tree2.Root();
-	stack[0].tree2AABB = tree2.BoundingAABB();	
+	stack[0].tree2AABB = tree2.BoundingAABB();
 	OBB tree2OBB = stack[0].tree2AABB.Transform(tree2Transform);
 	stack[0].tree2OBB = tree2OBB;
 
@@ -540,7 +540,7 @@ inline void KdTree<T>::KdTreeQuery(KdTree<T> &tree2, const float3x4 &thisWorldTr
 
 	while(stackSize > 0)
 	{
-		assert(stackSize < cMaxStackItems*100);
+		mgl_assert(stackSize < cMaxStackItems*100);
 		--stackSize;
 		KdTreeNode *thisNode = stack[stackSize].thisNode;
 		KdTreeNode *tree2Node = stack[stackSize].tree2Node;

--- a/src/Geometry/Line.cpp
+++ b/src/Geometry/Line.cpp
@@ -55,13 +55,13 @@ MATH_BEGIN_NAMESPACE
 	@see ClosestPoint(), Distance(). */
 void Line::ClosestPointLineLine(const vec &v0, const vec &v10, const vec &v2, const vec &v32, float &d, float &d2)
 {
-	assume(!v10.IsZero());
-	assume(!v32.IsZero());
+	mgl_assume(!v10.IsZero());
+	mgl_assume(!v32.IsZero());
 	vec v02 = v0 - v2;
 	float d0232 = v02.Dot(v32);
 	float d3210 = v32.Dot(v10);
 	float d3232 = v32.Dot(v32);
-	assume(d3232 != 0.f); // Don't call with a zero direction vector.
+	mgl_assume(d3232 != 0.f); // Don't call with a zero direction vector.
 	float d0210 = v02.Dot(v10);
 	float d1010 = v10.Dot(v10);
 	float denom = d1010*d3232 - d3210*d3210;
@@ -75,13 +75,13 @@ void Line::ClosestPointLineLine(const vec &v0, const vec &v10, const vec &v2, co
 Line::Line(const vec &pos_, const vec &dir_)
 :pos(pos_), dir(dir_)
 {
-	assume2(dir.IsNormalized(), dir, dir.LengthSq());
+	mgl_assume2(dir.IsNormalized(), dir, dir.LengthSq());
 }
 
 Line::Line(const Ray &ray)
 :pos(ray.pos), dir(ray.dir)
 {
-	assume2(dir.IsNormalized(), dir, dir.LengthSq());
+	mgl_assume2(dir.IsNormalized(), dir, dir.LengthSq());
 }
 
 Line::Line(const LineSegment &lineSegment)
@@ -96,7 +96,7 @@ bool Line::IsFinite() const
 
 vec Line::GetPoint(float d) const
 {
-	assume2(dir.IsNormalized(), dir, dir.LengthSq());
+	mgl_assume2(dir.IsNormalized(), dir, dir.LengthSq());
 	return pos + d * dir;
 }
 
@@ -146,8 +146,8 @@ bool Line::Contains(const LineSegment &lineSegment, float epsilon) const
 
 bool Line::Equals(const Line &line, float epsilon) const
 {
-	assume2(dir.IsNormalized(), dir, dir.LengthSq());
-	assume2(line.dir.IsNormalized(), line.dir, line.dir.LengthSq());
+	mgl_assume2(dir.IsNormalized(), dir, dir.LengthSq());
+	mgl_assume2(line.dir.IsNormalized(), line.dir, line.dir.LengthSq());
 	// If the point of the other line is on this line, and the two lines point to the same, or exactly reverse directions,
 	// they must be equal.
 	return Contains(line.pos, epsilon) && EqualAbs(Abs(dir.Dot(line.dir)), 1.f, epsilon);
@@ -173,8 +173,8 @@ float Line::Distance(const Line &other, float &d, float &d2) const
 float Line::Distance(const LineSegment &other, float &d, float &d2) const
 {
 	vec c = ClosestPoint(other, d, d2);
-	mathassert(d2 >= 0.f);
-	mathassert(d2 <= 1.f);
+	mgl_mathassert(d2 >= 0.f);
+	mgl_mathassert(d2 <= 1.f);
 	return c.Distance(other.GetPoint(d2));
 }
 
@@ -373,7 +373,7 @@ StringT Line::SerializeToString() const
 	s = SerializeFloat(dir.x, s); *s = ','; ++s;
 	s = SerializeFloat(dir.y, s); *s = ','; ++s;
 	s = SerializeFloat(dir.z, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -396,7 +396,7 @@ std::ostream &operator <<(std::ostream &o, const Line &line)
 
 Line Line::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return Line(vec::nan, vec::nan);
 	Line l;

--- a/src/Geometry/LineSegment.cpp
+++ b/src/Geometry/LineSegment.cpp
@@ -470,7 +470,7 @@ StringT LineSegment::SerializeToString() const
 	s = SerializeFloat(b.x, s); *s = ','; ++s;
 	s = SerializeFloat(b.y, s); *s = ','; ++s;
 	s = SerializeFloat(b.z, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -493,7 +493,7 @@ std::ostream &operator <<(std::ostream &o, const LineSegment &lineSegment)
 
 LineSegment LineSegment::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return LineSegment(vec::nan, vec::nan);
 	LineSegment l;

--- a/src/Geometry/LineSegment2D.cpp
+++ b/src/Geometry/LineSegment2D.cpp
@@ -272,13 +272,13 @@ vec2d LineSegment2D::ClosestPoint(const Line2D &other, float &d, float &d2) cons
 	@see ClosestPoint(), Distance(). */
 void Line2DClosestPointLineLine(const vec2d &v0, const vec2d &v10, const vec2d &v2, const vec2d &v32, float &d, float &d2) // TODO: Move to Line2D when that exists
 {
-	assume(!v10.IsZero());
-	assume(!v32.IsZero());
+	mgl_assume(!v10.IsZero());
+	mgl_assume(!v32.IsZero());
 	vec2d v02 = v0 - v2;
 	float d0232 = v02.Dot(v32);
 	float d3210 = v32.Dot(v10);
 	float d3232 = v32.Dot(v32);
-	assume(d3232 != 0.f); // Don't call with a zero direction vector.
+	mgl_assume(d3232 != 0.f); // Don't call with a zero direction vector.
 	float d0210 = v02.Dot(v10);
 	float d1010 = v10.Dot(v10);
 	float denom = d1010*d3232 - d3210*d3210;
@@ -521,7 +521,7 @@ StringT LineSegment2D::SerializeToString() const
 	s = SerializeFloat(a.y, s); *s = ','; ++s;
 	s = SerializeFloat(b.x, s); *s = ','; ++s;
 	s = SerializeFloat(b.y, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -544,7 +544,7 @@ std::ostream &operator <<(std::ostream &o, const LineSegment2D &lineSegment)
 
 LineSegment2D LineSegment2D::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return LineSegment2D(vec2d::nan, vec2d::nan);
 	LineSegment2D l;

--- a/src/Geometry/OBB.cpp
+++ b/src/Geometry/OBB.cpp
@@ -110,8 +110,8 @@ void OBB::SetFrom(const AABB &aabb)
 template<typename Matrix>
 void OBBSetFrom(OBB &obb, const AABB &aabb, const Matrix &m)
 {
-	assume1(m.IsColOrthogonal(), m); // We cannot convert transform an AABB to OBB if it gets sheared in the process.
-	assume(m.HasUniformScale()); // Nonuniform scale will produce shear as well.
+	mgl_assume1(m.IsColOrthogonal(), m); // We cannot convert transform an AABB to OBB if it gets sheared in the process.
+	mgl_assume(m.HasUniformScale()); // Nonuniform scale will produce shear as well.
 	obb.pos = m.MulPos(aabb.CenterPoint());
 	obb.r = aabb.HalfSize();
 	obb.axis[0] = DIR_VEC(m.Col(0));
@@ -127,15 +127,15 @@ void OBBSetFrom(OBB &obb, const AABB &aabb, const Matrix &m)
 	obb.axis[1] *= matrixScale;
 	obb.axis[2] *= matrixScale;
 
-//	mathassert(vec::AreOrthogonal(obb.axis[0], obb.axis[1], obb.axis[2]));
-//	mathassert(vec::AreOrthonormal(obb.axis[0], obb.axis[1], obb.axis[2]));
+//	mgl_mathassert(vec::AreOrthogonal(obb.axis[0], obb.axis[1], obb.axis[2]));
+//	mgl_mathassert(vec::AreOrthonormal(obb.axis[0], obb.axis[1], obb.axis[2]));
 	///@todo Would like to simply do the above, but instead numerical stability requires to do the following:
 	vec::Orthonormalize(obb.axis[0], obb.axis[1], obb.axis[2]);
 }
 
 void OBB::SetFrom(const AABB &aabb, const float3x3 &transform)
 {
-	assume(transform.IsColOrthogonal());
+	mgl_assume(transform.IsColOrthogonal());
 	OBBSetFrom(*this, aabb, transform);
 }
 
@@ -146,7 +146,7 @@ void OBB::SetFrom(const AABB &aabb, const float3x4 &transform)
 
 void OBB::SetFrom(const AABB &aabb, const float4x4 &transform)
 {
-	assume(transform.Row(3).Equals(0,0,0,1));
+	mgl_assume(transform.Row(3).Equals(0,0,0,1));
 	OBBSetFrom(*this, aabb, transform.Float3x4Part());
 }
 
@@ -237,7 +237,7 @@ AABB OBB::MaximalContainedAABB() const
 #else
 #warning OBB::MaximalContainedAABB not implemented!
 #endif
-	assume(false && "OBB::MaximalContainedAABB not implemented!"); /// @todo Implement.
+	mgl_assume(false && "OBB::MaximalContainedAABB not implemented!"); /// @todo Implement.
 	return AABB();
 }
 #endif
@@ -275,9 +275,9 @@ vec OBB::CenterPoint() const
 
 vec OBB::PointInside(float x, float y, float z) const
 {
-	assume(0.f <= x && x <= 1.f);
-	assume(0.f <= y && y <= 1.f);
-	assume(0.f <= z && z <= 1.f);
+	mgl_assume(0.f <= x && x <= 1.f);
+	mgl_assume(0.f <= y && y <= 1.f);
+	mgl_assume(0.f <= z && z <= 1.f);
 
 	return pos + axis[0] * (2.f * r.x * x - r.x)
 			   + axis[1] * (2.f * r.y * y - r.y)
@@ -286,7 +286,7 @@ vec OBB::PointInside(float x, float y, float z) const
 
 LineSegment OBB::Edge(int edgeIndex) const
 {
-	assume(0 <= edgeIndex && edgeIndex <= 11);
+	mgl_assume(0 <= edgeIndex && edgeIndex <= 11);
 	switch(edgeIndex)
 	{
 		default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -307,7 +307,7 @@ LineSegment OBB::Edge(int edgeIndex) const
 
 vec OBB::CornerPoint(int cornerIndex) const
 {	
-	assume(0 <= cornerIndex && cornerIndex <= 7);
+	mgl_assume(0 <= cornerIndex && cornerIndex <= 7);
 	switch(cornerIndex)
 	{
 		default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -366,8 +366,8 @@ int OBB::UniqueEdgeDirections(vec *out) const
 
 vec OBB::PointOnEdge(int edgeIndex, float u) const
 {
-	assume(0 <= edgeIndex && edgeIndex <= 11);
-	assume(0 <= u && u <= 1.f);
+	mgl_assume(0 <= edgeIndex && edgeIndex <= 11);
+	mgl_assume(0 <= u && u <= 1.f);
 
 	edgeIndex = Clamp(edgeIndex, 0, 11);
 	vec d = axis[edgeIndex/4] * (2.f * u - 1.f) * r[edgeIndex/4];
@@ -393,7 +393,7 @@ vec OBB::PointOnEdge(int edgeIndex, float u) const
 
 vec OBB::FaceCenterPoint(int faceIndex) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
 
 	switch(faceIndex)
 	{
@@ -409,9 +409,9 @@ vec OBB::FaceCenterPoint(int faceIndex) const
 
 vec OBB::FacePoint(int faceIndex, float u, float v) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
-	assume(0 <= u && u <= 1.f);
-	assume(0 <= v && v <= 1.f);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= u && u <= 1.f);
+	mgl_assume(0 <= v && v <= 1.f);
 
 	int uIdx = faceIndex/2;
 	int vIdx = (faceIndex/2 + 1) % 3;
@@ -431,7 +431,7 @@ vec OBB::FacePoint(int faceIndex, float u, float v) const
 
 Plane OBB::FacePlane(int faceIndex) const
 {
-	assume(0 <= faceIndex && faceIndex <= 5);
+	mgl_assume(0 <= faceIndex && faceIndex <= 5);
 	switch(faceIndex)
 	{
 	default: // For release builds where assume() is disabled, return always the first option if out-of-bounds.
@@ -446,14 +446,14 @@ Plane OBB::FacePlane(int faceIndex) const
 
 void OBB::GetCornerPoints(vec *outPointArray) const
 {
-	assume(outPointArray);
+	mgl_assume(outPointArray);
 	for(int i = 0; i < 8; ++i)
 		outPointArray[i] = CornerPoint(i);
 }
 
 void OBB::GetFacePlanes(Plane *outPlaneArray) const
 {
-	assume(outPlaneArray);
+	mgl_assume(outPlaneArray);
 	for(int i = 0; i < 6; ++i)
 		outPlaneArray[i] = FacePlane(i);
 }
@@ -461,7 +461,7 @@ void OBB::GetFacePlanes(Plane *outPlaneArray) const
 /// See Christer Ericson's book Real-Time Collision Detection, page 83.
 void OBB::ExtremePointsAlongDirection(const vec &dir, const vec *pointArray, int numPoints, int &idxSmallest, int &idxLargest, float &smallestD, float &largestD)
 {
-	assume(pointArray || numPoints == 0);
+	mgl_assume(pointArray || numPoints == 0);
 
 	idxSmallest = idxLargest = 0;
 
@@ -500,14 +500,14 @@ OBB SmallestOBBVolumeOneEdgeFixed(const vec &edge, const vec *pointArray, int nu
 	float2::MinAreaRectInPlace(&pts[0], (int)pts.size(), rectCenter, uDir, vDir, minU, maxU, minV, maxV);
 	vec basisU = uDir.x * u + uDir.y * v;
 	vec basisV = vDir.x * u + vDir.y * v;
-	assume2(basisU.IsPerpendicular(basisV), basisU, basisV);
+	mgl_assume2(basisU.IsPerpendicular(basisV), basisU, basisV);
 	return OBB::FixedOrientationEnclosingOBB(pointArray, numPoints, basisU, basisV);
 }
 
 float SmallestOBBVolumeJiggle(const vec &edge_, const vec *pointArray, int numPoints, std::vector<float2> &pts,
 	vec &outEdgeA, vec &outEdgeB)
 {
-	assume(numPoints >= 3);
+	mgl_assume(numPoints >= 3);
 	vec edge = edge_;
 	int numTimesNotImproved = 0;
 	float bestVolume = FLOAT_INF;
@@ -531,9 +531,9 @@ float SmallestOBBVolumeJiggle(const vec &edge_, const vec *pointArray, int numPo
 		float minU, maxU, minV, maxV;
 
 		float2::MinAreaRectInPlace(&pts[0], (int)pts.size(), rectCenter, uDir, vDir, minU, maxU, minV, maxV);
-		assume(uDir.IsNormalized());
-		assume(vDir.IsNormalized());
-		assume(uDir.IsPerpendicular(vDir));
+		mgl_assume(uDir.IsNormalized());
+		mgl_assume(vDir.IsNormalized());
+		mgl_assume(uDir.IsPerpendicular(vDir));
 		float2 c10 = (maxV - minV) * vDir;
 		float2 c20 = (maxU - minU) * uDir;
 
@@ -546,16 +546,16 @@ float SmallestOBBVolumeJiggle(const vec &edge_, const vec *pointArray, int numPo
 		{
 			bestVolume = volume;
 			edgeFirstChoice = (uDir.x*u + uDir.y*v);
-			assume(edgeFirstChoice.IsPerpendicular(edge));
+			mgl_assume(edgeFirstChoice.IsPerpendicular(edge));
 			float len = edgeFirstChoice.Normalize();
-			assert(len > 0.f);
+			mgl_assert(len > 0.f);
 
 			edgeSecondChoice = (vDir.x*u + vDir.y*v);
 			len = edgeSecondChoice.Normalize();
-			assert(len > 0.f);
+			mgl_assert(len > 0.f);
 
-			assume3(edgeSecondChoice.IsPerpendicular(edge), edgeSecondChoice, edge, edgeSecondChoice.Dot(edge));
-			assume3(edgeSecondChoice.IsPerpendicular(edgeFirstChoice), edgeSecondChoice, edgeFirstChoice, edgeSecondChoice.Dot(edgeFirstChoice));
+			mgl_assume3(edgeSecondChoice.IsPerpendicular(edge), edgeSecondChoice, edge, edgeSecondChoice.Dot(edge));
+			mgl_assume3(edgeSecondChoice.IsPerpendicular(edgeFirstChoice), edgeSecondChoice, edgeFirstChoice, edgeSecondChoice.Dot(edgeFirstChoice));
 			outEdgeA = edge;
 			outEdgeB = edge = edgeFirstChoice;
 			numTimesNotImproved = 0;
@@ -834,8 +834,8 @@ bool AreCompatibleOpposingEdges(const vec &f1a, const vec &f1b, const vec &f2a, 
 
 OBB OBB::OptimalEnclosingOBB(const vec *pointArray, int numPoints)
 {
-	assert(pointArray);
-	assert(numPoints >= 0);
+	mgl_assert(pointArray);
+	mgl_assert(numPoints >= 0);
 
 	// Precomputation: Generate the convex hull of the input point set. This is because
 	// we need vertex-edge-face connectivity information about the convex hull shape, and
@@ -975,10 +975,10 @@ void FORCE_INLINE TestThreeAdjacentFaces(const vec &n1, const vec &n2, const vec
 		minOBB->r[1] = (maxN2 - minN2) * 0.5f;
 		minOBB->r[2] = (maxN3 - minN3) * 0.5f;
 		minOBB->pos = (minN1 + minOBB->r[0])*n1 + (minN2 + minOBB->r[1])*n2 + (minN3 + minOBB->r[2])*n3;
-		assert(volume > 0.f);
+		mgl_assert(volume > 0.f);
 #ifdef OBB_ASSERT_VALIDITY
 		OBB o = OBB::FixedOrientationEnclosingOBB((const vec*)&convexHull.v[0], convexHull.v.size(), minOBB->axis[0], minOBB->axis[1]);
-		assert2(EqualRel(o.Volume(), volume), o.Volume(), volume);
+		mgl_assert2(EqualRel(o.Volume(), volume), o.Volume(), volume);
 #endif
 		*minVolume = volume;
 	}
@@ -1802,7 +1802,7 @@ OBB OBB::OptimalEnclosingOBB(const Polyhedron &convexHull)
 						minOBB.r[2] = (maxN3 - minN3) * 0.5f;
 #ifdef OBB_ASSERT_VALIDITY
 						OBB o = OBB::FixedOrientationEnclosingOBB((const vec*)&convexHull.v[0], convexHull.v.size(), minOBB.axis[0], minOBB.axis[1]);
-						assert2(EqualRel(o.Volume(), volume), o.Volume(), volume);
+						mgl_assert2(EqualRel(o.Volume(), volume), o.Volume(), volume);
 #endif
 						minVolume = volume;
 					}
@@ -1939,10 +1939,10 @@ OBB OBB::OptimalEnclosingOBB(const Polyhedron &convexHull)
 					minOBB.r[0] = (maxN1 - minN1) * 0.5f;
 					minOBB.r[1] = (maxN2 - minN2) * 0.5f;
 					minOBB.r[2] = (maxN3 - minN3) * 0.5f;
-					assert(volume > 0.f);
+					mgl_assert(volume > 0.f);
 #ifdef OBB_ASSERT_VALIDITY
 					OBB o = OBB::FixedOrientationEnclosingOBB((const vec*)&convexHull.v[0], convexHull.v.size(), minOBB.axis[0], minOBB.axis[1]);
-					assert2(EqualRel(o.Volume(), volume), o.Volume(), volume);
+					mgl_assert2(EqualRel(o.Volume(), volume), o.Volume(), volume);
 #endif
 					minVolume = volume;
 				}
@@ -1969,9 +1969,9 @@ OBB OBB::OptimalEnclosingOBB(const Polyhedron &convexHull)
 
 OBB OBB::FixedOrientationEnclosingOBB(const vec *pointArray, int numPoints, const vec &dir0, const vec &dir1)
 {
-	assume(dir0.IsNormalized());
-	assume(dir1.IsNormalized());
-	assume(dir0.IsPerpendicular(dir1));
+	mgl_assume(dir0.IsNormalized());
+	mgl_assume(dir1.IsNormalized());
+	mgl_assume(dir0.IsPerpendicular(dir1));
 
 	int d0, d1;
 	float mind0, maxd0, mind1, maxd1, mind2, maxd2;
@@ -2042,7 +2042,7 @@ OBB OBB::BruteEnclosingOBB(const Polyhedron &convexPolyhedron)
 			float fz = Sqrt(1.0f - lenSq);
 
 			vec edge = DIR_VEC(fx, fy, fz);
-			assert(edge.IsNormalized());
+			mgl_assert(edge.IsNormalized());
 
 			vec edgeA, edgeB;
 			float volume = SmallestOBBVolumeJiggle(edge, (const vec*)&convexPolyhedron.v[0], (int)convexPolyhedron.v.size(), pts, /*adjacencyData, floodFillVisited, floodFillVisitColor,*/
@@ -2050,7 +2050,7 @@ OBB OBB::BruteEnclosingOBB(const Polyhedron &convexPolyhedron)
 
 			if (volume < minVolume)
 			{
-				assert3(edgeA.IsPerpendicular(edgeB), edgeA, edgeB, edgeA.Dot(edgeB));
+				mgl_assert3(edgeA.IsPerpendicular(edgeB), edgeA, edgeB, edgeA.Dot(edgeB));
 				minVolumeEdgeA = edgeA;
 				minVolumeEdgeB = edgeB;
 				minVolume = volume;
@@ -2243,21 +2243,21 @@ float3x4 OBB::LocalToWorld() const
 	return m;
 	*/
 
-	assume2(axis[0].IsNormalized(), axis[0], axis[0].LengthSq());
-	assume2(axis[1].IsNormalized(), axis[1], axis[1].LengthSq());
-	assume2(axis[2].IsNormalized(), axis[2], axis[2].LengthSq());
+	mgl_assume2(axis[0].IsNormalized(), axis[0], axis[0].LengthSq());
+	mgl_assume2(axis[1].IsNormalized(), axis[1], axis[1].LengthSq());
+	mgl_assume2(axis[2].IsNormalized(), axis[2], axis[2].LengthSq());
 	float3x4 m; ///\todo sse-matrix
 	m.SetCol(0, axis[0].ptr());
 	m.SetCol(1, axis[1].ptr());
 	m.SetCol(2, axis[2].ptr());
 	vec p = pos - axis[0] * r.x - axis[1] * r.y - axis[2] * r.z;
 	m.SetCol(3, p.ptr());
-	assume1(m.Row3(0).IsNormalized(), m.Row3(0));
-	assume1(m.Row3(1).IsNormalized(), m.Row3(1));
-	assume1(m.Row3(2).IsNormalized(), m.Row3(2));
-	assume3(m.Col(0).IsPerpendicular(m.Col(1)), m.Col(0), m.Col(1), m.Col(0).Dot(m.Col(1)));
-	assume3(m.Col(0).IsPerpendicular(m.Col(2)), m.Col(0), m.Col(2), m.Col(0).Dot(m.Col(2)));
-	assume3(m.Col(1).IsPerpendicular(m.Col(2)), m.Col(1), m.Col(2), m.Col(1).Dot(m.Col(2)));
+	mgl_assume1(m.Row3(0).IsNormalized(), m.Row3(0));
+	mgl_assume1(m.Row3(1).IsNormalized(), m.Row3(1));
+	mgl_assume1(m.Row3(2).IsNormalized(), m.Row3(2));
+	mgl_assume3(m.Col(0).IsPerpendicular(m.Col(1)), m.Col(0), m.Col(1), m.Col(0).Dot(m.Col(1)));
+	mgl_assume3(m.Col(0).IsPerpendicular(m.Col(2)), m.Col(0), m.Col(2), m.Col(0).Dot(m.Col(2)));
+	mgl_assume3(m.Col(1).IsPerpendicular(m.Col(2)), m.Col(1), m.Col(2), m.Col(1).Dot(m.Col(2)));
 	return m;
 }
 
@@ -2357,19 +2357,19 @@ void OBBTransform(OBB &o, const Matrix &transform)
 
 void OBB::Transform(const float3x3 &transform)
 {
-	assume(transform.IsColOrthogonal());
+	mgl_assume(transform.IsColOrthogonal());
 	OBBTransform(*this, transform);
 }
 
 void OBB::Transform(const float3x4 &transform)
 {
-	assume(transform.IsColOrthogonal());
+	mgl_assume(transform.IsColOrthogonal());
 	OBBTransform(*this, transform);
 }
 
 void OBB::Transform(const float4x4 &transform)
 {
-	assume(transform.IsColOrthogonal3());
+	mgl_assume(transform.IsColOrthogonal3());
 	OBBTransform(*this, transform);
 }
 
@@ -2467,7 +2467,7 @@ bool OBB::Contains(const Frustum &frustum) const
 
 bool OBB::Contains(const Polyhedron &polyhedron) const
 {
-	assume(polyhedron.IsClosed());
+	mgl_assume(polyhedron.IsClosed());
 	for(int i = 0; i < polyhedron.NumVertices(); ++i)
 		if (!Contains(polyhedron.Vertex(i)))
 			return false;
@@ -2485,7 +2485,7 @@ void OBB::Enclose(const vec &point)
 	vec p = point - pos;
 	for(int i = 0; i < 3; ++i)
 	{
-		assume2(EqualAbs(axis[i].Length(), 1.f), axis[i], axis[i].Length());
+		mgl_assume2(EqualAbs(axis[i].Length(), 1.f), axis[i], axis[i].Length());
 		float dist = p.Dot(axis[i]);
 		float distanceFromOBB = Abs(dist) - r[i];
 		if (distanceFromOBB > 0.f)
@@ -2498,11 +2498,11 @@ void OBB::Enclose(const vec &point)
 
 			p = point-pos; ///\todo Can we omit this? (redundant since axis[i] are orthonormal?)
 
-			mathassert(EqualAbs(Abs(p.Dot(axis[i])), r[i], 1e-1f));
+			mgl_mathassert(EqualAbs(Abs(p.Dot(axis[i])), r[i], 1e-1f));
 		}
 	}
 	// Should now contain the point.
-	assume2(Distance(point) <= 1e-3f, point, Distance(point));
+	mgl_assume2(Distance(point) <= 1e-3f, point, Distance(point));
 }
 
 void OBB::Triangulate(int x, int y, int z, vec *outPos, vec *outNormal, float2 *outUV, bool ccwIsFrontFacing) const
@@ -2510,14 +2510,14 @@ void OBB::Triangulate(int x, int y, int z, vec *outPos, vec *outNormal, float2 *
 	AABB aabb(POINT_VEC_SCALAR(0), r*2.f);
 	aabb.Triangulate(x, y, z, outPos, outNormal, outUV, ccwIsFrontFacing);
 	float3x4 localToWorld = LocalToWorld();
-	assume(localToWorld.HasUnitaryScale()); // Transforming of normals will fail otherwise.
+	mgl_assume(localToWorld.HasUnitaryScale()); // Transforming of normals will fail otherwise.
 	localToWorld.BatchTransformPos(outPos, NumVerticesInTriangulation(x,y,z), sizeof(vec));
 	localToWorld.BatchTransformDir(outNormal, NumVerticesInTriangulation(x,y,z), sizeof(vec));
 }
 
 void OBB::ToEdgeList(vec *outPos) const
 {
-	assume(outPos);
+	mgl_assume(outPos);
 	if (!outPos)
 		return;
 	for(int i = 0; i < 12; ++i)
@@ -2530,10 +2530,10 @@ void OBB::ToEdgeList(vec *outPos) const
 
 bool OBB::Intersects(const OBB &b, float epsilon) const
 {
-	assume(pos.IsFinite());
-	assume(b.pos.IsFinite());
-	assume(vec::AreOrthogonal(axis[0], axis[1], axis[2]));
-	assume(vec::AreOrthogonal(b.axis[0], b.axis[1], b.axis[2]));
+	mgl_assume(pos.IsFinite());
+	mgl_assume(b.pos.IsFinite());
+	mgl_assume(vec::AreOrthogonal(axis[0], axis[1], axis[2]));
+	mgl_assume(vec::AreOrthogonal(b.axis[0], b.axis[1], b.axis[2]));
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	// SSE4.1:
@@ -2844,7 +2844,7 @@ std::ostream &operator <<(std::ostream &o, const OBB &obb)
 
 OBB OBB::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return OBB(vec::nan, vec::nan, vec::nan, vec::nan, vec::nan);
 	OBB o;

--- a/src/Geometry/PBVolume.h
+++ b/src/Geometry/PBVolume.h
@@ -240,10 +240,10 @@ public:
 						break;
 					}
 				}
-				assert(found);
+				mgl_assert(found);
 				MARK_UNUSED(found);
 			}
-			assert(pt[0].j == pt[pt.size()-1].k);
+			mgl_assert(pt[0].j == pt[pt.size()-1].k);
 			Polyhedron::Face face;
 			for(size_t j = 0; j < pt.size(); ++j)
 			{

--- a/src/Geometry/Plane.cpp
+++ b/src/Geometry/Plane.cpp
@@ -49,7 +49,7 @@ MATH_BEGIN_NAMESPACE
 Plane::Plane(const vec &normal_, float d_)
 :normal(normal_), d(d_)
 {
-	assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
+	mgl_assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
 }
 
 Plane::Plane(const vec &v1, const vec &v2, const vec &v3)
@@ -89,21 +89,21 @@ void Plane::Set(const vec &v1, const vec &v2, const vec &v3)
 {
 	normal = (v2-v1).Cross(v3-v1);
 	float len = normal.Length();
-	assume1(len > 1e-10f, len);
+	mgl_assume1(len > 1e-10f, len);
 	normal /= len;
-	assume2(normal.IsNormalized(), normal, normal.LengthSq());
+	mgl_assume2(normal.IsNormalized(), normal, normal.LengthSq());
 	d = normal.Dot(v1);
 }
 
 void Plane::Set(const vec &point, const vec &normal_)
 {
 	normal = normal_;
-	assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
+	mgl_assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
 	d = point.Dot(normal);
 
 #ifdef MATH_ASSERT_CORRECTNESS
-	assert1(EqualAbs(SignedDistance(point), 0.f, 0.01f), SignedDistance(point));
-	assert1(EqualAbs(SignedDistance(point + normal_), 1.f, 0.01f), SignedDistance(point + normal_));
+	mgl_assert1(EqualAbs(SignedDistance(point), 0.f, 0.01f), SignedDistance(point));
+	mgl_assert1(EqualAbs(SignedDistance(point + normal_), 1.f, 0.01f), SignedDistance(point + normal_));
 #endif
 }
 
@@ -153,7 +153,7 @@ void Plane::Transform(const float3x4 &transform)
 	///@todo Could optimize this function by switching to plane convention ax+by+cz+d=0 instead of ax+by+cz=d.
 	float3x3 r = transform.Float3x3Part();
 	bool success = r.Inverse(); ///@todo Can optimize the inverse here by assuming orthogonality or orthonormality.
-	assume(success);
+	mgl_assume(success);
 	MARK_UNUSED(success);
 	d = d + normal.Dot(DIR_VEC(r * transform.TranslatePart()));
 	normal = normal * r;
@@ -161,7 +161,7 @@ void Plane::Transform(const float3x4 &transform)
 
 void Plane::Transform(const float4x4 &transform)
 {
-	assume(transform.Row(3).Equals(float4(0,0,0,1)));
+	mgl_assume(transform.Row(3).Equals(float4(0,0,0,1)));
 	Transform(transform.Float3x4Part());
 }
 
@@ -221,9 +221,9 @@ float Plane::Distance(const Capsule &capsule) const
 
 float Plane::SignedDistance(const vec &point) const
 {
-	assume2(normal.IsNormalized(), normal, normal.Length());
+	mgl_assume2(normal.IsNormalized(), normal, normal.Length());
 #ifdef MATH_VEC_IS_FLOAT4
-	assert1(normal.w == 0.f, normal.w);
+	mgl_assert1(normal.w == 0.f, normal.w);
 #endif
 	return normal.Dot(point) - d;
 }
@@ -232,7 +232,7 @@ template<typename T>
 float Plane_SignedDistance(const Plane &plane, const T &object)
 {
 	float pMin, pMax;
-	assume(plane.normal.IsNormalized());
+	mgl_assume(plane.normal.IsNormalized());
 	object.ProjectToAxis(plane.normal, pMin, pMax);
 	pMin -= plane.d;
 	pMax -= plane.d;
@@ -268,7 +268,7 @@ float3x4 Plane::ObliqueProjection(const vec & /*obliqueProjectionDir*/) const
 #else
 #warning Plane::ObliqueProjection not implemented!
 #endif
-	assume(false && "Plane::ObliqueProjection not implemented!"); /// @todo Implement.
+	mgl_assume(false && "Plane::ObliqueProjection not implemented!"); /// @todo Implement.
 	return float3x4();
 }
 #endif
@@ -283,10 +283,10 @@ vec Plane::Mirror(const vec &point) const
 #ifdef MATH_ASSERT_CORRECTNESS
 	float signedDistance = SignedDistance(point);
 #endif
-	assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
+	mgl_assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
 	vec reflected = point - 2.f * (point.Dot(normal) - d) * normal;
-	mathassert(EqualAbs(signedDistance, -SignedDistance(reflected), 1e-2f));
-	mathassert(reflected.Equals(MirrorMatrix().MulPos(point)));
+	mgl_mathassert(EqualAbs(signedDistance, -SignedDistance(reflected), 1e-2f));
+	mgl_mathassert(reflected.Equals(MirrorMatrix().MulPos(point)));
 	return reflected;
 }
 
@@ -358,8 +358,8 @@ Polygon Plane::Project(const Polygon &polygon) const
 
 vec Plane::ClosestPoint(const Ray &ray) const
 {
-	assume(ray.IsFinite());
-	assume(!IsDegenerate());
+	mgl_assume(ray.IsFinite());
+	mgl_assume(!IsDegenerate());
 
 	// The plane and a ray have three configurations:
 	// 1) the ray and the plane don't intersect: the closest point is the ray origin point.
@@ -389,8 +389,8 @@ vec Plane::ClosestPoint(const LineSegment &lineSegment) const
 			return Project(lineSegment.b);
 	*/
 
-	assume(lineSegment.IsFinite());
-	assume(!IsDegenerate());
+	mgl_assume(lineSegment.IsFinite());
+	mgl_assume(!IsDegenerate());
 
 	float aDist = Dot(normal, lineSegment.a);
 	float bDist = Dot(normal, lineSegment.b);
@@ -419,7 +419,7 @@ vec Plane::ObliqueProject(const vec & /*point*/, const vec & /*obliqueProjection
 #else
 #warning Plane::ObliqueProject not implemented!
 #endif
-	assume(false && "Plane::ObliqueProject not implemented!"); /// @todo Implement.
+	mgl_assume(false && "Plane::ObliqueProject not implemented!"); /// @todo Implement.
 	return vec();
 }
 #endif
@@ -458,7 +458,7 @@ bool Plane::Contains(const Polygon &polygon, float epsilon) const
 {
 	switch(polygon.NumVertices())
 	{
-	case 0: assume(false && "Plane::Contains(Polygon) called with a degenerate polygon of 0 vertices!"); return false;
+	case 0: mgl_assume(false && "Plane::Contains(Polygon) called with a degenerate polygon of 0 vertices!"); return false;
 	case 1: return Contains(polygon.Vertex(0), epsilon);
 	case 2: return Contains(polygon.Vertex(0), epsilon) && Contains(polygon.Vertex(1), epsilon);
 	default:
@@ -928,7 +928,7 @@ StringT Plane::SerializeToString() const
 	s = SerializeFloat(normal.y, s); *s = ','; ++s;
 	s = SerializeFloat(normal.z, s); *s = ','; ++s;
 	s = SerializeFloat(d, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -943,7 +943,7 @@ StringT Plane::SerializeToCodeString() const
 
 Plane Plane::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return Plane(vec::nan, FLOAT_NAN);
 	Plane p;

--- a/src/Geometry/Polygon.cpp
+++ b/src/Geometry/Polygon.cpp
@@ -57,8 +57,8 @@ int Polygon::NumEdges() const
 
 vec Polygon::Vertex(int vertexIndex) const
 {
-	assume(vertexIndex >= 0);
-	assume(vertexIndex < (int)p.size());
+	mgl_assume(vertexIndex >= 0);
+	mgl_assume(vertexIndex < (int)p.size());
 	return p[vertexIndex];
 }
 
@@ -82,18 +82,18 @@ LineSegment Polygon::Edge2D(int i) const
 
 bool Polygon::DiagonalExists(int i, int j) const
 {
-	assume(p.size() >= 3);
-	assume(i >= 0);
-	assume(j >= 0);
-	assume(i < (int)p.size());
-	assume(j < (int)p.size());
-	assume(IsPlanar());
-	assume(i != j);
+	mgl_assume(p.size() >= 3);
+	mgl_assume(i >= 0);
+	mgl_assume(j >= 0);
+	mgl_assume(i < (int)p.size());
+	mgl_assume(j < (int)p.size());
+	mgl_assume(IsPlanar());
+	mgl_assume(i != j);
 	if (i == j) // Degenerate if i == j.
 		return false;
 	if (i > j)
 		Swap(i, j);
-	assume(i+1 != j);
+	mgl_assume(i+1 != j);
 	if (i+1 == j) // Is this LineSegment an edge of this polygon?
 		return false;
 
@@ -127,16 +127,16 @@ vec Polygon::BasisV() const
 
 LineSegment Polygon::Diagonal(int i, int j) const
 {
-	assume(i >= 0);
-	assume(j >= 0);
-	assume(i < (int)p.size());
-	assume(j < (int)p.size());
+	mgl_assume(i >= 0);
+	mgl_assume(j >= 0);
+	mgl_assume(i < (int)p.size());
+	mgl_assume(j < (int)p.size());
 	return LineSegment(p[i], p[j]);
 }
 
 bool Polygon::IsConvex() const
 {
-	assume(IsPlanar());
+	mgl_assume(IsPlanar());
 	if (p.empty())
 		return false;
 	if (p.size() <= 3)
@@ -161,14 +161,14 @@ bool Polygon::IsConvex() const
 
 float2 Polygon::MapTo2D(int i) const
 {
-	assume(i >= 0);
-	assume(i < (int)p.size());
+	mgl_assume(i >= 0);
+	mgl_assume(i < (int)p.size());
 	return MapTo2D(p[i]);
 }
 
 float2 Polygon::MapTo2D(const vec &point) const
 {
-	assume(!p.empty());
+	mgl_assume(!p.empty());
 	vec basisU = BasisU();
 	vec basisV = BasisV();
 	vec pt = point - p[0];
@@ -177,7 +177,7 @@ float2 Polygon::MapTo2D(const vec &point) const
 
 vec Polygon::MapFrom2D(const float2 &point) const
 {
-	assume(!p.empty());
+	mgl_assume(!p.empty());
 	return (vec)p[0] + point.x * BasisU() + point.y * BasisV();
 }
 
@@ -200,7 +200,7 @@ bool Polygon::IsPlanar(float epsilonSq) const
 
 bool Polygon::IsSimple() const
 {
-	assume(IsPlanar());
+	mgl_assume(IsPlanar());
 	Plane plane = PlaneCCW();
 	for(int i = 0; i < (int)p.size(); ++i)
 	{
@@ -349,11 +349,11 @@ bool Polygon::Contains(const vec &worldSpacePoint, float polygonThicknessSq) con
 
 	vec basisU = BasisU();
 	vec basisV = BasisV();
-	assert1(basisU.IsNormalized(), basisU);
-	assert1(basisV.IsNormalized(), basisV);
-	assert2(basisU.IsPerpendicular(basisV), basisU, basisV);
-	assert3(basisU.IsPerpendicular(PlaneCCW().normal), basisU, PlaneCCW().normal, basisU.Dot(PlaneCCW().normal));
-	assert3(basisV.IsPerpendicular(PlaneCCW().normal), basisV, PlaneCCW().normal, basisV.Dot(PlaneCCW().normal));
+	mgl_assert1(basisU.IsNormalized(), basisU);
+	mgl_assert1(basisV.IsNormalized(), basisV);
+	mgl_assert2(basisU.IsPerpendicular(basisV), basisU, basisV);
+	mgl_assert3(basisU.IsPerpendicular(PlaneCCW().normal), basisU, PlaneCCW().normal, basisU.Dot(PlaneCCW().normal));
+	mgl_assert3(basisV.IsPerpendicular(PlaneCCW().normal), basisV, PlaneCCW().normal, basisV.Dot(PlaneCCW().normal));
 
 	vec normal = basisU.Cross(basisV);
 //	float lenSq = normal.LengthSq(); ///\todo Could we treat basisU and basisV unnormalized here?
@@ -727,7 +727,7 @@ bool Polygon::Intersects(const Capsule &capsule) const
 
 vec Polygon::ClosestPoint(const vec &point) const
 {
-	assume(IsPlanar());
+	mgl_assume(IsPlanar());
 
 	TriangleArray tris = Triangulate();
 	vec closestPt = vec::nan;
@@ -838,7 +838,7 @@ bool Contains(const vec &point, const vec &viewDirection) const;
 /** Implementation based on Graphics Gems 2, p. 170: "IV.1. Area of Planar Polygons and Volume of Polyhedra." */
 float Polygon::Area() const
 {
-	assume(IsPlanar());
+	mgl_assume(IsPlanar());
 	vec area = vec::zero;
 	if (p.size() <= 2)
 		return 0.f;
@@ -884,12 +884,12 @@ vec Polygon::PointOnEdge(float normalizedDistance) const
 	{
 		LineSegment edge = Edge(i);
 		float len = edge.Length();
-		assume(len != 0.f && "Degenerate Polygon detected!");
+		mgl_assume(len != 0.f && "Degenerate Polygon detected!");
 		if (d <= len)
 			return edge.GetPoint(d / len);
 		d -= len;
 	}
-	mathassert(false && "Polygon::PointOnEdge reached end of loop which shouldn't!");
+	mgl_mathassert(false && "Polygon::PointOnEdge reached end of loop which shouldn't!");
 	return p[0];
 }
 
@@ -973,8 +973,8 @@ bool IsAnEar(const std::vector<float2> &poly, int i, int j)
 	The running time of this function is O(n^2). */
 TriangleArray Polygon::Triangulate() const
 {
-	assume(IsPlanar());
-//	assume1(IsPlanar(), this->SerializeToString()); // TODO: enable
+	mgl_assume(IsPlanar());
+//	mgl_assume1(IsPlanar(), this->SerializeToString()); // TODO: enable
 
 	TriangleArray t;
 	// Handle degenerate cases.
@@ -1026,7 +1026,7 @@ TriangleArray Polygon::Triangulate() const
 		}
 	}
 
-	assume3(p2d.size() == 3, (int)p2d.size(), (int)polyIndices.size(), (int)NumVertices());
+	mgl_assume3(p2d.size() == 3, (int)p2d.size(), (int)polyIndices.size(), (int)NumVertices());
 	if (p2d.size() > 3) // If this occurs, then the polygon is NOT counter-clockwise oriented.
 		return t;
 /*

--- a/src/Geometry/Polygon2DRef.h
+++ b/src/Geometry/Polygon2DRef.h
@@ -18,8 +18,8 @@ public:
 
 	FORCE_INLINE vec2d AnyPointFast() const
 	{
-		assert(points);
-		assert(numPoints > 0);
+		mgl_assert(points);
+		mgl_assert(numPoints > 0);
 		return points[0];
 	}
 

--- a/src/Geometry/Polyhedron.cpp
+++ b/src/Geometry/Polyhedron.cpp
@@ -126,17 +126,17 @@ int Polyhedron::NumEdges() const
 
 vec Polyhedron::Vertex(int vertexIndex) const
 {
-	assume(vertexIndex >= 0);
-	assume(vertexIndex < (int)v.size());
+	mgl_assume(vertexIndex >= 0);
+	mgl_assume(vertexIndex < (int)v.size());
 	
 	return v[vertexIndex];
 }
 
 LineSegment Polyhedron::Edge(int edgeIndex) const
 {
-	assume(edgeIndex >= 0);
+	mgl_assume(edgeIndex >= 0);
 	LineSegmentArray edges = Edges();
-	assume(edgeIndex < (int)edges.size());
+	mgl_assume(edgeIndex < (int)edges.size());
 	return edges[edgeIndex];
 }
 
@@ -156,7 +156,7 @@ std::vector<std::pair<int, int> > Polyhedron::EdgeIndices() const
 	std::set<std::pair<int, int> > uniqueEdges;
 	for(int i = 0; i < NumFaces(); ++i)
 	{
-		assume(f[i].v.size() >= 3);
+		mgl_assume(f[i].v.size() >= 3);
 		if (f[i].v.size() < 3)
 			continue; // Degenerate face with less than three vertices, skip!
 		int x = f[i].v.back();
@@ -185,8 +185,8 @@ std::vector<Polygon> Polyhedron::Faces() const
 Polygon Polyhedron::FacePolygon(int faceIndex) const
 {
 	Polygon p;
-	assume(faceIndex >= 0);
-	assume(faceIndex < (int)f.size());
+	mgl_assume(faceIndex >= 0);
+	mgl_assume(faceIndex < (int)f.size());
 
 	p.p.reserve(f[faceIndex].v.size());
 	for(size_t i = 0; i < f[faceIndex].v.size(); ++i)
@@ -254,7 +254,7 @@ cv PolyFaceNormal(const Polyhedron &poly, int faceIndex)
 			a = b;
 			b = c;
 		}
-		assert(bestLen != -FLOAT_INF);
+		mgl_assert(bestLen != -FLOAT_INF);
 		return DIR_VEC((float)bestNormal.x, (float)bestNormal.y, (float)bestNormal.z);
 #endif
 
@@ -296,7 +296,7 @@ cv PolyFaceNormal(const Polyhedron &poly, int faceIndex)
 				bestNormal = normal;
 			}
 		}
-		assert(bestLen != -FLOAT_INF);
+		mgl_assert(bestLen != -FLOAT_INF);
 		return DIR_VEC((float)bestNormal.x, (float)bestNormal.y, (float)bestNormal.z);
 #endif
 	}
@@ -615,9 +615,9 @@ bool Polyhedron::IsClosed() const
 	{
 		if (f[i].v.size() <= 1)
 			continue;
-		assume(FacePolygon(i).IsPlanar());
-//		assume1(FacePolygon(i).IsPlanar(), FacePolygon(i).SerializeToString()); // TODO: enable
-		assume(FacePolygon(i).IsSimple());
+		mgl_assume(FacePolygon(i).IsPlanar());
+//		mgl_assume1(FacePolygon(i).IsPlanar(), FacePolygon(i).SerializeToString()); // TODO: enable
+		mgl_assume(FacePolygon(i).IsSimple());
 		int x = f[i].v.back();
 		for(size_t j = 0; j < f[i].v.size(); ++j) // O(1)
 		{
@@ -757,11 +757,11 @@ float Polyhedron::FaceContainmentDistance2D(int faceIndex, const vec &worldSpace
 	vec basisU = (vec)v[vertices[1]] - (vec)v[vertices[0]];
 	basisU.Normalize();
 	vec basisV = Cross(p.normal, basisU).Normalized();
-	mathassert(basisU.IsNormalized());
-	mathassert(basisV.IsNormalized());
-	mathassert(basisU.IsPerpendicular(basisV));
-	mathassert(basisU.IsPerpendicular(p.normal));
-	mathassert(basisV.IsPerpendicular(p.normal));
+	mgl_mathassert(basisU.IsNormalized());
+	mgl_mathassert(basisV.IsNormalized());
+	mgl_mathassert(basisU.IsPerpendicular(basisV));
+	mgl_mathassert(basisU.IsPerpendicular(p.normal));
+	mgl_mathassert(basisV.IsPerpendicular(p.normal));
 
 	// Tracks a pseudo-distance of the point to the ~nearest edge of the polygon. If the point is very close to the polygon
 	// edge, this is very small, and it's possible that due to numerical imprecision we cannot rely on the result in higher-level
@@ -949,7 +949,7 @@ bool Polyhedron::Contains(const Frustum &frustum) const
 
 bool Polyhedron::Contains(const Polyhedron &polyhedron) const
 {
-	assume(polyhedron.IsClosed());
+	mgl_assume(polyhedron.IsClosed());
 	for(int i = 0; i < polyhedron.NumVertices(); ++i)
 		if (!Contains(polyhedron.Vertex(i)))
 			return false;
@@ -959,7 +959,7 @@ bool Polyhedron::Contains(const Polyhedron &polyhedron) const
 
 bool Polyhedron::ContainsConvex(const vec &point, float epsilon) const
 {
-	assume(IsConvex());
+	mgl_assume(IsConvex());
 	for(int i = 0; i < NumFaces(); ++i)
 		if (FacePlane(i).SignedDistance(point) > epsilon)
 			return false;
@@ -979,7 +979,7 @@ bool Polyhedron::ContainsConvex(const Triangle &triangle) const
 
 vec Polyhedron::ClosestPointConvex(const vec &point) const
 {
-	assume(IsConvex());
+	mgl_assume(IsConvex());
 	if (ContainsConvex(point))
 		return point;
 	vec closestPoint = vec::nan;
@@ -1064,7 +1064,7 @@ float Polyhedron::Distance(const vec &point) const
 bool Polyhedron::ClipLineSegmentToConvexPolyhedron(const vec &ptA, const vec &dir,
                                                    float &tFirst, float &tLast) const
 {
-	assume(IsConvex());
+	mgl_assume(IsConvex());
 
 	// Intersect line segment against each plane.
 	for(int i = 0; i < NumFaces(); ++i)
@@ -1167,7 +1167,7 @@ bool Polyhedron::Intersects(const Polyhedron &polyhedron) const
 	// Test for each edge of this polyhedron whether the other polyhedron intersects it.
 	for(size_t i = 0; i < f.size(); ++i)
 	{
-		assert(!f[i].v.empty()); // Cannot have degenerate faces here, and for performance reasons, don't start checking for this condition in release mode!
+		mgl_assert(!f[i].v.empty()); // Cannot have degenerate faces here, and for performance reasons, don't start checking for this condition in release mode!
 		int v0 = f[i].v.back();
 		vec l0 = v[v0];
 		for(size_t j = 0; j < f[i].v.size(); ++j)
@@ -1184,7 +1184,7 @@ bool Polyhedron::Intersects(const Polyhedron &polyhedron) const
 	// Test for each edge of the other polyhedron whether this polyhedron intersects it.
 	for(size_t i = 0; i < polyhedron.f.size(); ++i)
 	{
-		assert(!polyhedron.f[i].v.empty()); // Cannot have degenerate faces here, and for performance reasons, don't start checking for this condition in release mode!
+		mgl_assert(!polyhedron.f[i].v.empty()); // Cannot have degenerate faces here, and for performance reasons, don't start checking for this condition in release mode!
 		int v0 = polyhedron.f[i].v.back();
 		vec l0 = polyhedron.v[v0];
 		for(size_t j = 0; j < polyhedron.f[i].v.size(); ++j)
@@ -1217,7 +1217,7 @@ bool PolyhedronIntersectsAABB_OBB(const Polyhedron &p, const T &obj)
 	// Test for each edge of this polyhedron whether the AABB/OBB intersects it.
 	for(size_t i = 0; i < p.f.size(); ++i)
 	{
-		assert(!p.f[i].v.empty()); // Cannot have degenerate faces here, and for performance reasons, don't start checking for this condition in release mode!
+		mgl_assert(!p.f[i].v.empty()); // Cannot have degenerate faces here, and for performance reasons, don't start checking for this condition in release mode!
 		int v0 = p.f[i].v.back();
 		vec l0 = p.v[v0];
 		for(size_t j = 0; j < p.f[i].v.size(); ++j)
@@ -1398,7 +1398,7 @@ void Polyhedron::MergeConvex(const vec &point)
 			//vec newTriangleNormal = (v[v.size()-1]-v[iter->second]).Cross(v[iter->first]-v[iter->second]).Normalized();
 
 			std::map<std::pair<int, int>, int>::iterator existing = remainingEdges.find(opposite);
-			assert(existing != remainingEdges.end());
+			mgl_assert(existing != remainingEdges.end());
 			MARK_UNUSED(existing);
 
 #if 0			
@@ -1430,8 +1430,8 @@ void Polyhedron::MergeConvex(const vec &point)
 
 						break;
 					}
-				assert(added);
-				assume(added);
+				mgl_assert(added);
+				mgl_assume(added);
 			}
 			else
 #endif
@@ -1447,14 +1447,14 @@ void Polyhedron::MergeConvex(const vec &point)
 		}
 	}
 
-#define mathasserteq(lhs, op, rhs) do { if (!((lhs) op (rhs))) { LOGE("Condition %s %s %s (%g %s %g) failed!", #lhs, #op, #rhs, (double)(lhs), #op, (double)(rhs)); assert(false); } } while(0)
+#define mgl_mathasserteq(lhs, op, rhs) do { if (!((lhs) op (rhs))) { LOGE("Condition %s %s %s (%g %s %g) failed!", #lhs, #op, #rhs, (double)(lhs), #op, (double)(rhs)); mgl_assert(false); } } while(0)
 
 //	mathasserteq(NumVertices() + NumFaces(), ==, 2 + NumEdges());
-	assert(FaceIndicesValid());
-//	assert(EulerFormulaHolds());
-//	assert(IsClosed());
-//	assert(FacesAreNondegeneratePlanar());
-//	assert(IsConvex());
+	mgl_assert(FaceIndicesValid());
+//	mgl_assert(EulerFormulaHolds());
+//	mgl_assert(IsClosed());
+//	mgl_assert(FacesAreNondegeneratePlanar());
+//	mgl_assert(IsConvex());
 
 //	if (hadDisconnectedHorizon)
 //		MergeConvex(point);
@@ -1463,8 +1463,8 @@ void Polyhedron::MergeConvex(const vec &point)
 
 void Polyhedron::MergeConvex(const vec &point)
 {
-//	assert(IsClosed());
-//	assert(IsConvex());
+//	mgl_assert(IsClosed());
+//	mgl_assert(IsConvex());
 
 	std::set<std::pair<int, int> > deletedEdges;
 
@@ -1513,11 +1513,11 @@ void Polyhedron::MergeConvex(const vec &point)
 		f.push_back(tri);
 	}
 
-//	assert(FaceIndicesValid());
-//	assert(EulerFormulaHolds());
-//	assert(IsClosed());
-//	assert(FacesAreNondegeneratePlanar());
-//	assert(IsConvex());
+//	mgl_assert(FaceIndicesValid());
+//	mgl_assert(EulerFormulaHolds());
+//	mgl_assert(IsClosed());
+//	mgl_assert(FacesAreNondegeneratePlanar());
+//	mgl_assert(IsConvex());
 }
 
 void Polyhedron::Translate(const vec &offset)
@@ -1663,7 +1663,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 		extremes.insert(extremeI);
 	}
 
-//	assume(extremes.size() >= 3);
+//	mgl_assume(extremes.size() >= 3);
 	if (extremes.size() < 3)
 		return p; // This might happen if there's NaNs in the vertex data, or duplicates.
 
@@ -1710,7 +1710,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 		int v1 = *iter; ++iter;
 		int v2 = *iter; ++iter;
 		int v3 = *iter;
-		assert(v0 < v1 && v1 < v2 && v2 < v3);
+		mgl_assert(v0 < v1 && v1 < v2 && v2 < v3);
 		Swap(p.v[0], p.v[v0]);
 		Swap(p.v[1], p.v[v1]);
 		Swap(p.v[2], p.v[v2]);
@@ -1749,9 +1749,9 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 		p.f[3].FlipWindingOrder();
 	}
 
-	assert(p.IsClosed());
-	assert(p.FaceIndicesValid());
-	assert(p.FacesAreNondegeneratePlanar());
+	mgl_assert(p.IsClosed());
+	mgl_assert(p.FaceIndicesValid());
+	mgl_assert(p.FacesAreNondegeneratePlanar());
 
 #ifdef CONVEXHULL_VERBOSE
 	p.DumpStructure();
@@ -1944,8 +1944,8 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 				C_LOG("Traversing edge %d->%d which belongs to face %d, and edge %d->%d belongs to face %d",
 					v0, v1, edgesToFaces[std::make_pair(v0, v1)],
 					v1, v0, edgesToFaces[std::make_pair(v1, v0)]);
-				assert(edgesToFaces[std::make_pair(v0, v1)] == fi);
-				assert(adjFace != fi);
+				mgl_assert(edgesToFaces[std::make_pair(v0, v1)] == fi);
+				mgl_assert(adjFace != fi);
 
 				bool adjFaceIsInConflict = (conflictingFaces.find(adjFace) != conflictingFaces.end());
 
@@ -2004,7 +2004,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 				for(std::set<int>::iterator fi = conflictingFaces.begin(); fi != conflictingFaces.end(); ++fi)
 				{
 					std::set<int>::iterator iter = conflictListVertices[v].find(*fi);
-					//assert(iter3 != conflictListVertices[*iter].end());
+					//mgl_assert(iter3 != conflictListVertices[*iter].end());
 					if (iter != conflictListVertices[v].end())
 					{
 						C_LOG("Vertex %d no longer with face %d, because the face was removed.", 
@@ -2044,7 +2044,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 #ifdef MATH_ENABLE_STL_SUPPORT
 				LOGE("Polyhedron: %s", p.ToString().c_str());
 #endif
-				assert(false);
+				mgl_assert(false);
 				return Polyhedron();
 			}
 			prev = boundaryEdges[i];
@@ -2058,7 +2058,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 		// Create new faces to close the boundary.
 		for(size_t i = 0; i < boundaryEdges.size(); ++i)
 		{
-			assert(face.v.size() == 3);
+			mgl_assert(face.v.size() == 3);
 			face.v[0] = boundaryEdges[i].first; face.v[1] = boundaryEdges[i].second; face.v[2] = extremeI; p.f.push_back(face);
 
 #if 0
@@ -2086,14 +2086,14 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 				degenerateTris.push_back(t);
 			}
 #endif
-			assert(!faceNormal.IsZero() && faceNormal.IsFinite());
+			mgl_assert(!faceNormal.IsZero() && faceNormal.IsFinite());
 			faceNormals.push_back(faceNormal);
-			assert(extremeI >= (int)hullVertices.size() || !hullVertices[extremeI]);
-			assert(edgesToFaces.find(std::make_pair(boundaryEdges[i].first, boundaryEdges[i].second))
+			mgl_assert(extremeI >= (int)hullVertices.size() || !hullVertices[extremeI]);
+			mgl_assert(edgesToFaces.find(std::make_pair(boundaryEdges[i].first, boundaryEdges[i].second))
 				== edgesToFaces.end() || edgesToFaces[std::make_pair(boundaryEdges[i].first, boundaryEdges[i].second)] == -1);
-			assert(edgesToFaces.find(std::make_pair(boundaryEdges[i].second, extremeI))
+			mgl_assert(edgesToFaces.find(std::make_pair(boundaryEdges[i].second, extremeI))
 				== edgesToFaces.end() || edgesToFaces[std::make_pair(boundaryEdges[i].second, extremeI)] == -1);
-			assert(edgesToFaces.find(std::make_pair(extremeI, boundaryEdges[i].first))
+			mgl_assert(edgesToFaces.find(std::make_pair(extremeI, boundaryEdges[i].first))
 				== edgesToFaces.end() || edgesToFaces[std::make_pair(extremeI, boundaryEdges[i].first)] == -1);
 
 			if (!(edgesToFaces.find(std::make_pair(boundaryEdges[i].first, boundaryEdges[i].second))
@@ -2168,7 +2168,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 #endif
 		// Add new faces that still have conflicting vertices to the work stack for later processing.
 		// The algorithm will terminate once all faces are clear of conflicts.
-		assert(conflictList.size() == p.f.size());
+		mgl_assert(conflictList.size() == p.f.size());
 		for(size_t j = oldNumFaces; j < p.f.size(); ++j)
 			if (!conflictList.at(j).empty())
 //				if (!conflictList[j].empty())
@@ -2184,7 +2184,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 					if (p.f[j].v.empty()) continue;
 					vec pointOnFace = p.v[p.f[j].v[0]];
 					float d = Dot((vec)p.v[i] - pointOnFace, faceNormals[j]);
-					assert(d <= 1e-1f);
+					mgl_assert(d <= 1e-1f);
 				}
 			}
 #endif
@@ -2194,7 +2194,7 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 
 #ifndef NDEBUG
 	for(size_t i = 0; i < conflictList.size(); ++i)
-		assert(conflictList[i].empty());
+		mgl_assert(conflictList[i].empty());
 #endif
 
 #ifdef CONVEXHULL_VERBOSE
@@ -2217,19 +2217,19 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 	p.RemoveRedundantVertices();
 //	p.DumpStructure();
 
-	assume(p.IsClosed());
-	assume(p.FaceIndicesValid());
-	assume(p.EulerFormulaHolds());
-	assume(p.FacesAreNondegeneratePlanar());
-	assume(p.IsConvex());
+	mgl_assume(p.IsClosed());
+	mgl_assume(p.FaceIndicesValid());
+	mgl_assume(p.EulerFormulaHolds());
+	mgl_assume(p.FacesAreNondegeneratePlanar());
+	mgl_assume(p.IsConvex());
 
 #ifndef NDEBUG
 //	for(int i = 0; i < numPoints; ++i)
-//		assume1(p.ContainsConvex(pointArray[i]), p.Distance(pointArray[i]));
+//		mgl_assume1(p.ContainsConvex(pointArray[i]), p.Distance(pointArray[i]));
 
 #ifdef MATH_VEC_IS_FLOAT4
 	for(size_t i = 0; i < p.v.size(); ++i)
-		assume1(p.v[i].w == 1.f && vec(p.v[i]).IsFinite(), vec(p.v[i]));
+		mgl_assume1(p.v[i].w == 1.f && vec(p.v[i]).IsFinite(), vec(p.v[i]));
 #endif
 #endif
 
@@ -2246,10 +2246,10 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 	{
 		p.MergeConvex(pointArray[*iter]);
 
-//		assert(p.FaceIndicesValid());
-//		assert(p.IsClosed());
-//		assert(p.FacesAreNondegeneratePlanar());
-//		assert(p.IsConvex());
+//		mgl_assert(p.FaceIndicesValid());
+//		mgl_assert(p.IsClosed());
+//		mgl_assert(p.FacesAreNondegeneratePlanar());
+//		mgl_assert(p.IsConvex());
 	}
 
 	// Merge all the rest of the points.
@@ -2259,18 +2259,18 @@ Polyhedron Polyhedron::ConvexHull(const vec *pointArray, int numPoints, LCG &rng
 			continue; // The extreme points have already been merged.
 		p.MergeConvex(pointArray[j]);
 
-//		assert(p.FaceIndicesValid());
-//		assert(p.IsClosed());
+//		mgl_assert(p.FaceIndicesValid());
+//		mgl_assert(p.IsClosed());
 //		mathassert(p.FacesAreNondegeneratePlanar());
-//		assert(p.IsConvex());
+//		mgl_assert(p.IsConvex());
 
 //		if (p.f.size() > 5000)
 //			break;
 	}
 
-//	assert(p.FaceIndicesValid());
-//	assert(p.IsClosed());
-//	assert(p.IsConvex());
+//	mgl_assert(p.FaceIndicesValid());
+//	mgl_assert(p.IsClosed());
+//	mgl_assert(p.IsConvex());
 	p.RemoveRedundantVertices();
 	return p;
 #endif
@@ -2302,12 +2302,12 @@ Polyhedron Polyhedron::Tetrahedron(const vec &centerPos, float scale, bool ccwIs
 		p.f.push_back(f);
 	}
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	if (!ccwIsFrontFacing)
 		p.FlipWindingOrder();
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	return p;
 }
@@ -2347,12 +2347,12 @@ Polyhedron Polyhedron::Octahedron(const vec &centerPos, float scale, bool ccwIsF
 		p.f.push_back(f);
 	}
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	if (!ccwIsFrontFacing)
 		p.FlipWindingOrder();
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	return p;
 }
@@ -2365,12 +2365,12 @@ Polyhedron Polyhedron::Hexahedron(const vec &centerPos, float scale, bool ccwIsF
 	aabb.Translate(centerPos);
 	Polyhedron p = aabb.ToPolyhedron();
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	if (ccwIsFrontFacing)
 		p.FlipWindingOrder();
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	return p;
 }
@@ -2428,12 +2428,12 @@ Polyhedron Polyhedron::Icosahedron(const vec &centerPos, float scale, bool ccwIs
 		p.f.push_back(f);
 	}
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	if (!ccwIsFrontFacing)
 		p.FlipWindingOrder();
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	return p;
 }
@@ -2493,12 +2493,12 @@ Polyhedron Polyhedron::Dodecahedron(const vec &centerPos, float scale, bool ccwI
 		p.f.push_back(f);
 	}
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	if (!ccwIsFrontFacing)
 		p.FlipWindingOrder();
 
-	assume(p.Contains(centerPos));
+	mgl_assume(p.Contains(centerPos));
 
 	return p;
 }
@@ -2683,7 +2683,7 @@ void Polyhedron::RemoveRedundantVertices()
 		{
 			int oldIndex = f[i].v[j];
 			int newIndex = ArrayBinarySearch(&usedVerticesArray[0], (int)usedVerticesArray.size(), oldIndex, IntTriCmp);
-			assert(newIndex != -1);
+			mgl_assert(newIndex != -1);
 			f[i].v[j] = newIndex;
 		}
 
@@ -2692,7 +2692,7 @@ void Polyhedron::RemoveRedundantVertices()
 		v[i] = v[usedVerticesArray[i]];
 	v.resize(usedVerticesArray.size());
 	
-	assert(FaceIndicesValid());
+	mgl_assert(FaceIndicesValid());
 }
 
 void PolyExtremeVertexOnFace(const Polyhedron &poly, int face, const cv &dir, cs &outMin, cs &outMax)
@@ -2946,7 +2946,7 @@ int Polyhedron::MergeAdjacentPlanarFaces(bool snapVerticesToMergedPlanes, bool c
 						{
 							std::vector<int> v2 = nghb.v;
 							std::sort(v2.begin(), v2.end());
-							assert(std::unique(v2.begin(), v2.end()) == v2.end());
+							mgl_assert(std::unique(v2.begin(), v2.end()) == v2.end());
 						}
 #endif
 */
@@ -2962,7 +2962,7 @@ int Polyhedron::MergeAdjacentPlanarFaces(bool snapVerticesToMergedPlanes, bool c
 						verticesToFaces.erase(std::make_pair(v0, v1));
 
 						f[i].v.clear();
-//						assert(IsClosed());
+//						mgl_assert(IsClosed());
 						break;
 					}
 				}
@@ -2973,8 +2973,8 @@ int Polyhedron::MergeAdjacentPlanarFaces(bool snapVerticesToMergedPlanes, bool c
 #endif
 	RemoveDegenerateFaces();
 	RemoveRedundantVertices();
-	assume(IsClosed());
-	assume(IsConvex());
+	mgl_assume(IsClosed());
+	mgl_assume(IsConvex());
 
 #if 0
 	for(size_t i = 0; i < f.size(); ++i)

--- a/src/Geometry/QuadTree.inl
+++ b/src/Geometry/QuadTree.inl
@@ -1,4 +1,4 @@
-/* Copyright Jukka Jylänki
+/* Copyright Jukka Jylï¿½nki
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
    limitations under the License. */
 
 /** @file QuadTree.inl
-	@author Jukka Jylänki
+	@author Jukka Jylï¿½nki
 	@brief Implementation for the QuadTree object. */
 #pragma once
 
@@ -29,10 +29,10 @@ void QuadTree<T>::Clear(const float2 &minXY, const float2 &maxXY)
 	boundingAABB.minPoint = minXY;
 	boundingAABB.maxPoint = maxXY;
 
-	assert(!boundingAABB.IsDegenerate());
+	mgl_assert(!boundingAABB.IsDegenerate());
 
 	rootNodeIndex = AllocateNodeGroup(0);
-	assert(Root());
+	mgl_assert(Root());
 	Node *root = Root();
 	root->center = (minXY + maxXY) * 0.5f;
 	root->radius = maxXY - root->center;
@@ -47,14 +47,14 @@ void QuadTree<T>::Add(const T &object)
 {
 	MGL_PROFILE(QuadTree_Add);
 	Node *n = Root();
-	assert(n && "Error: QuadTree has not been initialized with a root node! Call QuadTree::Clear() to initialize the root node.");
+	mgl_assert(n && "Error: QuadTree has not been initialized with a root node! Call QuadTree::Clear() to initialize the root node.");
 
-	assert(boundingAABB.IsFinite());
-	assert(!boundingAABB.IsDegenerate());
+	mgl_assert(boundingAABB.IsFinite());
+	mgl_assert(!boundingAABB.IsDegenerate());
 
 	AABB2D objectAABB = GetAABB2D(object);
-	assert(objectAABB.IsFinite());
-	assert(!objectAABB.HasNegativeVolume());
+	mgl_assert(objectAABB.IsFinite());
+	mgl_assert(!objectAABB.HasNegativeVolume());
 
 #ifdef QUADTREE_VERBOSE_LOGGING
 	++totalNumObjectsInTree;
@@ -131,10 +131,10 @@ void QuadTree<T>::Add(const T &object, Node *n)
 	for(;;)
 	{
 		// Traverse the QuadTree to decide which quad to place this object into.
-		assert(MinX(object) <= MaxX(object));
+		mgl_assert(MinX(object) <= MaxX(object));
 		float left = n->center.x - MinX(object); // If left > 0.f, then the object overlaps with the left quadrant.
 		float right = MaxX(object) - n->center.x; // If right > 0.f, then the object overlaps with the right quadrant.
-		assert(MinY(object) <= MaxY(object));
+		mgl_assert(MinY(object) <= MaxY(object));
 		float top = n->center.y - MinY(object); // If top > 0.f, then the object overlaps with the top quadrant.
 		float bottom = MaxY(object) - n->center.y; // If bottom > 0.f, then the object overlaps with the bottom quadrant.
 		float leftAndRight = Min(left, right); // If > 0.f, then the object straddles left-right halves.
@@ -165,12 +165,12 @@ void QuadTree<T>::Add(const T &object, Node *n)
 		{
 			if (top > 0.f)
 			{
-				assert(nodes[n->TopLeftChildIndex()].parent == n);
+				mgl_assert(nodes[n->TopLeftChildIndex()].parent == n);
 				n = &nodes[n->TopLeftChildIndex()];
 			}
 			else
 			{
-				assert(nodes[n->BottomLeftChildIndex()].parent == n);
+				mgl_assert(nodes[n->BottomLeftChildIndex()].parent == n);
 				n = &nodes[n->BottomLeftChildIndex()];
 			}
 		}
@@ -178,12 +178,12 @@ void QuadTree<T>::Add(const T &object, Node *n)
 		{
 			if (top > 0.f)
 			{
-				assert(nodes[n->TopRightChildIndex()].parent == n);
+				mgl_assert(nodes[n->TopRightChildIndex()].parent == n);
 				n = &nodes[n->TopRightChildIndex()];
 			}
 			else
 			{
-				assert(nodes[n->BottomRightChildIndex()].parent == n);
+				mgl_assert(nodes[n->BottomRightChildIndex()].parent == n);
 				n = &nodes[n->BottomRightChildIndex()];
 			}
 		}
@@ -232,7 +232,7 @@ int QuadTree<T>::AllocateNodeGroup(Node *parent)
 		n.center.x = parent->center.x + n.radius.x;
 	nodes.push_back(n);
 #ifdef _DEBUG
-	assert(nodes.capacity() == oldCap); // Limitation: Cannot resize the nodes vector!
+	mgl_assert(nodes.capacity() == oldCap); // Limitation: Cannot resize the nodes vector!
 #endif
 	return index;
 }
@@ -240,8 +240,8 @@ int QuadTree<T>::AllocateNodeGroup(Node *parent)
 template<typename T>
 void QuadTree<T>::SplitLeaf(Node *leaf)
 {
-	assert(leaf->IsLeaf());
-	assert(leaf->childIndex == 0xFFFFFFFF);
+	mgl_assert(leaf->IsLeaf());
+	mgl_assert(leaf->childIndex == 0xFFFFFFFF);
 
 	leaf->childIndex = AllocateNodeGroup(leaf);
 
@@ -251,10 +251,10 @@ void QuadTree<T>::SplitLeaf(Node *leaf)
 		const T &object = leaf->objects[i];
 
 		// Traverse the QuadTree to decide which quad to place this object into.
-		assert(MinX(object) <= MaxX(object));
+		mgl_assert(MinX(object) <= MaxX(object));
 		float left = leaf->center.x - MinX(object); // If left > 0.f, then the object overlaps with the left quadrant.
 		float right = MaxX(object) - leaf->center.x; // If right > 0.f, then the object overlaps with the right quadrant.
-		assert(MinY(object) <= MaxY(object));
+		mgl_assert(MinY(object) <= MaxY(object));
 		float top = leaf->center.y - MinY(object); // If top > 0.f, then the object overlaps with the top quadrant.
 		float bottom = MaxY(object) - leaf->center.y; // If bottom > 0.f, then the object overlaps with the bottom quadrant.
 		float leftAndRight = Min(left, right); // If > 0.f, then the object straddles left-right halves.
@@ -385,7 +385,7 @@ public:
 					if (aabbI.Intersects(aabbJ))
 						(*collisionCallback)(node.objects[i], n->objects[j]);
 				}
-				assert(n != n->parent);
+				mgl_assert(n != n->parent);
 				n = n->parent;
 			}
 		}
@@ -759,15 +759,15 @@ template<typename T>
 void QuadTree<T>::DebugSanityCheckNode(Node *n)
 {
 #ifdef _DEBUG
-	assert(n);
-	assert(n->parent || n == Root()); // If no parent, must be root.
-	assert(n != Root() || !n->parent); // If not root, must have a parent.
+	mgl_assert(n);
+	mgl_assert(n->parent || n == Root()); // If no parent, must be root.
+	mgl_assert(n != Root() || !n->parent); // If not root, must have a parent.
 
 	// Must have a good AABB.
 	AABB2D aabb = n->ComputeAABB();
-	assert(aabb.IsFinite());
-	assert(aabb.minPoint.x <= aabb.maxPoint.x);
-	assert(aabb.minPoint.y <= aabb.maxPoint.y);
+	mgl_assert(aabb.IsFinite());
+	mgl_assert(aabb.minPoint.x <= aabb.maxPoint.x);
+	mgl_assert(aabb.minPoint.y <= aabb.maxPoint.y);
 
 	LOGI("Node AABB: %s.", aabb.ToString().c_str());
 	// Each object in this node must be contained in this node.
@@ -775,7 +775,7 @@ void QuadTree<T>::DebugSanityCheckNode(Node *n)
 	{
 		LOGI("Object AABB: %s.", GetAABB2D(n->objects[i]).ToString().c_str());
 
-		assert(aabb.Contains(GetAABB2D(n->objects[i])));
+		mgl_assert(aabb.Contains(GetAABB2D(n->objects[i])));
 	}
 
 	// Parent <-> child links must be valid.
@@ -784,11 +784,11 @@ void QuadTree<T>::DebugSanityCheckNode(Node *n)
 		for(int i = 0; i < 4; ++i)
 		{
 			Node *child = &nodes[n->TopLeftChildIndex()+i];
-			assert(child->parent == n);
+			mgl_assert(child->parent == n);
 
 			// Must contain all its child nodes.
-			assert(aabb.Contains(child->center));
-			assert(aabb.Contains(child->ComputeAABB()));
+			mgl_assert(aabb.Contains(child->center));
+			mgl_assert(aabb.Contains(child->ComputeAABB()));
 
 			DebugSanityCheckNode(child);
 		}

--- a/src/Geometry/Ray.cpp
+++ b/src/Geometry/Ray.cpp
@@ -43,13 +43,13 @@ MATH_BEGIN_NAMESPACE
 Ray::Ray(const vec &pos_, const vec &dir_)
 :pos(pos_), dir(dir_)
 {
-	assume2(dir.IsNormalized(), dir, dir.LengthSq());
+	mgl_assume2(dir.IsNormalized(), dir, dir.LengthSq());
 }
 
 Ray::Ray(const Line &line)
 :pos(line.pos), dir(line.dir)
 {
-	assume2(dir.IsNormalized(), dir, dir.LengthSq());
+	mgl_assume2(dir.IsNormalized(), dir, dir.LengthSq());
 }
 
 Ray::Ray(const LineSegment &lineSegment)
@@ -64,7 +64,7 @@ bool Ray::IsFinite() const
 
 vec Ray::GetPoint(float d) const
 {
-	assume2(dir.IsNormalized(), dir, dir.LengthSq());
+	mgl_assume2(dir.IsNormalized(), dir, dir.LengthSq());
 	return pos + d * dir;
 }
 
@@ -378,7 +378,7 @@ StringT Ray::SerializeToString() const
 	s = SerializeFloat(dir.x, s); *s = ','; ++s;
 	s = SerializeFloat(dir.y, s); *s = ','; ++s;
 	s = SerializeFloat(dir.z, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -401,7 +401,7 @@ std::ostream &operator <<(std::ostream &o, const Ray &ray)
 
 Ray Ray::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return Ray(vec::nan, vec::nan);
 	Ray r;
@@ -417,19 +417,19 @@ Ray Ray::FromString(const char *str, const char **outEndStr)
 
 Ray operator *(const float3x3 &transform, const Ray &ray)
 {
-	assume(transform.IsInvertible());
+	mgl_assume(transform.IsInvertible());
 	return Ray(transform * ray.pos, (transform * ray.dir).Normalized());
 }
 
 Ray operator *(const float3x4 &transform, const Ray &ray)
 {
-	assume(transform.IsInvertible());
+	mgl_assume(transform.IsInvertible());
 	return Ray(transform.MulPos(ray.pos), transform.MulDir(ray.dir).Normalized());
 }
 
 Ray operator *(const float4x4 &transform, const Ray &ray)
 {
-	assume(transform.IsInvertible());
+	mgl_assume(transform.IsInvertible());
 	return Ray(transform.MulPos(ray.pos), transform.MulDir(ray.dir).Normalized());
 }
 

--- a/src/Geometry/Sphere.cpp
+++ b/src/Geometry/Sphere.cpp
@@ -80,22 +80,22 @@ void Sphere::Translate(const vec &offset)
 
 void Sphere::Transform(const float3x3 &transform)
 {
-	assume(transform.HasUniformScale());
+	mgl_assume(transform.HasUniformScale());
 	pos = transform * pos;
 	r *= transform.Col(0).Length();
 }
 
 void Sphere::Transform(const float3x4 &transform)
 {
-	assume(transform.HasUniformScale());
+	mgl_assume(transform.HasUniformScale());
 	pos = transform.MulPos(pos);
 	r *= transform.Col(0).Length();
 }
 
 void Sphere::Transform(const float4x4 &transform)
 {
-	assume(transform.HasUniformScale());
-	assume(!transform.ContainsProjection());
+	mgl_assume(transform.HasUniformScale());
+	mgl_assume(!transform.ContainsProjection());
 	pos = transform.MulPos(pos);
 	r *= transform.Col3(0).Length();
 }
@@ -140,7 +140,7 @@ float Sphere::SurfaceArea() const
 vec Sphere::ExtremePoint(const vec &direction) const
 {
 	float len = direction.Length();
-	assume(len > 0.f);
+	mgl_assume(len > 0.f);
 	return pos + direction * (r / len);
 }
 
@@ -231,7 +231,7 @@ bool Sphere::Contains(const Frustum &frustum) const
 
 bool Sphere::Contains(const Polyhedron &polyhedron) const
 {
-	assume(polyhedron.IsClosed());
+	mgl_assume(polyhedron.IsClosed());
 	for(int i = 0; i < polyhedron.NumVertices(); ++i)
 		if (!Contains(polyhedron.Vertex(i)))
 			return false;
@@ -263,7 +263,7 @@ Sphere Sphere::FastEnclosingSphere(const vec *pts, int numPoints)
 		s.SetNegativeInfinity();
 		return s;
 	}
-	assume(pts || numPoints == 0);
+	mgl_assume(pts || numPoints == 0);
 
 	// First pass: Pick the cardinal axis (X,Y or Z) which has the two most distant points.
 	int minx, maxx, miny, maxy, minz, maxz;
@@ -304,7 +304,7 @@ Sphere WelzlSphere(const vec *pts, int numPoints, vec *support, int numSupports)
 	{
 		switch(numSupports)
 		{
-		default: assert(false);
+		default: mgl_assert(false);
 		case 0: return Sphere();
 		case 1: return Sphere(support[0], 0.f);
 		case 2: return Sphere(support[0], support[1]);
@@ -468,8 +468,8 @@ bool Sphere::Intersects(const Capsule &capsule) const
 int Sphere::IntersectLine(const vec &linePos, const vec &lineDir, const vec &sphereCenter,
                           float sphereRadius, float &t1, float &t2)
 {
-	assume2(lineDir.IsNormalized(), lineDir, lineDir.LengthSq());
-	assume1(sphereRadius >= 0.f, sphereRadius);
+	mgl_assume2(lineDir.IsNormalized(), lineDir, lineDir.LengthSq());
+	mgl_assume1(sphereRadius >= 0.f, sphereRadius);
 
 	/* A line is represented explicitly by the set { linePos + t * lineDir }, where t is an arbitrary float.
 	  A sphere is represented implictly by the set of vectors that satisfy ||v - sphereCenter|| == sphereRadius.
@@ -663,11 +663,11 @@ void Sphere::Enclose(const vec &point, float epsilon)
 		pos += d * halfDist / dist;
 		r += halfDist + 1e-4f; // Use a fixed epsilon deliberately, the param is a squared epsilon, so different order of magnitude.
 #ifdef MATH_ASSERT_CORRECTNESS
-		mathassert(this->Contains(copy, epsilon));
+		mgl_mathassert(this->Contains(copy, epsilon));
 #endif
 	}
 
-	assume(this->Contains(point));
+	mgl_assume(this->Contains(point));
 }
 
 struct PointWithDistance
@@ -746,14 +746,14 @@ void Sphere::Enclose(const AABB &aabb)
 {
 	Sphere_Enclose<AABB, 8>(*this, aabb);
 
-	assume(this->Contains(aabb));
+	mgl_assume(this->Contains(aabb));
 }
 
 void Sphere::Enclose(const OBB &obb)
 {
 	Sphere_Enclose<OBB, 8>(*this, obb);
 
-	assume(this->Contains(obb));
+	mgl_assume(this->Contains(obb));
 }
 
 void Sphere::Enclose(const Sphere &sphere)
@@ -765,7 +765,7 @@ void Sphere::Enclose(const Sphere &sphere)
 	Enclose(sphere.pos + toFarthestPoint);
 	Enclose(sphere.pos - toFarthestPoint);
 
-	assume(this->Contains(sphere));
+	mgl_assume(this->Contains(sphere));
 }
 
 void Sphere::Enclose(const LineSegment &lineSegment)
@@ -784,7 +784,7 @@ void Sphere::Enclose(const LineSegment &lineSegment)
 
 void Sphere::Enclose(const vec *pointArray, int numPoints)
 {
-	assume(pointArray || numPoints == 0);
+	mgl_assume(pointArray || numPoints == 0);
 	Sphere_Enclose_pts(*this, pointArray, numPoints);
 }
 
@@ -843,11 +843,11 @@ void Sphere::ExtendRadiusToContain(const Sphere &sphere, float epsilon)
 
 int Sphere::Triangulate(vec *outPos, vec *outNormal, float2 *outUV, int numVertices, bool ccwIsFrontFacing) const
 {
-	assume(outPos);
-	assume(numVertices >= 24 && "At minimum, sphere triangulation will contain at least 8 triangles, which is 24 vertices, but fewer were specified!");
-	assume(numVertices % 3 == 0 && "Warning:: The size of output should be divisible by 3 (each triangle takes up 3 vertices!)");
+	mgl_assume(outPos);
+	mgl_assume(numVertices >= 24 && "At minimum, sphere triangulation will contain at least 8 triangles, which is 24 vertices, but fewer were specified!");
+	mgl_assume(numVertices % 3 == 0 && "Warning:: The size of output should be divisible by 3 (each triangle takes up 3 vertices!)");
 
-	assume(this->r > 0.f);
+	mgl_assume(this->r > 0.f);
 
 	if (numVertices < 24)
 		return 0;
@@ -904,7 +904,7 @@ int Sphere::Triangulate(vec *outPos, vec *outNormal, float2 *outUV, int numVerti
 		++oldEnd;
 	}
 	// Check that we really did tessellate as many new triangles as possible.
-	assert(((int)temp.size()-oldEnd)*3 <= numVertices && ((int)temp.size()-oldEnd)*3 + 9 > numVertices);
+	mgl_assert(((int)temp.size()-oldEnd)*3 <= numVertices && ((int)temp.size()-oldEnd)*3 + 9 > numVertices);
 
 	for(size_t i = oldEnd, j = 0; i < temp.size(); ++i, ++j)
 	{
@@ -934,7 +934,7 @@ int Sphere::Triangulate(vec *outPos, vec *outNormal, float2 *outUV, int numVerti
 
 vec Sphere::RandomPointInside(LCG &lcg)
 {
-	assume(r > 1e-3f);
+	mgl_assume(r > 1e-3f);
 	vec v = vec::zero;
 	// Rejection sampling analysis: The unit sphere fills ~52.4% of the volume of its enclosing box, so this
 	// loop is expected to take only very few iterations before succeeding.
@@ -946,7 +946,7 @@ vec Sphere::RandomPointInside(LCG &lcg)
 		if (v.LengthSq() <= r*r)
 			return pos + v;
 	}
-	assume(false && "Sphere::RandomPointInside failed!");
+	mgl_assume(false && "Sphere::RandomPointInside failed!");
 
 	// Failed to generate a point inside this sphere. Return the sphere center as fallback.
 	return pos;
@@ -967,7 +967,7 @@ vec Sphere::RandomPointOnSurface(LCG &lcg)
 			return pos + (r / Sqrt(lenSq)) * v;
 	}
 	// Astronomically small probability to reach here, and if we do so, the provided random number generator must have been in a bad state.
-	assume(false && "Sphere::RandomPointOnSurface failed!");
+	mgl_assume(false && "Sphere::RandomPointOnSurface failed!");
 
 	// Failed to generate a point inside this sphere. Return an arbitrary point on the surface as fallback.
 	return pos + DIR_VEC(r, 0, 0);
@@ -988,15 +988,15 @@ Sphere Sphere::OptimalEnclosingSphere(const vec &a, const vec &b)
 	Sphere s;
 	s.pos = (a + b) * 0.5f;
 	s.r = (b - s.pos).Length();
-	assume(s.pos.IsFinite());
-	assume(s.r >= 0.f);
+	mgl_assume(s.pos.IsFinite());
+	mgl_assume(s.r >= 0.f);
 
 	// Allow floating point inconsistency and expand the radius by a small epsilon so that the containment tests
 	// really contain the points (note that the points must be sufficiently near enough to the origin)
 	s.r += sEpsilon;
 
-	mathassert(s.Contains(a));
-	mathassert(s.Contains(b));
+	mgl_mathassert(s.Contains(a));
+	mgl_mathassert(s.Contains(b));
 	return s;
 }
 
@@ -1227,7 +1227,7 @@ Sphere Sphere::OptimalEnclosingSphere(const vec &a, const vec &b, const vec &c)
 		LOGE("A: %s, dist: %f", a.ToString().c_str(), a.Distance(sphere.pos));
 		LOGE("B: %s, dist: %f", b.ToString().c_str(), b.Distance(sphere.pos));
 		LOGE("C: %s, dist: %f", c.ToString().c_str(), c.Distance(sphere.pos));
-		mathassert(false);
+		mgl_mathassert(false);
 	}
 #endif
 	return sphere;
@@ -1256,7 +1256,7 @@ Sphere Sphere::OptimalEnclosingSphere(const vec &a, const vec &b, const vec &c, 
 				{
 					sphere = OptimalEnclosingSphere(b,c,d);
 					sphere.r = Max(sphere.r, a.Distance(sphere.pos) + 1e-3f); // For numerical stability, expand the radius of the sphere so it certainly contains the fourth point.
-					assume(sphere.Contains(a));
+					mgl_assume(sphere.Contains(a));
 				}
 			}
 		}
@@ -1296,7 +1296,7 @@ Sphere Sphere::OptimalEnclosingSphere(const vec &a, const vec &b, const vec &c, 
 		LOGE("B: %s, dist: %f", b.ToString().c_str(), b.Distance(sphere.pos));
 		LOGE("C: %s, dist: %f", c.ToString().c_str(), c.Distance(sphere.pos));
 		LOGE("D: %s, dist: %f", d.ToString().c_str(), d.Distance(sphere.pos));
-		mathassert(false);
+		mgl_mathassert(false);
 	}
 #endif
 
@@ -1331,7 +1331,7 @@ Sphere Sphere::OptimalEnclosingSphere(const vec &a, const vec &b, const vec &c, 
 		return s;
 	}
 	s = OptimalEnclosingSphere(a,b,c,d);
-	mathassert(s.Contains(e, sEpsilon));
+	mgl_mathassert(s.Contains(e, sEpsilon));
 	redundantPoint = 4;
 	return s;
 }
@@ -1406,7 +1406,7 @@ StringT Sphere::SerializeToString() const
 	s = SerializeFloat(pos.y, s); *s = ','; ++s;
 	s = SerializeFloat(pos.z, s); *s = ','; ++s;
 	s = SerializeFloat(r, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -1431,7 +1431,7 @@ std::ostream &operator <<(std::ostream &o, const Sphere &sphere)
 
 Sphere Sphere::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return Sphere(vec::nan, FLOAT_NAN);
 	Sphere s;

--- a/src/Geometry/Triangle.cpp
+++ b/src/Geometry/Triangle.cpp
@@ -199,8 +199,8 @@ float Triangle::Perimeter() const
 
 LineSegment Triangle::Edge(int i) const
 {
-	assume(0 <= i);
-	assume(i <= 2);
+	mgl_assume(0 <= i);
+	mgl_assume(i <= 2);
 	if (i == 0)
 		return LineSegment(a, b);
 	else if (i == 1)
@@ -213,8 +213,8 @@ LineSegment Triangle::Edge(int i) const
 
 vec Triangle::Vertex(int i) const
 {
-	assume(0 <= i);
-	assume(i <= 2);
+	mgl_assume(0 <= i);
+	mgl_assume(i <= 2);
 	if (i == 0)
 		return a;
 	else if (i == 1)
@@ -564,7 +564,7 @@ bool Triangle::Intersects(const Triangle &t2, LineSegment *outLine) const
 		// Find the intersection line of the two planes.
 		Line l;
 		bool success = p1.Intersects(p2, &l);
-		assume(success); // We already determined the two triangles have intersecting planes, so this should always succeed.
+		mgl_assume(success); // We already determined the two triangles have intersecting planes, so this should always succeed.
 		if (!success)
 			return false;
 
@@ -1018,7 +1018,7 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 	bool intersects = (t >= 0.0f && t <= 1.0f);
 	if (intersects)
 	{
-//		assume3(lineSegment.GetPoint(t).Equals(this->Point(u, v)), lineSegment.GetPoint(t).SerializeToCodeString(), this->Point(u, v).SerializeToCodeString(), lineSegment.GetPoint(t).Distance(this->Point(u, v)));
+//		mgl_assume3(lineSegment.GetPoint(t).Equals(this->Point(u, v)), lineSegment.GetPoint(t).SerializeToCodeString(), this->Point(u, v).SerializeToCodeString(), lineSegment.GetPoint(t).Distance(this->Point(u, v)));
 		if (otherPt)
 			*otherPt = lineSegment.GetPoint(t);
 		return this->Point(u, v);
@@ -1150,7 +1150,7 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 		{
 			// Clamp to t == 0 and solve for v.
 			v = B[1] / m[1][1];
-//			mathassert(EqualAbs(v, Clamp01(v)));
+//			mgl_mathassert(EqualAbs(v, Clamp01(v)));
 			v = Clamp01(v); // The solution for v must also be in the range [0,1]. TODO: Is this guaranteed by the above?
 			// The solution is (u,v,t)=(0,v,0).
 			if (otherPt)
@@ -1161,7 +1161,7 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 		{
 			// Clamp to t == 1 and solve for v.
 			v = (B[1] - m[1][2]) / m[1][1];
-//			mathassert(EqualAbs(v, Clamp01(v)));
+//			mgl_mathassert(EqualAbs(v, Clamp01(v)));
 			v = Clamp01(v); // The solution for v must also be in the range [0,1]. TODO: Is this guaranteed by the above?
 			// The solution is (u,v,t)=(0,v,1).
 			if (otherPt)
@@ -1213,7 +1213,7 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 		{
 			// Clamp to t == 0 and solve for u.
 			u = B[0] / m[0][0];
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 			u = Clamp01(u); // The solution for u must also be in the range [0,1].
 			if (otherPt)
 				*otherPt = lineSegment.a;
@@ -1223,7 +1223,7 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 		{
 			// Clamp to t == 1 and solve for u.
 			u = (B[0] - m[0][2]) / m[0][0];
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 			u = Clamp01(u); // The solution for u must also be in the range [0,1].
 			if (otherPt)
 				*otherPt = lineSegment.b;
@@ -1269,7 +1269,7 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 		{
 			// Set v = 1-u and solve again.
 //			u = (B[0] - m[0][0]) / (m[0][0] - m[0][1]);
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 //			u = Clamp01(u); // The solution for u must also be in the range [0,1].
 //			return a + u*e0;
 
@@ -1343,7 +1343,7 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 			u = (B[0] - m[0][1] - m[0][2]) / (m[0][0] - m[0][1]);
 //			u = Dot(a + e1 + lineSegment.b, e1 - e0) / Dot(e0-e1, e0-e1);
 
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 			u = Clamp01(u);
 			return a + u*e0 + (1-u)*e1;
 		}
@@ -1382,8 +1382,8 @@ vec Triangle::ClosestPoint(const LineSegment &lineSegment, vec *otherPt) const
 			// The solution is (u,v,t)=(1,0,t)
 			return b;
 		}
-		mathassert(t >= 0.f);
-		mathassert(t <= 1.f);
+		mgl_mathassert(t >= 0.f);
+		mgl_mathassert(t <= 1.f);
 		return a + u*e0 + (1.f-u)*e1;
 	}
 	else // All parameters are within range, so the triangle and the line segment intersect, and the intersection point is the closest point.
@@ -1888,14 +1888,14 @@ vec Triangle::RandomPointInside(LCG &rng) const
 #ifdef MATH_ASSERT_CORRECTNESS
 	vec pt = Point(s, t);
 	float2 uv = BarycentricUV(pt);
-	assert1(uv.x >= 0.f, uv.x);
-	assert1(uv.y >= 0.f, uv.y);
-	assert3(uv.x + uv.y <= 1.f, uv.x, uv.y, uv.x + uv.y);
+	mgl_assert1(uv.x >= 0.f, uv.x);
+	mgl_assert1(uv.y >= 0.f, uv.y);
+	mgl_assert3(uv.x + uv.y <= 1.f, uv.x, uv.y, uv.x + uv.y);
 	float3 uvw = BarycentricUVW(pt);
-	assert1(uvw.x >= 0.f, uvw.x);
-	assert1(uvw.y >= 0.f, uvw.y);
-	assert1(uvw.z >= 0.f, uvw.z);
-	assert4(EqualAbs(uvw.x + uvw.y + uvw.z, 1.f), uvw.x, uvw.y, uvw.z, uvw.x + uvw.y + uvw.z);
+	mgl_assert1(uvw.x >= 0.f, uvw.x);
+	mgl_assert1(uvw.y >= 0.f, uvw.y);
+	mgl_assert1(uvw.z >= 0.f, uvw.z);
+	mgl_assert4(EqualAbs(uvw.x + uvw.y + uvw.z, 1.f), uvw.x, uvw.y, uvw.z, uvw.x + uvw.y + uvw.z);
 #endif
 	return Point(s, t);
 }
@@ -1907,7 +1907,7 @@ vec Triangle::RandomVertex(LCG &rng) const
 
 vec Triangle::RandomPointOnEdge(LCG &rng) const
 {
-	assume(!IsDegenerate());
+	mgl_assume(!IsDegenerate());
 	float ab = a.Distance(b);
 	float bc = b.Distance(c);
 	float ca = c.Distance(a);
@@ -1970,7 +1970,7 @@ StringT Triangle::SerializeToString() const
 	s = SerializeFloat(c.x, s); *s = ','; ++s;
 	s = SerializeFloat(c.y, s); *s = ','; ++s;
 	s = SerializeFloat(c.z, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -1993,7 +1993,7 @@ std::ostream &operator <<(std::ostream &o, const Triangle &triangle)
 
 Triangle Triangle::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return Triangle(vec::nan, vec::nan, vec::nan);
 	Triangle t;

--- a/src/Geometry/Triangle2D.cpp
+++ b/src/Geometry/Triangle2D.cpp
@@ -153,8 +153,8 @@ float Triangle2D::Perimeter() const
 
 LineSegment2D Triangle2D::Edge(int i) const
 {
-	assume(0 <= i);
-	assume(i <= 2);
+	mgl_assume(0 <= i);
+	mgl_assume(i <= 2);
 	if (i == 0)
 		return LineSegment2D(a, b);
 	else if (i == 1)
@@ -167,8 +167,8 @@ LineSegment2D Triangle2D::Edge(int i) const
 
 vec2d Triangle2D::Vertex(int i) const
 {
-	assume(0 <= i);
-	assume(i <= 2);
+	mgl_assume(0 <= i);
+	mgl_assume(i <= 2);
 	if (i == 0)
 		return a;
 	else if (i == 1)
@@ -767,7 +767,7 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 	bool intersects = (t >= 0.0f && t <= 1.0f);
 	if (intersects)
 	{
-//		assume3(lineSegment.GetPoint(t).Equals(this->Point(u, v)), lineSegment.GetPoint(t).SerializeToCodeString(), this->Point(u, v).SerializeToCodeString(), lineSegment.GetPoint(t).Distance(this->Point(u, v)));
+//		mgl_assume3(lineSegment.GetPoint(t).Equals(this->Point(u, v)), lineSegment.GetPoint(t).SerializeToCodeString(), this->Point(u, v).SerializeToCodeString(), lineSegment.GetPoint(t).Distance(this->Point(u, v)));
 		if (otherPt)
 			*otherPt = lineSegment.GetPoint(t);
 		return this->Point(u, v);
@@ -899,7 +899,7 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 		{
 			// Clamp to t == 0 and solve for v.
 			v = B[1] / m[1][1];
-//			mathassert(EqualAbs(v, Clamp01(v)));
+//			mgl_mathassert(EqualAbs(v, Clamp01(v)));
 			v = Clamp01(v); // The solution for v must also be in the range [0,1]. TODO: Is this guaranteed by the above?
 			// The solution is (u,v,t)=(0,v,0).
 			if (otherPt)
@@ -910,7 +910,7 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 		{
 			// Clamp to t == 1 and solve for v.
 			v = (B[1] - m[1][2]) / m[1][1];
-//			mathassert(EqualAbs(v, Clamp01(v)));
+//			mgl_mathassert(EqualAbs(v, Clamp01(v)));
 			v = Clamp01(v); // The solution for v must also be in the range [0,1]. TODO: Is this guaranteed by the above?
 			// The solution is (u,v,t)=(0,v,1).
 			if (otherPt)
@@ -962,7 +962,7 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 		{
 			// Clamp to t == 0 and solve for u.
 			u = B[0] / m[0][0];
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 			u = Clamp01(u); // The solution for u must also be in the range [0,1].
 			if (otherPt)
 				*otherPt = lineSegment.a;
@@ -972,7 +972,7 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 		{
 			// Clamp to t == 1 and solve for u.
 			u = (B[0] - m[0][2]) / m[0][0];
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 			u = Clamp01(u); // The solution for u must also be in the range [0,1].
 			if (otherPt)
 				*otherPt = lineSegment.b;
@@ -1018,7 +1018,7 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 		{
 			// Set v = 1-u and solve again.
 //			u = (B[0] - m[0][0]) / (m[0][0] - m[0][1]);
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 //			u = Clamp01(u); // The solution for u must also be in the range [0,1].
 //			return a + u*e0;
 
@@ -1092,7 +1092,7 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 			u = (B[0] - m[0][1] - m[0][2]) / (m[0][0] - m[0][1]);
 //			u = Dot(a + e1 + lineSegment.b, e1 - e0) / Dot(e0-e1, e0-e1);
 
-//			mathassert(EqualAbs(u, Clamp01(u)));
+//			mgl_mathassert(EqualAbs(u, Clamp01(u)));
 			u = Clamp01(u);
 			return a + u*e0 + (1-u)*e1;
 		}
@@ -1131,8 +1131,8 @@ vec2d Triangle2D::ClosestPoint(const LineSegment2D &lineSegment, vec2d *otherPt)
 			// The solution is (u,v,t)=(1,0,t)
 			return b;
 		}
-		mathassert(t >= 0.f);
-		mathassert(t <= 1.f);
+		mgl_mathassert(t >= 0.f);
+		mgl_mathassert(t <= 1.f);
 		return a + u*e0 + (1.f-u)*e1;
 	}
 	else // All parameters are within range, so the triangle and the line segment intersect, and the intersection point is the closest point.
@@ -1638,14 +1638,14 @@ vec2d Triangle2D::RandomPointInside(LCG &rng) const
 #ifdef MATH_ASSERT_CORRECTNESS
 	vec2d pt = Point(s, t);
 	float2 uv = BarycentricUV(pt);
-	assert1(uv.x >= 0.f, uv.x);
-	assert1(uv.y >= 0.f, uv.y);
-	assert3(uv.x + uv.y <= 1.f, uv.x, uv.y, uv.x + uv.y);
+	mgl_assert1(uv.x >= 0.f, uv.x);
+	mgl_assert1(uv.y >= 0.f, uv.y);
+	mgl_assert3(uv.x + uv.y <= 1.f, uv.x, uv.y, uv.x + uv.y);
 	float3 uvw = BarycentricUVW(pt);
-	assert1(uvw.x >= 0.f, uvw.x);
-	assert1(uvw.y >= 0.f, uvw.y);
-	assert1(uvw.z >= 0.f, uvw.z);
-	assert4(EqualAbs(uvw.x + uvw.y + uvw.z, 1.f), uvw.x, uvw.y, uvw.z, uvw.x + uvw.y + uvw.z);
+	mgl_assert1(uvw.x >= 0.f, uvw.x);
+	mgl_assert1(uvw.y >= 0.f, uvw.y);
+	mgl_assert1(uvw.z >= 0.f, uvw.z);
+	mgl_assert4(EqualAbs(uvw.x + uvw.y + uvw.z, 1.f), uvw.x, uvw.y, uvw.z, uvw.x + uvw.y + uvw.z);
 #endif
 	return Point(s, t);
 }
@@ -1657,7 +1657,7 @@ vec2d Triangle2D::RandomVertex(LCG &rng) const
 
 vec2d Triangle2D::RandomPointOnEdge(LCG &rng) const
 {
-	assume(!IsDegenerate());
+	mgl_assume(!IsDegenerate());
 	float ab = a.Distance(b);
 	float bc = b.Distance(c);
 	float ca = c.Distance(a);
@@ -1710,7 +1710,7 @@ StringT Triangle2D::SerializeToString() const
 	s = SerializeFloat(b.y, s); *s = ','; ++s;
 	s = SerializeFloat(c.x, s); *s = ','; ++s;
 	s = SerializeFloat(c.y, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -1733,7 +1733,7 @@ std::ostream &operator <<(std::ostream &o, const Triangle2D &triangle)
 
 Triangle2D Triangle2D::FromString(const char *str, const char **outEndStr)
 {
-	assume(str);
+	mgl_assume(str);
 	if (!str)
 		return Triangle2D(vec2d::nan, vec2d::nan, vec2d::nan);
 	Triangle2D t;

--- a/src/Geometry/TriangleMesh.cpp
+++ b/src/Geometry/TriangleMesh.cpp
@@ -316,10 +316,10 @@ void TriangleMesh::SetSoA4(const float *vertexData, int numTris, int vtxSizeByte
 	vertexDataLayout = 1; // SoA4
 #endif
 
-	assert(vtxSizeBytes % 4 == 0);
+	mgl_assert(vtxSizeBytes % 4 == 0);
 	int vertexSizeFloats = vtxSizeBytes / 4;
 	int triangleSizeFloats = vertexSizeFloats * 3;
-	assert(numTris % 4 == 0); // We must have an evenly divisible amount of triangles, so that the SoA swizzling succeeds.
+	mgl_assert(numTris % 4 == 0); // We must have an evenly divisible amount of triangles, so that the SoA swizzling succeeds.
 
 	// From (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz)
 	// To xxxx yyyy zzzz xxxx yyyy zzzz xxxx yyyy zzzz
@@ -363,10 +363,10 @@ void TriangleMesh::SetSoA8(const float *vertexData, int numTris, int vtxSizeByte
 	vertexDataLayout = 2; // SoA8
 #endif
 
-	assert(vtxSizeBytes % 4 == 0);
+	mgl_assert(vtxSizeBytes % 4 == 0);
 	int vertexSizeFloats = vtxSizeBytes / 4;
 	int triangleSizeFloats = vertexSizeFloats * 3;
-	assert(numTris % 8 == 0); // We must have an evenly divisible amount of triangles, so that the SoA swizzling succeeds.
+	mgl_assert(numTris % 8 == 0); // We must have an evenly divisible amount of triangles, so that the SoA swizzling succeeds.
 
 	// From (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz) (xyz xyz xyz)
 	// To xxxxxxxx yyyyyyyy zzzzzzzz xxxxxxxx yyyyyyyy zzzzzzzz xxxxxxxx yyyyyyyy zzzzzzzz
@@ -409,10 +409,10 @@ void TriangleMesh::SetSoA8(const float *vertexData, int numTris, int vtxSizeByte
 
 float TriangleMesh::IntersectRay_TriangleIndex_UV_CPP(const Ray &ray, int &outTriangleIndex, float &outU, float &outV) const
 {
-	assert(sizeof(float3) == 3*sizeof(float));
-	assert(sizeof(Triangle) == 3*sizeof(vec));
+	mgl_assert(sizeof(float3) == 3*sizeof(float));
+	mgl_assert(sizeof(Triangle) == 3*sizeof(vec));
 #ifdef _DEBUG
-	assert(vertexDataLayout == 0); // Must be AoS structured!
+	mgl_assert(vertexDataLayout == 0); // Must be AoS structured!
 #endif
 
 	float nearestD = FLOAT_INF;

--- a/src/Geometry/TriangleMesh_IntersectRay_AVX.inl
+++ b/src/Geometry/TriangleMesh_IntersectRay_AVX.inl
@@ -1,4 +1,4 @@
-/* Copyright Jukka Jylänki
+/* Copyright Jukka Jylï¿½nki
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
    limitations under the License. */
 
 /** @file TriangleMesh_IntersectRay_AVX.inl
-	@author Jukka Jylänki
+	@author Jukka Jylï¿½nki
 	@brief AVX implementation of ray-mesh intersection routines. */
 
 #include "../Math/SSEMath.h"
@@ -31,10 +31,10 @@ float TriangleMesh::IntersectRay_TriangleIndex_UV_AVX(const Ray &ray, int &outTr
 //	std::cout << numTris << " tris: ";
 //	TRACESTART(RayTriMeshIntersectAVX);
 
-	assert(sizeof(float3) == 3*sizeof(float));
-	assert(sizeof(Triangle) == 3*sizeof(vec));
+	mgl_assert(sizeof(float3) == 3*sizeof(float));
+	mgl_assert(sizeof(Triangle) == 3*sizeof(vec));
 #ifdef _DEBUG
-	assert(vertexDataLayout == 2); // Must be SoA8 structured!
+	mgl_assert(vertexDataLayout == 2); // Must be SoA8 structured!
 #endif
 
 //	hitTriangleIndex = -1;
@@ -60,7 +60,7 @@ float TriangleMesh::IntersectRay_TriangleIndex_UV_AVX(const Ray &ray, int &outTr
 	const __m256 zero = _mm256_setzero_ps();
 	const __m256 one = _mm256_set1_ps(1.f);
 
-	assert(((uintptr_t)data & 0x1F) == 0);
+	mgl_assert(((uintptr_t)data & 0x1F) == 0);
 
 	const float *tris = reinterpret_cast<const float*>(data);
 

--- a/src/Geometry/TriangleMesh_IntersectRay_SSE.inl
+++ b/src/Geometry/TriangleMesh_IntersectRay_SSE.inl
@@ -1,4 +1,4 @@
-/* Copyright Jukka Jylänki
+/* Copyright Jukka Jylï¿½nki
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
    limitations under the License. */
 
 /** @file TriangleMesh_IntersectRay_SSE.inl
-	@author Jukka Jylänki
+	@author Jukka Jylï¿½nki
 	@brief SSE implementation of ray-mesh intersection routines. */
 MATH_BEGIN_NAMESPACE
 
@@ -34,12 +34,12 @@ float TriangleMesh::IntersectRay_TriangleIndex_UV_SSE41(const Ray &ray, int &out
 //	std::cout << numTris << " tris: ";
 //	TRACESTART(RayTriMeshIntersectSSE);
 
-	assert(sizeof(float3) == 3*sizeof(float));
-	assert(sizeof(Triangle) == 3*sizeof(float3));
+	mgl_assert(sizeof(float3) == 3*sizeof(float));
+	mgl_assert(sizeof(Triangle) == 3*sizeof(float3));
 #ifdef _DEBUG
-	assert(vertexDataLayout == 1); // Must be SoA4 structured!
+	mgl_assert(vertexDataLayout == 1); // Must be SoA4 structured!
 #endif
-	
+
 	__m128 nearestD = _mm_set1_ps(inf);
 #ifdef MATH_GEN_UV
 	__m128 nearestU = _mm_set1_ps(inf);
@@ -63,7 +63,7 @@ float TriangleMesh::IntersectRay_TriangleIndex_UV_SSE41(const Ray &ray, int &out
 
     const __m128 sign_mask = _mm_set1_ps(-0.f); // -0.f = 1 << 31
 
-	assert(((uintptr_t)data & 0xF) == 0);
+	mgl_assert(((uintptr_t)data & 0xF) == 0);
 
 	const float *tris = reinterpret_cast<const float*>(data);
 
@@ -234,7 +234,7 @@ float TriangleMesh::IntersectRay_TriangleIndex_UV_SSE41(const Ray &ray, int &out
 //	static double avgtimes = 0.f;
 //	static double nAvgTimes = 0;
 //	static double processedBytes;
-	
+
 //	processedBytes += numTris * 3 * 4;
 
 //	avgtimes += Clock::TicksToMillisecondsD(time_RayTriMeshIntersectSSE);

--- a/src/Math/BitOps.h
+++ b/src/Math/BitOps.h
@@ -88,7 +88,7 @@ public:
 	LSB(32) and above are undefined. */
 inline u32 LSB(u32 bits)
 {
-	assert(bits <= 32);
+	mgl_assert(bits <= 32);
 	if (bits >= 32)
 		return 0xFFFFFFFFU;
 	return (1U << bits) - 1;
@@ -96,7 +96,7 @@ inline u32 LSB(u32 bits)
 
 inline u64 LSB64(u64 bits)
 {
-	assert(bits <= 64);
+	mgl_assert(bits <= 64);
 	if (bits >= 64)
 		return 0xFFFFFFFFFFFFFFFFULL;
 	return (1ULL << bits) - 1;

--- a/src/Math/FixedPoint.h
+++ b/src/Math/FixedPoint.h
@@ -66,7 +66,7 @@ public:
 	FixedPoint(const BaseT &whole, const BaseT &nomin, const BaseT &denom)
 	:value((whole << FracBits) + (nomin << FracBits) / denom)
 	{
-		assert(denom != 0);
+		mgl_assert(denom != 0);
 	}
 
 	operator double() const

--- a/src/Math/Interpolate.h
+++ b/src/Math/Interpolate.h
@@ -28,27 +28,27 @@ MATH_BEGIN_NAMESPACE
 // Sometimes also referred to as EaseIn or EaseInQuad.
 inline float SmoothStart(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   return t*t;
 }
 
 // Like SmoothStart, but even smoother start (and sharper stop)
 inline float SmoothStart3(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   return t*t*t;
 }
 
 inline float SmoothStart4(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   float tt = t*t;
   return tt*tt;
 }
 
 inline float SmoothStart5(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   float tt = t*t;
   return tt*tt*t;
 }
@@ -56,21 +56,21 @@ inline float SmoothStart5(float t)
 // Starts sharply at (0,0), but stops smoothly to (1,1). I.e. reverse of SmoothStart2.
 inline float SmoothStop(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   float oneT = 1.f - t;
   return 1.f - oneT*oneT;
 }
 
 inline float SmoothStop3(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   float oneT = 1.f - t;
   return 1.f - oneT*oneT*oneT;
 }
 
 inline float SmoothStop4(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   float oneT = 1.f - t;
   oneT *= oneT;
   return 1.f - oneT*oneT;
@@ -78,7 +78,7 @@ inline float SmoothStop4(float t)
 
 inline float SmoothStop5(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   float oneT = 1.f - t;
   float oneT2 = oneT * oneT;
   return 1.f - oneT2*oneT2*oneT;
@@ -87,7 +87,7 @@ inline float SmoothStop5(float t)
 // Starts out as SmoothStop, and linearly blends to SmoothStart
 inline float SharpStep(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   //   t * t^2 + (1-t)*(1 - (1-t)^2)
   // = 2t^3 - 3t^2 + 2t
   // = t(2t^2 + 2 - 3t)
@@ -99,7 +99,7 @@ inline float SharpStep(float t)
 // Also called "cubic Hermite interpolation"
 inline float SmoothStep(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   //   (1-t) * SmoothStart(t) + t * SmoothStop(t)
   // = (1-t) * t^2 + t*(1 - (1-t)^2)
   // = 3t^2 - 2t^3
@@ -124,7 +124,7 @@ inline float SmoothStep(float t)
 
 inline float SmoothStep5(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   // 6t^5 -15t^4 + 10t^3
   float tt = t*t;
   return tt*t*(6.f*tt - 15.f*t + 10.f);
@@ -132,7 +132,7 @@ inline float SmoothStep5(float t)
 
 inline float SmoothStep7(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   // -20t^7 + 70t^6 - 84t^5 + 35t^4
   float tt = t*t;
   float tttt = tt*tt;
@@ -141,7 +141,7 @@ inline float SmoothStep7(float t)
 
 inline float CosineStep01(float t)
 {
-  assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
+  mgl_assume1(t >= 0.f && t <= 1.f, t); // Input should be pre-clamped for performance (combine with Clamp01() from MathFunc.h)
   return 0.5f - Cos(t*pi) * 0.5f;
 }
 

--- a/src/Math/MathFunc.cpp
+++ b/src/Math/MathFunc.cpp
@@ -336,7 +336,7 @@ bool IsPow2(u64 number)
 
 u32 RoundUpPow2(u32 x)
 {
-	assert(sizeof(u32) == 4);
+	mgl_assert(sizeof(u32) == 4);
 	--x;
 	x |= x >> 1;
 	x |= x >> 2;
@@ -350,7 +350,7 @@ u32 RoundUpPow2(u32 x)
 
 u64 RoundUpPow2(u64 x)
 {
-	assert(sizeof(u64) == 8);
+	mgl_assert(sizeof(u64) == 8);
 	--x;
 	x |= x >> 1;
 	x |= x >> 2;
@@ -365,7 +365,7 @@ u64 RoundUpPow2(u64 x)
 
 u32 RoundDownPow2(u32 x)
 {
-	assert(sizeof(u32) == 4);
+	mgl_assert(sizeof(u32) == 4);
 	x |= x >> 1;
 	x |= x >> 2;
 	x |= x >> 4;
@@ -376,7 +376,7 @@ u32 RoundDownPow2(u32 x)
 
 u64 RoundDownPow2(u64 x)
 {
-	assert(sizeof(u64) == 8);
+	mgl_assert(sizeof(u64) == 8);
 	x |= x >> 1;
 	x |= x >> 2;
 	x |= x >> 4;
@@ -388,13 +388,13 @@ u64 RoundDownPow2(u64 x)
 
 int RoundIntUpToMultipleOfPow2(int x, int n)
 {
-	assert(IsPow2(n));
+	mgl_assert(IsPow2(n));
 	return (x + n-1) & ~(n-1);
 }
 
 s64 RoundIntUpToMultipleOfPow2(s64 x, s64 n)
 {
-	assert(IsPow2(n));
+	mgl_assert(IsPow2(n));
 	return (x + n-1) & ~(n-1);
 }
 
@@ -490,7 +490,7 @@ float LerpMod(float a, float b, float mod, float t)
 
 float InvLerp(float a, float b, float x)
 {
-	assume(Abs(b-a) > 1e-5f);
+	mgl_assume(Abs(b-a) > 1e-5f);
 	return (x - a) / (b - a);
 }
 
@@ -688,7 +688,7 @@ float DeserializeFloat(const char *str, const char **outEndStr)
 
 int hexstr_to_u64(const char *str, uint64_t *u)
 {
-	assert(u);
+	mgl_assert(u);
 	*u = 0;
 	const char *s = str;
 	for(int i = 0; i <= 16; ++i)

--- a/src/Math/MathFunc.h
+++ b/src/Math/MathFunc.h
@@ -1,4 +1,4 @@
-/* Copyright Jukka Jylänki
+/* Copyright Jukka Jylï¿½nki
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
    limitations under the License. */
 
 /** @file MathFunc.h
-	@author Jukka Jylänki
+	@author Jukka Jylï¿½nki
 	@brief Common mathematical functions. */
 #pragma once
 
@@ -98,22 +98,22 @@ float Tanh(float x);
 	@see RoundUpPow2(), RoundDownPow2(). */
 bool IsPow2(u32 number);
 bool IsPow2(u64 number);
-FORCE_INLINE bool IsPow2(s32 number) { assert(number >= 0); return IsPow2((u32)number); }
-FORCE_INLINE bool IsPow2(s64 number) { assert(number >= 0); return IsPow2((u64)number); }
+FORCE_INLINE bool IsPow2(s32 number) { mgl_assert(number >= 0); return IsPow2((u32)number); }
+FORCE_INLINE bool IsPow2(s64 number) { mgl_assert(number >= 0); return IsPow2((u64)number); }
 /// Returns the smallest power-of-2 number (1,2,4,8,16,32,...) greater or equal than the given number.
 /** @note RoundUpPow2(0) == 0. Also, note that RoundUpPow2(x) == 0 if x >= 0x80000001 for the u32 version, or if x >= 0x8000000000000001 for the u64 version.
 	@see IsPow2(), RoundDownPow2(). */
 u32 RoundUpPow2(u32 number);
 u64 RoundUpPow2(u64 number);
-FORCE_INLINE s32 RoundUpPow2(s32 number) { assert(number >= 0); return (int /*s32*/)RoundUpPow2((u32)number); }
-FORCE_INLINE s64 RoundUpPow2(s64 number) { assert(number >= 0); return (s64)RoundUpPow2((u64)number); }
+FORCE_INLINE s32 RoundUpPow2(s32 number) { mgl_assert(number >= 0); return (int /*s32*/)RoundUpPow2((u32)number); }
+FORCE_INLINE s64 RoundUpPow2(s64 number) { mgl_assert(number >= 0); return (s64)RoundUpPow2((u64)number); }
 /// Returns the largest power-of-2 number (1,2,4,8,16,32,...) smaller or equal than the given number.
 /** @note RoundDownPow2(0) == 0.
 	@see IsPow2(), RoundUpPow2(). */
 u32 RoundDownPow2(u32 number);
 u64 RoundDownPow2(u64 number);
-FORCE_INLINE s32 RoundDownPow2(s32 number) { assert(number >= 0); return (int /*s32*/)RoundDownPow2((u32)number); }
-FORCE_INLINE s64 RoundDownPow2(s64 number) { assert(number >= 0); return (s64)RoundDownPow2((u64)number); }
+FORCE_INLINE s32 RoundDownPow2(s32 number) { mgl_assert(number >= 0); return (int /*s32*/)RoundDownPow2((u32)number); }
+FORCE_INLINE s64 RoundDownPow2(s64 number) { mgl_assert(number >= 0); return (s64)RoundDownPow2((u64)number); }
 
 /// Returns the given number rounded up to the next multiple of n.
 /** @param x The number to round up.
@@ -256,7 +256,7 @@ FORCE_INLINE float RSqrt(float x)
 	// e_n = e + 0.5 * (e - x * e^3)
 	simd4f e3 = _mm_mul_ss(_mm_mul_ss(e,e), e);
 	simd4f half = _mm_set_ss(0.5f);
-	
+
 	return s4f_x(_mm_add_ss(e, _mm_mul_ss(half, _mm_sub_ss(e, _mm_mul_ss(X, e3)))));
 #else
 	return 1.f / sqrtf(x);
@@ -328,7 +328,7 @@ int CombinatorialTab(int n, int k);
 template<typename T>
 FORCE_INLINE T Clamp(const T &val, const T &floor, const T &ceil)
 {
-	assume(floor <= ceil);
+	mgl_assume(floor <= ceil);
 	return val <= ceil ? (val >= floor ? val : floor) : ceil;
 }
 
@@ -484,9 +484,9 @@ template<> FORCE_INLINE bool IsFinite<long double>(long double value) { return _
 FORCE_INLINE bool IsInf(long double value) { return IsInf((double)value); }
 FORCE_INLINE bool IsNan(long double value) { return IsNan((double)value); }
 #elif !defined(__EMSCRIPTEN__) // long double is not supported.
-//template<> FORCE_INLINE bool IsFinite<long double>(long double value) { asserteq(sizeof(long double), 16); u64 val[2]; memcpy(val, &value, sizeof(u64)*2); return (val[1] & 0x7FFF) != 0x7FFF || val[0] < 0x8000000000000000ULL; }
-//FORCE_INLINE bool IsInf(long double value) { asserteq(sizeof(long double), 16); u64 val[2]; memcpy(val, &value, sizeof(u64)*2); return (val[1] & 0x7FFF) == 0x7FFF && val[0] == 0x8000000000000000ULL; }
-//FORCE_INLINE bool IsNan(long double value) { asserteq(sizeof(long double), 16); u64 val[2]; memcpy(val, &value, sizeof(u64)*2); return (val[1] & 0x7FFF) == 0x7FFF && val[0] >  0x8000000000000000ULL; }
+//template<> FORCE_INLINE bool IsFinite<long double>(long double value) { mgl_asserteq(sizeof(long double), 16); u64 val[2]; memcpy(val, &value, sizeof(u64)*2); return (val[1] & 0x7FFF) != 0x7FFF || val[0] < 0x8000000000000000ULL; }
+//FORCE_INLINE bool IsInf(long double value) { mgl_asserteq(sizeof(long double), 16); u64 val[2]; memcpy(val, &value, sizeof(u64)*2); return (val[1] & 0x7FFF) == 0x7FFF && val[0] == 0x8000000000000000ULL; }
+//FORCE_INLINE bool IsNan(long double value) { mgl_asserteq(sizeof(long double), 16); u64 val[2]; memcpy(val, &value, sizeof(u64)*2); return (val[1] & 0x7FFF) == 0x7FFF && val[0] >  0x8000000000000000ULL; }
 template<> FORCE_INLINE bool IsFinite<long double>(long double value) { return IsFinite<double>((double)value); }
 FORCE_INLINE bool IsInf(long double value) { return IsInf((double)value); }
 FORCE_INLINE bool IsNan(long double value) { return IsNan((double)value); }

--- a/src/Math/MathOps.cpp
+++ b/src/Math/MathOps.cpp
@@ -52,9 +52,9 @@ inline int ReinterpretFloatAsInt(float a)
 
 bool EqualUlps(float a, float b, int maxUlps)
 {
-	assert(sizeof(float) == sizeof(int));
-	assert(maxUlps >= 0);
-	assert(maxUlps < 4 * 1024 * 1024);
+	mgl_assert(sizeof(float) == sizeof(int));
+	mgl_assert(maxUlps >= 0);
+	mgl_assert(maxUlps < 4 * 1024 * 1024);
 
 	int intA = ReinterpretFloatAsInt(a);
 	if (intA < 0) intA = 0x80000000 - intA;

--- a/src/Math/Matrix.inl
+++ b/src/Math/Matrix.inl
@@ -690,8 +690,8 @@ void ExtractEulerZYZ(Matrix &m, float &z2, float &y, float &z1)
 template<typename Matrix, typename Vector>
 void SetRotationAxis3x3(Matrix &m, const Vector &a, float angle)
 {
-	assume(a.IsNormalized());
-	assume(MATH_NS::IsFinite(angle));
+	mgl_assume(a.IsNormalized());
+	mgl_assume(MATH_NS::IsFinite(angle));
 
 	float s, c;
 	SinCos(angle, s, c);
@@ -794,7 +794,7 @@ bool InverseMatrix(Matrix &mat, float epsilon)
 		}
 		
 		// multiply rows
-		assume(!EqualAbs(mat[column][column], 0.f, epsilon));
+		mgl_assume(!EqualAbs(mat[column][column], 0.f, epsilon));
 		float scale = 1.f / mat[column][column];
 		inversed.ScaleRow(column, scale);
 		mat.ScaleRow(column, scale);
@@ -880,7 +880,7 @@ void SetMatrixRotatePart(Matrix &m, const Quat &q)
 {
 	// See e.g. http://www.geometrictools.com/Documentation/LinearAlgebraicQuaternions.pdf .
 
-	assume2(q.IsNormalized(1e-3f), q.ToString(), q.LengthSq());
+	mgl_assume2(q.IsNormalized(1e-3f), q.ToString(), q.LengthSq());
 	const float x = q.x; const float y = q.y; const float z = q.z; const float w = q.w;
 	m[0][0] = 1 - 2*(y*y + z*z); m[0][1] =     2*(x*y - z*w); m[0][2] =     2*(x*z + y*w);
 	m[1][0] =     2*(x*y + z*w); m[1][1] = 1 - 2*(x*x + z*z); m[1][2] =     2*(y*z - x*w);
@@ -891,7 +891,7 @@ void SetMatrixRotatePart(Matrix &m, const Quat &q)
 template<typename Matrix>
 void SetMatrix3x3LinearPlaneMirror(Matrix &m, float x, float y, float z)
 {
-	assume(float3(x,y,z).IsNormalized());
+	mgl_assume(float3(x,y,z).IsNormalized());
 	m[0][0] = 1.f - 2.f*x*x; m[0][1] =      -2.f*y*x; m[0][2] =      -2.f*z*x;
 	m[1][0] =      -2.f*x*y; m[1][1] = 1.f - 2.f*y*y; m[1][2] =      -2.f*y*z;
 	m[2][0] =      -2.f*x*z; m[2][1] =      -2.f*y*z; m[2][2] = 1.f - 2.f*z*z;
@@ -909,7 +909,7 @@ void SetMatrix3x4AffinePlaneMirror(Matrix &m, float x, float y, float z, float d
 template<typename Matrix>
 void SetMatrix3x3LinearPlaneProject(Matrix &m, float x, float y, float z)
 {
-	assume(float3(x,y,z).IsNormalized());
+	mgl_assume(float3(x,y,z).IsNormalized());
 	m[0][0] = 1.f - x*x; m[0][1] =      -y*x; m[0][2] =      -z*x;
 	m[1][0] =      -x*y; m[1][1] = 1.f - y*y; m[1][2] =      -y*z;
 	m[2][0] =      -x*z; m[2][1] =      -y*z; m[2][2] = 1.f - z*z;

--- a/src/Math/MatrixProxy.h
+++ b/src/Math/MatrixProxy.h
@@ -33,15 +33,15 @@ private:
 public:
 	CONST_WIN32 FORCE_INLINE float operator[](int col) const
 	{
-		assert(col >= 0);
-		assert(col < Cols);
+		mgl_assert(col >= 0);
+		mgl_assert(col < Cols);
 		
 		return v[col*Rows];
 	}
 	FORCE_INLINE float &operator[](int col)
 	{
-		assert(col >= 0);
-		assert(col < Cols);
+		mgl_assert(col >= 0);
+		mgl_assert(col < Cols);
 		
 		return v[col*Rows];
 	}
@@ -56,15 +56,15 @@ private:
 public:
 	CONST_WIN32 FORCE_INLINE float operator[](int col) const
 	{
-		assert(col >= 0);
-		assert(col < Cols);
+		mgl_assert(col >= 0);
+		mgl_assert(col < Cols);
 
 		return v[col];
 	}
 	FORCE_INLINE float &operator[](int col)
 	{
-		assert(col >= 0);
-		assert(col < Cols);
+		mgl_assert(col >= 0);
+		mgl_assert(col < Cols);
 
 		return v[col];
 	}

--- a/src/Math/MiniFloat.cpp
+++ b/src/Math/MiniFloat.cpp
@@ -97,11 +97,11 @@ uint16_t Float32ToFloat16(float float32)
 
 uint32_t Float32ToMiniFloat(bool signBit, int exponentBits, int mantissaBits, int exponentBias, float value)
 {
-	assert(sizeof(float) == 4);
-	assert(exponentBits > 0);
-	assert(exponentBits <= 8);
-	assert(mantissaBits > 0);
-	assert(mantissaBits <= 23);
+	mgl_assert(sizeof(float) == 4);
+	mgl_assert(exponentBits > 0);
+	mgl_assert(exponentBits <= 8);
+	mgl_assert(mantissaBits > 0);
+	mgl_assert(mantissaBits <= 23);
 	uint32_t v = ReinterpretAsU32(value);
 	uint32_t biasedExponent = (v & 0x7F800000) >> 23;
 	uint32_t mantissa = v & 0x7FFFFF;
@@ -152,11 +152,11 @@ uint32_t Float32ToMiniFloat(bool signBit, int exponentBits, int mantissaBits, in
 
 float MiniFloatToFloat32(bool signBit, int exponentBits, int mantissaBits, int exponentBias, uint32_t miniFloat)
 {
-	assert(sizeof(float) == 4);
-	assert(exponentBits > 0);
-	assert(exponentBits <= 8);
-	assert(mantissaBits > 0);
-	assert(mantissaBits <= 23);
+	mgl_assert(sizeof(float) == 4);
+	mgl_assert(exponentBits > 0);
+	mgl_assert(exponentBits <= 8);
+	mgl_assert(mantissaBits > 0);
+	mgl_assert(mantissaBits <= 23);
 
 	uint32_t sign = signBit ? (miniFloat & (1U << (exponentBits + mantissaBits))) : 0;
 	uint32_t exponent = (miniFloat >> mantissaBits) & ((1U << exponentBits) - 1);

--- a/src/Math/Polynomial.cpp
+++ b/src/Math/Polynomial.cpp
@@ -48,7 +48,7 @@ int Polynomial::SolveCubic(float /*a*/, float /*b*/, float /*c*/, float /*d*/, f
 #else
 #warning Polynomial::SolveCubic not implemented!
 #endif
-	assume(false && "Polynomial::SolveCubic not implemented!"); /// @todo Implement.
+	mgl_assume(false && "Polynomial::SolveCubic not implemented!"); /// @todo Implement.
 	return 0;
 }
 
@@ -59,7 +59,7 @@ int Polynomial::SolveQuartic(float /*a*/, float /*b*/, float /*c*/, float /*d*/,
 #else
 #warning Polynomial::SolveQuartic not implemented!
 #endif
-	assume(false && "Polynomial::SolveQuartic not implemented!"); /// @todo Implement.
+	mgl_assume(false && "Polynomial::SolveQuartic not implemented!"); /// @todo Implement.
 	return 0;
 }
 #endif

--- a/src/Math/Quat.cpp
+++ b/src/Math/Quat.cpp
@@ -42,7 +42,7 @@ MATH_BEGIN_NAMESPACE
 
 Quat::Quat(const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 #if defined(MATH_AUTOMATIC_SSE)
 	q = loadu_ps(data);
 #else
@@ -92,10 +92,10 @@ vec Quat::WorldZ() const
 
 vec Quat::Axis() const
 {
-	assume2(this->IsNormalized(), *this, this->Length());
+	mgl_assume2(this->IsNormalized(), *this, this->Length());
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	// Best: 6.145 nsecs / 16.88 ticks, Avg: 6.367 nsecs, Worst: 6.529 nsecs
-	assume2(this->IsNormalized(), *this, this->Length());
+	mgl_assume2(this->IsNormalized(), *this, this->Length());
 	simd4f cosAngle = wwww_ps(q);
 	simd4f rcpSinAngle = rsqrt_ps(sub_ps(set1_ps(1.f), mul_ps(cosAngle, cosAngle)));
 	simd4f a = mul_ps(q, rcpSinAngle);
@@ -176,7 +176,7 @@ Quat Quat::Normalized() const
 #else
 	Quat copy = *this;
 	float success = copy.Normalize();
-	assume(success > 0 && "Quat::Normalized failed!");
+	mgl_assume(success > 0 && "Quat::Normalized failed!");
 	MARK_UNUSED(success);
 	return copy;
 #endif
@@ -212,15 +212,15 @@ bool Quat::BitEquals(const Quat &other) const
 
 void Quat::Inverse()
 {
-	assume(IsNormalized());
-	assume(IsInvertible());
+	mgl_assume(IsNormalized());
+	mgl_assume(IsInvertible());
 	Conjugate();
 }
 
 Quat MUST_USE_RESULT Quat::Inverted() const
 {
-	assume(IsNormalized());
-	assume(IsInvertible());
+	mgl_assume(IsNormalized());
+	mgl_assume(IsInvertible());
 	return Conjugated();
 }
 
@@ -252,7 +252,7 @@ Quat MUST_USE_RESULT Quat::Conjugated() const
 
 float3 MUST_USE_RESULT Quat::Transform(const float3 &vec) const
 {
-	assume2(this->IsNormalized(), *this, this->LengthSq());
+	mgl_assume2(this->IsNormalized(), *this, this->LengthSq());
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	return float4(quat_transform_vec4(q, load_vec3(vec.ptr(), 0.f))).xyz();
 #else
@@ -273,7 +273,7 @@ float3 MUST_USE_RESULT Quat::Transform(float X, float Y, float Z) const
 
 float4 MUST_USE_RESULT Quat::Transform(const float4 &vec) const
 {
-	assume(vec.IsWZeroOrOne());
+	mgl_assume(vec.IsWZeroOrOne());
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	return quat_transform_vec4(q, vec);
@@ -284,7 +284,7 @@ float4 MUST_USE_RESULT Quat::Transform(const float4 &vec) const
 
 Quat MUST_USE_RESULT Quat::Lerp(const Quat &b, float t) const
 {
-	assume(0.f <= t && t <= 1.f);
+	mgl_assume(0.f <= t && t <= 1.f);
 
 	// TODO: SSE
 	float angle = this->Dot(b);
@@ -296,9 +296,9 @@ Quat MUST_USE_RESULT Quat::Lerp(const Quat &b, float t) const
 
 Quat MUST_USE_RESULT Quat::Slerp(const Quat &q2, float t) const
 {
-	assume(0.f <= t && t <= 1.f);
-	assume(IsNormalized());
-	assume(q2.IsNormalized());
+	mgl_assume(0.f <= t && t <= 1.f);
+	mgl_assume(IsNormalized());
+	mgl_assume(q2.IsNormalized());
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	simd4f angle = dot4_ps(q, q2.q); // <q, q2.q>
@@ -401,7 +401,7 @@ float3 MUST_USE_RESULT Quat::SlerpVectorAbs(const float3 &from, const float3 &to
 
 float MUST_USE_RESULT Quat::AngleBetween(const Quat &target) const
 {
-	assume(this->IsInvertible());
+	mgl_assume(this->IsInvertible());
 	Quat delta = target / *this;
 	delta.Normalize();
 	return delta.Angle();
@@ -409,7 +409,7 @@ float MUST_USE_RESULT Quat::AngleBetween(const Quat &target) const
 
 vec MUST_USE_RESULT Quat::AxisFromTo(const Quat &target) const
 {
-	assume(this->IsInvertible());
+	mgl_assume(this->IsInvertible());
 	Quat delta = target / *this;
 	delta.Normalize();
 	return delta.Axis();
@@ -418,7 +418,7 @@ vec MUST_USE_RESULT Quat::AxisFromTo(const Quat &target) const
 void Quat::ToAxisAngle(float3 &axis, float &angle) const
 {
 	// Best: 36.868 nsecs / 98.752 ticks, Avg: 37.095 nsecs, Worst: 37.636 nsecs
-	assume2(this->IsNormalized(), *this, this->Length());
+	mgl_assume2(this->IsNormalized(), *this, this->Length());
 	float halfAngle = Acos(w);
 	angle = halfAngle * 2.f;
 	// Convert cos to sin via the identity sin^2 + cos^2 = 1, and fuse reciprocal and square root to the same instruction,
@@ -433,7 +433,7 @@ void Quat::ToAxisAngle(float4 &axis, float &angle) const
 {
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	// Best: 35.332 nsecs / 94.328 ticks, Avg: 35.870 nsecs, Worst: 57.607 nsecs
-	assume2(this->IsNormalized(), *this, this->Length());
+	mgl_assume2(this->IsNormalized(), *this, this->Length());
 	simd4f cosAngle = wwww_ps(q);
 	simd4f rcpSinAngle = rsqrt_ps(sub_ps(set1_ps(1.f), mul_ps(cosAngle, cosAngle)));
 	angle = Acos(s4f_x(cosAngle)) * 2.f;
@@ -454,8 +454,8 @@ void Quat::SetFromAxisAngle(const float3 &axis, float angle)
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE2)
 	SetFromAxisAngle(load_vec3(axis.ptr(), 0.f), angle);
 #else
-	assume1(axis.IsNormalized(), axis);
-	assume1(MATH_NS::IsFinite(angle), angle);
+	mgl_assume1(axis.IsNormalized(), axis);
+	mgl_assume1(MATH_NS::IsFinite(angle), angle);
 	float sinz, cosz;
 	SinCos(angle*0.5f, sinz, cosz);
 	x = axis.x * sinz;
@@ -467,9 +467,9 @@ void Quat::SetFromAxisAngle(const float3 &axis, float angle)
 
 void Quat::SetFromAxisAngle(const float4 &axis, float angle)
 {
-	assume1(EqualAbs(axis.w, 0.f), axis);
-	assume2(axis.IsNormalized(1e-4f), axis, axis.Length4());
-	assume1(MATH_NS::IsFinite(angle), angle);
+	mgl_assume1(EqualAbs(axis.w, 0.f), axis);
+	mgl_assume2(axis.IsNormalized(1e-4f), axis, axis.Length4());
+	mgl_assume1(MATH_NS::IsFinite(angle), angle);
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE2)
 	// Best: 26.499 nsecs / 71.024 ticks, Avg: 26.856 nsecs, Worst: 27.651 nsecs
@@ -531,47 +531,47 @@ void SetQuatFrom(Quat &q, const M &m)
 		q.w = (m[1][0] - m[0][1]) * z4;
 	}
 	float oldLength = q.Normalize();
-	assume(oldLength > 0.f);
+	mgl_assume(oldLength > 0.f);
 	MARK_UNUSED(oldLength);
 }
 
 void Quat::Set(const float3x3 &m)
 {
-	assume(m.IsColOrthogonal());
-	assume(m.HasUnitaryScale());
-	assume(!m.HasNegativeScale());
+	mgl_assume(m.IsColOrthogonal());
+	mgl_assume(m.HasUnitaryScale());
+	mgl_assume(!m.HasNegativeScale());
 	SetQuatFrom(*this, m);
 
 #ifdef MATH_ASSERT_CORRECTNESS
 	// Test that the conversion float3x3->Quat->float3x3 is correct.
-	mathassert(this->ToFloat3x3().Equals(m, 0.01f));
+	mgl_mathassert(this->ToFloat3x3().Equals(m, 0.01f));
 #endif
 }
 
 void Quat::Set(const float3x4 &m)
 {
-	assume(m.IsColOrthogonal());
-	assume(m.HasUnitaryScale());
-	assume(!m.HasNegativeScale());
+	mgl_assume(m.IsColOrthogonal());
+	mgl_assume(m.HasUnitaryScale());
+	mgl_assume(!m.HasNegativeScale());
 	SetQuatFrom(*this, m);
 
 #ifdef MATH_ASSERT_CORRECTNESS
 	// Test that the conversion float3x3->Quat->float3x3 is correct.
-	mathassert(this->ToFloat3x3().Equals(m.Float3x3Part(), 0.01f));
+	mgl_mathassert(this->ToFloat3x3().Equals(m.Float3x3Part(), 0.01f));
 #endif
 }
 
 void Quat::Set(const float4x4 &m)
 {
-	assume(m.IsColOrthogonal3());
-	assume(m.HasUnitaryScale());
-	assume(!m.HasNegativeScale());
-	assume(m.Row(3).Equals(0,0,0,1));
+	mgl_assume(m.IsColOrthogonal3());
+	mgl_assume(m.HasUnitaryScale());
+	mgl_assume(!m.HasNegativeScale());
+	mgl_assume(m.Row(3).Equals(0,0,0,1));
 	SetQuatFrom(*this, m);
 
 #ifdef MATH_ASSERT_CORRECTNESS
 	// Test that the conversion float3x3->Quat->float3x3 is correct.
-	mathassert(this->ToFloat3x3().Equals(m.Float3x3Part(), 0.01f));
+	mgl_mathassert(this->ToFloat3x3().Equals(m.Float3x3Part(), 0.01f));
 #endif
 }
 
@@ -638,8 +638,8 @@ Quat MUST_USE_RESULT Quat::RotateAxisAngle(const float3 &axis, float angle)
 
 Quat MUST_USE_RESULT Quat::RotateFromTo(const float3 &sourceDirection, const float3 &targetDirection)
 {
-	assume(sourceDirection.IsNormalized());
-	assume(targetDirection.IsNormalized());
+	mgl_assume(sourceDirection.IsNormalized());
+	mgl_assume(targetDirection.IsNormalized());
 	// If sourceDirection == targetDirection, the cross product comes out zero, and normalization would fail. In that case, pick an arbitrary axis.
 	float3 axis = sourceDirection.Cross(targetDirection);
 	float oldLength = axis.Normalize();
@@ -677,8 +677,8 @@ Quat MUST_USE_RESULT Quat::RotateFromTo(const float4 &sourceDirection, const flo
 	return q;
 #else
 	// Best: 19.970 nsecs / 53.632 ticks, Avg: 20.197 nsecs, Worst: 21.122 nsecs
-	assume(EqualAbs(sourceDirection.w, 0.f));
-	assume(EqualAbs(targetDirection.w, 0.f));
+	mgl_assume(EqualAbs(sourceDirection.w, 0.f));
+	mgl_assume(EqualAbs(targetDirection.w, 0.f));
 	return Quat::RotateFromTo(sourceDirection.xyz(), targetDirection.xyz());
 #endif
 }
@@ -715,7 +715,7 @@ Quat MUST_USE_RESULT Quat::RandomRotation(LCG &lcg)
 		if (lenSq >= 1e-6f && lenSq <= 1.f)
 			return Quat(x, y, z, w) / Sqrt(lenSq);
 	}
-	assume(false && "Quat::RandomRotation failed!");
+	mgl_assume(false && "Quat::RandomRotation failed!");
 	return Quat::identity;
 }
 
@@ -752,7 +752,7 @@ float3x4 MUST_USE_RESULT Quat::ToFloat3x4() const
 
 float4x4 MUST_USE_RESULT Quat::ToFloat4x4() const
 {
-	assume(IsNormalized());
+	mgl_assume(IsNormalized());
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	float4x4 m;
 	quat_to_mat4x4(q, _mm_set_ps(1,0,0,0), m.row);
@@ -773,7 +773,7 @@ float4x4 MUST_USE_RESULT Quat::ToFloat4x4(const float3 &translation) const
 
 float4x4 MUST_USE_RESULT Quat::ToFloat4x4(const float4 &translation) const
 {
-	assume(IsNormalized());
+	mgl_assume(IsNormalized());
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	float4x4 m;
 	quat_to_mat4x4(q, translation.v, m.row);
@@ -810,7 +810,7 @@ StringT MUST_USE_RESULT Quat::SerializeToString() const
 	s = SerializeFloat(y, s); *s = ','; ++s;
 	s = SerializeFloat(z, s); *s = ','; ++s;
 	s = SerializeFloat(w, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -823,8 +823,8 @@ StringT Quat::SerializeToCodeString() const
 
 Quat MUST_USE_RESULT Quat::FromString(const char *str, const char **outEndStr)
 {
-	assert(IsNeutralCLocale());
-	assume(str);
+	mgl_assert(IsNeutralCLocale());
+	mgl_assume(str);
 	if (!str)
 		return Quat::nan;
 	MATH_SKIP_WORD(str, "Quat");
@@ -899,7 +899,7 @@ float4 Quat::operator *(const float4 &rhs) const
 
 Quat Quat::operator /(float scalar) const
 {
-	assume(!EqualAbs(scalar, 0.f));
+	mgl_assume(!EqualAbs(scalar, 0.f));
 
 #ifdef MATH_AUTOMATIC_SSE
 	return div_ps(q, set1_ps(scalar));

--- a/src/Math/Reinterpret.h
+++ b/src/Math/Reinterpret.h
@@ -41,7 +41,7 @@ FORCE_INLINE float ReinterpretAsFloat(u32 i)
 	FloatIntReinterpret fi;
 	fi.i = i;
 #ifdef __EMSCRIPTEN__
-	assert(ReinterpretAsU32(fi.f) == i);
+	mgl_assert(ReinterpretAsU32(fi.f) == i);
 #endif
 	return fi.f;
 }
@@ -51,7 +51,7 @@ FORCE_INLINE double ReinterpretAsDouble(u64 i)
 	DoubleU64Reinterpret di;
 	di.i = i;
 #ifdef __EMSCRIPTEN__
-	assert(ReinterpretAsU64(di.d) == i);
+	mgl_assert(ReinterpretAsU64(di.d) == i);
 #endif
 	return di.d;
 }

--- a/src/Math/SSEMath.cpp
+++ b/src/Math/SSEMath.cpp
@@ -21,7 +21,7 @@ void *AlignedMalloc(size_t size, size_t alignment)
 	ptr += incr;
 	((u8*)ptr)[-1] = (u8)(incr+1);
 #endif
-	assert(ptr % alignment == 0);
+	mgl_assert(ptr % alignment == 0);
 	return (void*)ptr;
 }
 

--- a/src/Math/TransformOps.cpp
+++ b/src/Math/TransformOps.cpp
@@ -85,7 +85,7 @@ float3x4 operator *(const TranslateOp &lhs, const float3x4 &rhs)
 	r.SetTranslatePart(r.TranslatePart() + DIR_TO_FLOAT3(lhs.Offset()));
 
 	// Our optimized form of multiplication must be the same as this.
-	mathassert(r.Equals((float3x4)lhs * rhs));
+	mgl_mathassert(r.Equals((float3x4)lhs * rhs));
 	return r;
 }
 
@@ -95,7 +95,7 @@ float3x4 operator *(const float3x4 &lhs, const TranslateOp &rhs)
 	r.SetTranslatePart(lhs.TransformPos(DIR_TO_FLOAT3(rhs.Offset())));
 
 	// Our optimized form of multiplication must be the same as this.
-	assume4(r.Equals(lhs * (float3x4)rhs), lhs, rhs, r, lhs * (float3x4)rhs);
+	mgl_assume4(r.Equals(lhs * (float3x4)rhs), lhs, rhs, r, lhs * (float3x4)rhs);
 	return r;
 }
 
@@ -103,7 +103,7 @@ float4x4 operator *(const TranslateOp &lhs, const float4x4 &rhs)
 {
 	// This function is based on the optimized assumption that the last row of rhs is [0,0,0,1].
 	// If this does not hold and you are hitting the check below, explicitly cast TranslateOp lhs to float4x4 before multiplication!
-	assume(rhs.Row(3).Equals(0.f, 0.f, 0.f, 1.f));
+	mgl_assume(rhs.Row(3).Equals(0.f, 0.f, 0.f, 1.f));
 
 	float4x4 r = rhs;
 	r.SetTranslatePart(r.TranslatePart() + DIR_TO_FLOAT3(lhs.Offset()));
@@ -188,7 +188,7 @@ float3x3 operator *(const ScaleOp &lhs, const float3x3 &rhs)
 	ret.ScaleRow(2, lhs.scale.z);
 
 	// Our optimized form of multiplication must be the same as this.
-	mathassert(ret.Equals((float3x3)lhs * rhs));
+	mgl_mathassert(ret.Equals((float3x3)lhs * rhs));
 	return ret;
 }
 
@@ -200,7 +200,7 @@ float3x3 operator *(const float3x3 &lhs, const ScaleOp &rhs)
 	ret.ScaleCol(2, rhs.scale.z);
 
 	// Our optimized form of multiplication must be the same as this.
-	mathassert(ret.Equals(lhs * (float3x3)rhs));
+	mgl_mathassert(ret.Equals(lhs * (float3x3)rhs));
 	return ret;
 }
 
@@ -211,7 +211,7 @@ float3x4 operator *(const ScaleOp &lhs, const float3x4 &rhs)
 	ret[1][0] = rhs[1][0] * lhs.scale.y; ret[1][1] = rhs[1][1] * lhs.scale.y; ret[1][2] = rhs[1][2] * lhs.scale.y; ret[1][3] = rhs[1][3] * lhs.scale.y;
 	ret[2][0] = rhs[2][0] * lhs.scale.z; ret[2][1] = rhs[2][1] * lhs.scale.z; ret[2][2] = rhs[2][2] * lhs.scale.z; ret[2][3] = rhs[2][3] * lhs.scale.z;
 
-	mathassert(ret.Equals(lhs.ToFloat3x4() * rhs));
+	mgl_mathassert(ret.Equals(lhs.ToFloat3x4() * rhs));
 	return ret;
 }
 
@@ -222,7 +222,7 @@ float3x4 operator *(const float3x4 &lhs, const ScaleOp &rhs)
 	ret[1][0] = lhs[1][0] * rhs.scale.x; ret[1][1] = lhs[1][1] * rhs.scale.y; ret[1][2] = lhs[1][2] * rhs.scale.z; ret[1][3] = lhs[1][3];
 	ret[2][0] = lhs[2][0] * rhs.scale.x; ret[2][1] = lhs[2][1] * rhs.scale.y; ret[2][2] = lhs[2][2] * rhs.scale.z; ret[2][3] = lhs[2][3];
 
-	mathassert(ret.Equals(lhs * rhs.ToFloat3x4()));
+	mgl_mathassert(ret.Equals(lhs * rhs.ToFloat3x4()));
 	return ret;
 }
 
@@ -243,7 +243,7 @@ float4x4 operator *(const ScaleOp &lhs, const float4x4 &rhs)
 	ret[2][0] = rhs[2][0] * lhs.scale.z; ret[2][1] = rhs[2][1] * lhs.scale.z; ret[2][2] = rhs[2][2] * lhs.scale.z; ret[2][3] = rhs[2][3] * lhs.scale.z;
 	ret[3][0] = rhs[3][0];         ret[3][1] = rhs[3][1];         ret[3][2] = rhs[3][2];         ret[3][3] = rhs[3][3];
 #endif
-	mathassert(ret.Equals(lhs.ToFloat4x4() * rhs));
+	mgl_mathassert(ret.Equals(lhs.ToFloat4x4() * rhs));
 	return ret;
 }
 
@@ -255,7 +255,7 @@ float4x4 operator *(const float4x4 &lhs, const ScaleOp &rhs)
 	ret[2][0] = lhs[2][0] * rhs.scale.x; ret[2][1] = lhs[2][1] * rhs.scale.y; ret[2][2] = lhs[2][2] * rhs.scale.z; ret[2][3] = lhs[2][3];
 	ret[3][0] = lhs[3][0] * rhs.scale.x; ret[3][1] = lhs[3][1] * rhs.scale.y; ret[3][2] = lhs[3][2] * rhs.scale.z; ret[3][3] = lhs[3][3];
 
-	mathassert4(ret.Equals(lhs * rhs.ToFloat4x4()), lhs, rhs.ToFloat4x4(), ret, lhs * rhs.ToFloat4x4());
+	mgl_mathassert4(ret.Equals(lhs * rhs.ToFloat4x4()), lhs, rhs.ToFloat4x4(), ret, lhs * rhs.ToFloat4x4());
 	return ret;
 }
 
@@ -266,7 +266,7 @@ float3x4 operator *(const ScaleOp &lhs, const TranslateOp &rhs)
 	ret[1][0] =	          0; ret[1][1] = lhs.scale.y; ret[1][2] =       	0; ret[1][3] = lhs.scale.y * rhs.offset.y;
 	ret[2][0] =	          0; ret[2][1] =	       0; ret[2][2] = lhs.scale.z; ret[2][3] = lhs.scale.z * rhs.offset.z;
 
-	mathassert(ret.Equals(lhs.ToFloat3x4() * rhs));
+	mgl_mathassert(ret.Equals(lhs.ToFloat3x4() * rhs));
 	return ret;
 }
 
@@ -277,7 +277,7 @@ float3x4 operator *(const TranslateOp &lhs, const ScaleOp &rhs)
 	ret[1][0] =	 0; ret[1][1] = rhs.scale.y; ret[1][2] =	 0; ret[1][3] = lhs.offset.y;
 	ret[2][0] =	 0; ret[2][1] =	 0; ret[2][2] = rhs.scale.z; ret[2][3] = lhs.offset.z;
 
-	mathassert(ret.Equals(lhs.ToFloat3x4() * rhs));
+	mgl_mathassert(ret.Equals(lhs.ToFloat3x4() * rhs));
 	return ret;
 }
 

--- a/src/Math/assume.h
+++ b/src/Math/assume.h
@@ -174,148 +174,148 @@ MATH_END_NAMESPACE
 
 #ifdef FAIL_USING_EXCEPTIONS
 #include <stdexcept>
-#define assume_failed(message) throw std::runtime_error((message))
+#define mgl_assume_failed(message) throw std::runtime_error((message))
 #elif defined(MATH_ASSERT_ON_ASSUME)
-#define assume(x) assert(x)
-#define assume_failed(message) do { \
+#define mgl_assume(x) mgl_assert(x)
+#define mgl_assume_failed(message) do { \
 		LOGE("Assumption %s failed! in file %s, line %d!", message, __FILE__, __LINE__); \
-		assert(false); \
+		mgl_assert(false); \
 	} while(0) 
 #elif defined(MATH_SILENT_ASSUME)
-#define assume(x) ((void)0)
-#define assume_failed(message) ((void)0)
+#define mgl_assume(x) ((void)0)
+#define mgl_assume_failed(message) ((void)0)
 #else
-#define assume_failed(message) do { \
+#define mgl_assume_failed(message) do { \
 		LOGE("Assumption \"%s\" failed! in file %s, line %d!", message, __FILE__, __LINE__); \
 		AssumeFailed(); \
 	} while (0)
 #endif
 
-#ifndef assume
-#define assume(x) \
+#ifndef mgl_assume
+#define mgl_assume(x) \
 	MULTI_LINE_MACRO_BEGIN \
 		if (!(x)) \
-			assume_failed(#x " in " __FILE__ ":" STRINGIZE(__LINE__)); \
+			mgl_assume_failed(#x " in " __FILE__ ":" STRINGIZE(__LINE__)); \
 	MULTI_LINE_MACRO_END
 #endif
 
 // In assume1-assume4, print1-print4 are additional helper parameters that get printed out to log in case of failure.
-#define assume1(x, print1) \
+#define mgl_assume1(x, print1) \
 	MULTI_LINE_MACRO_BEGIN \
 		if (!(x)) \
-			assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
+			mgl_assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
 			                  (" in " __FILE__ ":" STRINGIZE(__LINE__))).c_str()); \
 	MULTI_LINE_MACRO_END
-#define assert1 assume1
+#define mgl_assert1 mgl_assume1
 
-#define assume2(x, print1, print2) \
+#define mgl_assume2(x, print1, print2) \
 	MULTI_LINE_MACRO_BEGIN \
 		if (!(x)) \
-			assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
+			mgl_assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
 			                  (", " #print2 ": ") + MATH_NS::ObjToString(print2) + \
 			                  (" in " __FILE__ ":" STRINGIZE(__LINE__))).c_str()); \
 	MULTI_LINE_MACRO_END
-#define assert2 assume2
+#define mgl_assert2 mgl_assume2
 
-#define assume3(x, print1, print2, print3) \
+#define mgl_assume3(x, print1, print2, print3) \
 	MULTI_LINE_MACRO_BEGIN \
 		if (!(x)) \
-			assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
+			mgl_assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
 			                  (", " #print2 ": ") + MATH_NS::ObjToString(print2) + \
 			                  (", " #print3 ": ") + MATH_NS::ObjToString(print3) + \
 			                  (" in " __FILE__ ":" STRINGIZE(__LINE__))).c_str()); \
 	MULTI_LINE_MACRO_END
-#define assert3 assume3
+#define mgl_assert3 mgl_assume3
 
-#define assume4(x, print1, print2, print3, print4) \
+#define mgl_assume4(x, print1, print2, print3, print4) \
 	MULTI_LINE_MACRO_BEGIN \
 		if (!(x)) \
-			assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
+			mgl_assume_failed((("\"" #x "\", " #print1 ": ") + MATH_NS::ObjToString(print1) + \
 			                  (", " #print2 ": ") + MATH_NS::ObjToString(print2) + \
 			                  (", " #print3 ": ") + MATH_NS::ObjToString(print3) + \
 			                  (", " #print4 ": ") + MATH_NS::ObjToString(print4) + \
 			                  (" in " __FILE__ ":" STRINGIZE(__LINE__))).c_str()); \
 	MULTI_LINE_MACRO_END
-#define assert4 assume4
+#define mgl_assert4 mgl_assume4
 
 // If MATH_ASSERT_CORRECTNESS is defined, the function mathassert() is enabled to test
 // that all forms of optimizations inside the math library produce proper results.
 #ifdef MATH_ASSERT_CORRECTNESS
-#define mathassert(x) assert(x)
-#define mathassert1 assert1
-#define mathassert2 assert2
-#define mathassert3 assert3
-#define mathassert4 assert4
+#define mgl_mathassert(x) mgl_assert(x)
+#define mgl_mathassert1 mgl_assert1
+#define mgl_mathassert2 mgl_assert2
+#define mgl_mathassert3 mgl_assert3
+#define mgl_mathassert4 mgl_assert4
 #else
-#define mathassert(x) ((void)0)
-#define mathassert1(...) ((void)0)
-#define mathassert2(...) ((void)0)
-#define mathassert3(...) ((void)0)
-#define mathassert4(...) ((void)0)
+#define mgl_mathassert(x) ((void)0)
+#define mgl_mathassert1(...) ((void)0)
+#define mgl_mathassert2(...) ((void)0)
+#define mgl_mathassert3(...) ((void)0)
+#define mgl_mathassert4(...) ((void)0)
 #endif
 
-// Kill both assume() and mathassert() macros in OPTIMIZED_RELEASE builds.
+// Kill both mgl_assume() and mathassert() macros in OPTIMIZED_RELEASE builds.
 #ifdef OPTIMIZED_RELEASE
-#ifdef assume
-#undef assume
+#ifdef mgl_assume
+#undef mgl_assume
 #endif
-#ifdef assume1
-#undef assume1
+#ifdef mgl_assume1
+#undef mgl_assume1
 #endif
-#ifdef assume2
-#undef assume2
+#ifdef mgl_assume2
+#undef mgl_assume2
 #endif
-#ifdef assume3
-#undef assume3
+#ifdef mgl_assume3
+#undef mgl_assume3
 #endif
-#ifdef assume4
-#undef assume4
+#ifdef mgl_assume4
+#undef mgl_assume4
 #endif
-#ifdef assert
-#undef assert
+#ifdef mgl_assert
+#undef mgl_assert
 #endif
-#ifdef assert1
-#undef assert1
+#ifdef mgl_assert1
+#undef mgl_assert1
 #endif
-#ifdef assert2
-#undef assert2
+#ifdef mgl_assert2
+#undef mgl_assert2
 #endif
-#ifdef assert3
-#undef assert3
+#ifdef mgl_assert3
+#undef mgl_assert3
 #endif
-#ifdef assert4
-#undef assert4
+#ifdef mgl_assert4
+#undef mgl_assert4
 #endif
-#ifdef mathassert
-#undef mathassert
+#ifdef mgl_mathassert
+#undef mgl_mathassert
 #endif
-#ifdef mathassert1
-#undef mathassert1
+#ifdef mgl_mathassert1
+#undef mgl_mathassert1
 #endif
-#ifdef mathassert2
-#undef mathassert2
+#ifdef mgl_mathassert2
+#undef mgl_mathassert2
 #endif
-#ifdef mathassert3
-#undef mathassert3
+#ifdef mgl_mathassert3
+#undef mgl_mathassert3
 #endif
-#ifdef mathassert4
-#undef mathassert4
+#ifdef mgl_mathassert4
+#undef mgl_mathassert4
 #endif
 
-#define assume(...) ((void)0)
-#define assume1(...) ((void)0)
-#define assume2(...) ((void)0)
-#define assume3(...) ((void)0)
-#define assume4(...) ((void)0)
-#define assert(...) ((void)0)
-#define assert1(...) ((void)0)
-#define assert2(...) ((void)0)
-#define assert3(...) ((void)0)
-#define assert4(...) ((void)0)
-#define mathassert(...) ((void)0)
-#define mathassert1(...) ((void)0)
-#define mathassert2(...) ((void)0)
-#define mathassert3(...) ((void)0)
-#define mathassert4(...) ((void)0)
+#define mgl_assume(...) ((void)0)
+#define mgl_assume1(...) ((void)0)
+#define mgl_assume2(...) ((void)0)
+#define mgl_assume3(...) ((void)0)
+#define mgl_assume4(...) ((void)0)
+#define mgl_assert(...) ((void)0)
+#define mgl_assert1(...) ((void)0)
+#define mgl_assert2(...) ((void)0)
+#define mgl_assert3(...) ((void)0)
+#define mgl_assert4(...) ((void)0)
+#define mgl_mathassert(...) ((void)0)
+#define mgl_mathassert1(...) ((void)0)
+#define mgl_mathassert2(...) ((void)0)
+#define mgl_mathassert3(...) ((void)0)
+#define mgl_mathassert4(...) ((void)0)
 
 #endif

--- a/src/Math/float2.cpp
+++ b/src/Math/float2.cpp
@@ -52,7 +52,7 @@ float2::float2(float scalar)
 
 float2::float2(const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	x = data[0];
 	y = data[1];
 }
@@ -108,13 +108,13 @@ float2 float2::ToPolarCoordinates() const
 
 float float2::AimedAngle() const
 {
-	assume(!IsZero());
+	mgl_assume(!IsZero());
 	return atan2(y, x);
 }
 
 float float2::Normalize()
 {
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	float lengthSq = LengthSq();
 	if (lengthSq > 1e-6f)
 	{
@@ -133,7 +133,7 @@ float2 float2::Normalized() const
 {
 	float2 copy = *this;
 	float oldLength = copy.Normalize();
-	assume(oldLength > 0.f && "float2::Normalized() failed!");
+	mgl_assume(oldLength > 0.f && "float2::Normalized() failed!");
 	MARK_UNUSED(oldLength);
 	return copy;
 }
@@ -153,7 +153,7 @@ float float2::ScaleToLength(float newLength)
 
 float2 float2::ScaledToLength(float newLength) const
 {
-	assume(!IsZero());
+	mgl_assume(!IsZero());
 
 	float2 v = *this;
 	v.ScaleToLength(newLength);
@@ -225,7 +225,7 @@ StringT float2::SerializeToString() const
 	char str[256];
 	char *s = SerializeFloat(x, str); *s = ','; ++s;
 	s = SerializeFloat(y, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -238,8 +238,8 @@ StringT float2::SerializeToCodeString() const
 
 float2 float2::FromString(const char *str, const char **outEndStr)
 {
-	assert(IsNeutralCLocale());
-	assume(str);
+	mgl_assert(IsNeutralCLocale());
+	mgl_assume(str);
 	if (!str)
 		return float2::nan;
 	MATH_SKIP_WORD(str, "float2");
@@ -370,7 +370,7 @@ float float2::PerpDot(const float2 &rhs) const
 
 float2 float2::Reflect(const float2 &normal) const
 {
-	assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
+	mgl_assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
 	return 2.f * this->ProjectToNorm(normal) - *this;
 }
 
@@ -388,13 +388,13 @@ float2 float2::Refract(const float2 &normal, float negativeSideRefractionIndex, 
 
 float2 float2::ProjectTo(const float2 &direction) const
 {
-	assume(!direction.IsZero());
+	mgl_assume(!direction.IsZero());
 	return direction * this->Dot(direction) / direction.LengthSq();
 }
 
 float2 float2::ProjectToNorm(const float2 &direction) const
 {
-	assume(direction.IsNormalized());
+	mgl_assume(direction.IsNormalized());
 	return direction * this->Dot(direction);
 }
 
@@ -405,14 +405,14 @@ float float2::AngleBetween(const float2 &other) const
 
 float float2::AngleBetweenNorm(const float2 &other) const
 {
-	assume(this->IsNormalized());
-	assume(other.IsNormalized());
+	mgl_assume(this->IsNormalized());
+	mgl_assume(other.IsNormalized());
 	return acos(Dot(other));
 }
 
 float2 float2::Lerp(const float2 &b, float t) const
 {
-	assume(0.f <= t && t <= 1.f);
+	mgl_assume(0.f <= t && t <= 1.f);
 	return (1.f - t) * *this + t * b;
 }
 
@@ -423,14 +423,14 @@ float2 float2::Lerp(const float2 &a, const float2 &b, float t)
 
 void float2::Decompose(const float2 &direction, float2 &outParallel, float2 &outPerpendicular) const
 {
-	assume(direction.IsNormalized());
+	mgl_assume(direction.IsNormalized());
 	outParallel = this->Dot(direction) * direction;
 	outPerpendicular = *this - outParallel;
 }
 
 void float2::Orthogonalize(const float2 &a, float2 &b)
 {
-	assume(!a.IsZero());
+	mgl_assume(!a.IsZero());
 	b -= a.Dot(b) / a.Length() * a;
 }
 
@@ -442,7 +442,7 @@ bool float2::AreOrthogonal(const float2 &a, const float2 &b, float epsilon)
 
 void float2::Orthonormalize(float2 &a, float2 &b)
 {
-	assume(!a.IsZero());
+	mgl_assume(!a.IsZero());
 	a.Normalize();
 	b -= a.Dot(b) * a;
 }
@@ -536,7 +536,7 @@ bool float2::ConvexHullContains(const float2 *convexHull, int numPointsInConvexH
 
 float float2::MinAreaRectInPlace(float2 *p, int n, float2 &center, float2 &uDir, float2 &vDir, float &minU, float &maxU, float &minV, float &maxV)
 {
-	assume(p || n == 0);
+	mgl_assume(p || n == 0);
 	if (!p || n <= 0)
 	{
 		center = uDir = vDir = float2::nan;
@@ -547,7 +547,7 @@ float float2::MinAreaRectInPlace(float2 *p, int n, float2 &center, float2 &uDir,
 	// As a preparation, need to compute the convex hull so that points are CCW-oriented,
 	// and this also greatly reduces the number of points for performance.
 	n = float2::ConvexHullInPlace(p, n);
-	assert(n > 0);
+	mgl_assert(n > 0);
 	if (n == 1)
 	{
 		center = p[0];
@@ -628,7 +628,7 @@ float float2::MinAreaRectInPlace(float2 *p, int n, float2 &center, float2 &uDir,
 
 float2 float2::RandomDir(LCG &lcg, float r)
 {
-	assume(r > 1e-3f);
+	mgl_assume(r > 1e-3f);
 	for(int i = 0; i < 1000; ++i)
 	{
 		float x = lcg.Float(-r, r);
@@ -637,7 +637,7 @@ float2 float2::RandomDir(LCG &lcg, float r)
 		if (lenSq >= 1e-6f && lenSq <= r*r)
 			return r / Sqrt(lenSq) * float2(x,y);
 	}
-	assume(false && "Failed to generate a random float2 direction vector!");
+	mgl_assume(false && "Failed to generate a random float2 direction vector!");
 	return float2(r, 0);
 }
 

--- a/src/Math/float2.h
+++ b/src/Math/float2.h
@@ -96,15 +96,15 @@ public:
 		@see ptr(), operator [](). */
 	FORCE_INLINE CONST_WIN32 float At(int index) const
 	{
-		assume(index >= 0);
-		assume(index < Size);
+		mgl_assume(index >= 0);
+		mgl_assume(index < Size);
 		return ptr()[index];
 	}
 	
 	FORCE_INLINE float &At(int index)
 	{
-		assume(index >= 0);
-		assume(index < Size);
+		mgl_assume(index >= 0);
+		mgl_assume(index < Size);
 		return ptr()[index];
 	}
 

--- a/src/Math/float2.inl
+++ b/src/Math/float2.inl
@@ -1,4 +1,4 @@
-/* Copyright Jukka Jylänki
+/* Copyright Jukka Jylï¿½nki
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@
    limitations under the License. */
 
 /** @file float2.inl
-	@author Jukka Jylänki
+	@author Jukka Jylï¿½nki
 	@brief */
 #include "float2.h"
 #include "float3.h"
@@ -74,7 +74,7 @@ float DistSq2D(const T &a, const T &b)
 template<typename T>
 int float2_ConvexHullInPlace(T *p, int n)
 {
-	assert(n >= 0);
+	mgl_assert(n >= 0);
 	if (n <= 1) return n > 0 ? n : 0;
 
 #ifdef MATH_CONTAINERLIB_SUPPORT
@@ -102,7 +102,7 @@ int float2_ConvexHullInPlace(T *p, int n)
 		while (k >= 2 && PerpDot2D(hull[k-2], hull[k-1], p[i]) <= 0)
 			--k;
 
-		assert(k < 2*n);
+		mgl_assert(k < 2*n);
 		hull[k++] = p[i];
 	}
 
@@ -114,7 +114,7 @@ int float2_ConvexHullInPlace(T *p, int n)
 		while (k > start && PerpDot2D(hull[k-2], hull[k-1], p[i]) <= 0)
 			--k;
 
-		assert(k < 2*n);
+		mgl_assert(k < 2*n);
 		hull[k++] = p[i];
 	}
 
@@ -132,7 +132,7 @@ int float2_ConvexHullInPlace(T *p, int n)
 	{
 		if (DistSq2D(hull[i], p[h]) > eps)
 		{
-			assert(h+1 < n);
+			mgl_assert(h+1 < n);
 			p[++h] = hull[i];
 		}
 	}
@@ -145,7 +145,7 @@ int float2_ConvexHullInPlace(T *p, int n)
 template<typename T>
 bool float2_ConvexHullContains(T *hull, int n, const T &point)
 {
-	assert(n >= 0);
+	mgl_assert(n >= 0);
 	if (n <= 2) return false; // todo: test vs point or vs line?
 
 	int prev = n-1;

--- a/src/Math/float3.cpp
+++ b/src/Math/float3.cpp
@@ -64,7 +64,7 @@ float3::float3(const float2 &xy, float z_)
 
 float3::float3(const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	x = data[0];
 	y = data[1];
 	z = data[2];
@@ -123,7 +123,7 @@ float float3::Normalize()
 	store_vec3(ptr(), normalized);
 	return s4f_x(origLength);
 #else
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	float length = Length();
 	if (length > 1e-6f)
 	{
@@ -149,7 +149,7 @@ float3 float3::Normalized() const
 #else
 	float3 copy = *this;
 	float oldLength = copy.Normalize();
-	assume(oldLength > 0.f && "float3::Normalized() failed!");
+	mgl_assume(oldLength > 0.f && "float3::Normalized() failed!");
 	MARK_UNUSED(oldLength);
 	return copy;
 #endif
@@ -174,7 +174,7 @@ float float3::ScaleToLength(float newLength)
 
 float3 float3::ScaledToLength(float newLength) const
 {
-	assume(!IsZero());
+	mgl_assume(!IsZero());
 
 	float3 v = *this;
 	v.ScaleToLength(newLength);
@@ -223,7 +223,7 @@ StringT float3::SerializeToString() const
 	char *s = SerializeFloat(x, str); *s = ','; ++s;
 	s = SerializeFloat(y, s); *s = ','; ++s;
 	s = SerializeFloat(z, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -236,8 +236,8 @@ StringT float3::SerializeToCodeString() const
 
 float3 MUST_USE_RESULT float3::FromString(const char *str, const char **outEndStr)
 {
-	assert(IsNeutralCLocale());
-	assume(str);
+	mgl_assert(IsNeutralCLocale());
+	mgl_assume(str);
 	if (!str)
 		return float3::nan;
 	MATH_SKIP_WORD(str, "float3");
@@ -291,7 +291,7 @@ vec PointVecFromString(const char *str, const char **outEndStr)
 	{
 		const char *end = FindNext(str, ')');
 		int numFields = CountCommas(str, end) + 1;
-		assume1(numFields == 3 || numFields == 4, numFields);
+		mgl_assume1(numFields == 3 || numFields == 4, numFields);
 		if (numFields == 4)
 			return FLOAT4_TO_POINT(float4::FromString(str, outEndStr));
 	}
@@ -313,7 +313,7 @@ vec DirVecFromString(const char *str, const char **outEndStr)
 	{
 		const char *end = FindNext(str, ')');
 		int numFields = CountCommas(str, end) + 1;
-		assume1(numFields == 3 || numFields == 4, numFields);
+		mgl_assume1(numFields == 3 || numFields == 4, numFields);
 		if (numFields == 4)
 			return FLOAT4_TO_DIR(float4::FromString(str, outEndStr));
 	}
@@ -568,9 +568,9 @@ float3x3 float3::OuterProduct(const float3 &rhs) const
 
 float3 float3::Perpendicular(const float3 &hint, const float3 &hint2) const
 {
-	assume(!this->IsZero());
-	assume(hint.IsNormalized());
-	assume(hint2.IsNormalized());
+	mgl_assume(!this->IsZero());
+	mgl_assume(hint.IsNormalized());
+	mgl_assume(hint2.IsNormalized());
 	float3 v = this->Cross(hint);
 	float len = v.Normalize();
 	if (len == 0)
@@ -581,9 +581,9 @@ float3 float3::Perpendicular(const float3 &hint, const float3 &hint2) const
 
 float3 float3::AnotherPerpendicular(const float3 &hint, const float3 &hint2) const
 {
-	assume(!this->IsZero());
-	assume(hint.IsNormalized());
-	assume(hint2.IsNormalized());
+	mgl_assume(!this->IsZero());
+	mgl_assume(hint.IsNormalized());
+	mgl_assume(hint2.IsNormalized());
 	float3 firstPerpendicular = Perpendicular(hint, hint2);
 	float3 v = this->Cross(firstPerpendicular);
 	return v.Normalized();
@@ -619,7 +619,7 @@ float MUST_USE_RESULT float3::ScalarTripleProduct(const float3 &u, const float3 
 
 float3 float3::Reflect(const float3 &normal) const
 {
-	assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
+	mgl_assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
 	return 2.f * this->ProjectToNorm(normal) - *this;
 }
 
@@ -637,13 +637,13 @@ float3 float3::Refract(const float3 &normal, float negativeSideRefractionIndex, 
 
 float3 float3::ProjectTo(const float3 &direction) const
 {
-	assume(!direction.IsZero());
+	mgl_assume(!direction.IsZero());
 	return direction * this->Dot(direction) / direction.LengthSq();
 }
 
 float3 float3::ProjectToNorm(const float3 &direction) const
 {
-	assume(direction.IsNormalized());
+	mgl_assume(direction.IsNormalized());
 	return direction * this->Dot(direction);
 }
 
@@ -660,8 +660,8 @@ float float3::AngleBetween(const float3 &other) const
 
 float float3::AngleBetweenNorm(const float3 &other) const
 {
-	assume(this->IsNormalized());
-	assume(other.IsNormalized());
+	mgl_assume(this->IsNormalized());
+	mgl_assume(other.IsNormalized());
 	float cosa = Dot(other);
 	if (cosa >= 1.f)
 		return 0.f;
@@ -673,14 +673,14 @@ float float3::AngleBetweenNorm(const float3 &other) const
 
 void float3::Decompose(const float3 &direction, float3 &outParallel, float3 &outPerpendicular) const
 {
-	assume(direction.IsNormalized());
+	mgl_assume(direction.IsNormalized());
 	outParallel = this->ProjectToNorm(direction);
 	outPerpendicular = *this - outParallel;
 }
 
 float3 float3::Lerp(const float3 &b, float t) const
 {
-	assume(0.f <= t && t <= 1.f);
+	mgl_assume(0.f <= t && t <= 1.f);
 	return (1.f - t) * *this + t * b;
 }
 
@@ -720,8 +720,8 @@ bool MUST_USE_RESULT float3::AreOrthogonal(const float3 &a, const float3 &b, con
 
 void float3::Orthonormalize(float3 &a, float3 &b)
 {
-	assume(!a.IsZero());
-	assume(!b.IsZero());
+	mgl_assume(!a.IsZero());
+	mgl_assume(!b.IsZero());
 	a.Normalize();
 	b -= b.ProjectToNorm(a);
 	b.Normalize();
@@ -729,14 +729,14 @@ void float3::Orthonormalize(float3 &a, float3 &b)
 
 void float3::Orthonormalize(float3 &a, float3 &b, float3 &c)
 {
-	assume(!a.IsZero());
+	mgl_assume(!a.IsZero());
 	a.Normalize();
 	b -= b.ProjectToNorm(a);
-	assume(!b.IsZero());
+	mgl_assume(!b.IsZero());
 	b.Normalize();
 	c -= c.ProjectToNorm(a);
 	c -= c.ProjectToNorm(b);
-	assume(!c.IsZero());
+	mgl_assume(!c.IsZero());
 	c.Normalize();
 }
 
@@ -831,7 +831,7 @@ float3 float3::ToSphericalCoordinates() const
 
 float2 float3::ToSphericalCoordinatesNormalized() const
 {
-	assume(IsNormalized());
+	mgl_assume(IsNormalized());
 	float azimuth = atan2(x, z);
 	float inclination = asin(-y);
 	return float2(azimuth, inclination);

--- a/src/Math/float3.h
+++ b/src/Math/float3.h
@@ -101,15 +101,15 @@ public:
 		@see ptr(), operator [](). */
 	FORCE_INLINE CONST_WIN32 float At(int index) const
 	{
-		assume(index >= 0);
-		assume(index < Size);
+		mgl_assume(index >= 0);
+		mgl_assume(index < Size);
 		return ptr()[index];
 	}
 	
 	FORCE_INLINE float &At(int index)
 	{
-		assume(index >= 0);
-		assume(index < Size);
+		mgl_assume(index >= 0);
+		mgl_assume(index < Size);
 		return ptr()[index];
 	}
 
@@ -761,12 +761,12 @@ bool EqualAbs(float a, float b, float epsilon);
 /* /// TODO: Enable this:
 inline float3 POINT_TO_FLOAT3(const vec &v)
 {
-	assume(EqualAbs(v.w, 1.f, 1e-4f));
+	mgl_assume(EqualAbs(v.w, 1.f, 1e-4f));
 	return v.xyz();
 }
 inline float3 DIR_TO_FLOAT3(const vec &v)
 {
-	assume(EqualAbs(v.w, 0.f, 1e-4f));
+	mgl_assume(EqualAbs(v.w, 0.f, 1e-4f));
 	return v.xyz();
 }
 */

--- a/src/Math/float3x3.cpp
+++ b/src/Math/float3x3.cpp
@@ -87,8 +87,8 @@ float3x3 float3x3::RotateAxisAngle(const float3 &axisDirection, float angleRadia
 
 float3x3 float3x3::RotateFromTo(const float3 &sourceDirection, const float3 &targetDirection)
 {
-	assume2(sourceDirection.IsNormalized(), sourceDirection, sourceDirection.Length());
-	assume2(targetDirection.IsNormalized(), targetDirection, targetDirection.Length());
+	mgl_assume2(sourceDirection.IsNormalized(), sourceDirection, sourceDirection.Length());
+	mgl_assume2(targetDirection.IsNormalized(), targetDirection, targetDirection.Length());
 
 	// http://cs.brown.edu/research/pubs/pdfs/1999/Moller-1999-EBA.pdf
 	float3x3 r;
@@ -184,7 +184,7 @@ float3x3 float3x3::FromEulerXYX(float x2, float y, float x)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerXYX(r, x2, y, x);
-	assume(r.Equals(float3x3::RotateX(x2) * float3x3::RotateY(y) * float3x3::RotateX(x)));
+	mgl_assume(r.Equals(float3x3::RotateX(x2) * float3x3::RotateY(y) * float3x3::RotateX(x)));
 	return r;
 }
 
@@ -192,7 +192,7 @@ float3x3 float3x3::FromEulerXZX(float x2, float z, float x)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerXZX(r, x2, z, x);
-	assume(r.Equals(float3x3::RotateX(x2) * float3x3::RotateZ(z) * float3x3::RotateX(x)));
+	mgl_assume(r.Equals(float3x3::RotateX(x2) * float3x3::RotateZ(z) * float3x3::RotateX(x)));
 	return r;
 }
 
@@ -200,7 +200,7 @@ float3x3 float3x3::FromEulerYXY(float y2, float x, float y)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerYXY(r, y2, x, y);
-	assume(r.Equals(float3x3::RotateY(y2) * float3x3::RotateX(x) * float3x3::RotateY(y)));
+	mgl_assume(r.Equals(float3x3::RotateY(y2) * float3x3::RotateX(x) * float3x3::RotateY(y)));
 	return r;
 }
 
@@ -208,7 +208,7 @@ float3x3 float3x3::FromEulerYZY(float y2, float z, float y)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerYZY(r, y2, z, y);
-	assume(r.Equals(float3x3::RotateY(y2) * float3x3::RotateZ(z) * float3x3::RotateY(y)));
+	mgl_assume(r.Equals(float3x3::RotateY(y2) * float3x3::RotateZ(z) * float3x3::RotateY(y)));
 	return r;
 }
 
@@ -216,7 +216,7 @@ float3x3 float3x3::FromEulerZXZ(float z2, float x, float z)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerZXZ(r, z2, x, z);
-	assume(r.Equals(float3x3::RotateZ(z2) * float3x3::RotateX(x) * float3x3::RotateZ(z)));
+	mgl_assume(r.Equals(float3x3::RotateZ(z2) * float3x3::RotateX(x) * float3x3::RotateZ(z)));
 	return r;
 }
 
@@ -224,7 +224,7 @@ float3x3 float3x3::FromEulerZYZ(float z2, float y, float z)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerZYZ(r, z2, y, z);
-	assume(r.Equals(float3x3::RotateZ(z2) * float3x3::RotateY(y) * float3x3::RotateZ(z)));
+	mgl_assume(r.Equals(float3x3::RotateZ(z2) * float3x3::RotateY(y) * float3x3::RotateZ(z)));
 	return r;
 }
 
@@ -232,7 +232,7 @@ float3x3 float3x3::FromEulerXYZ(float x, float y, float z)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerXYZ(r, x, y, z);
-	assume(r.Equals(float3x3::RotateX(x) * float3x3::RotateY(y) * float3x3::RotateZ(z)));
+	mgl_assume(r.Equals(float3x3::RotateX(x) * float3x3::RotateY(y) * float3x3::RotateZ(z)));
 	return r;
 }
 
@@ -240,7 +240,7 @@ float3x3 float3x3::FromEulerXZY(float x, float z, float y)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerXZY(r, x, z, y);
-	assume(r.Equals(float3x3::RotateX(x) * float3x3::RotateZ(z) * float3x3::RotateY(y)));
+	mgl_assume(r.Equals(float3x3::RotateX(x) * float3x3::RotateZ(z) * float3x3::RotateY(y)));
 	return r;
 }
 
@@ -248,7 +248,7 @@ float3x3 float3x3::FromEulerYXZ(float y, float x, float z)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerYXZ(r, y, x, z);
-	assume(r.Equals(float3x3::RotateY(y) * float3x3::RotateX(x) * float3x3::RotateZ(z)));
+	mgl_assume(r.Equals(float3x3::RotateY(y) * float3x3::RotateX(x) * float3x3::RotateZ(z)));
 	return r;
 }
 
@@ -256,7 +256,7 @@ float3x3 float3x3::FromEulerYZX(float y, float z, float x)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerYZX(r, y, z, x);
-	assume(r.Equals(float3x3::RotateY(y) * float3x3::RotateZ(z) * float3x3::RotateX(x)));
+	mgl_assume(r.Equals(float3x3::RotateY(y) * float3x3::RotateZ(z) * float3x3::RotateX(x)));
 	return r;
 }
 
@@ -264,7 +264,7 @@ float3x3 float3x3::FromEulerZXY(float z, float x, float y)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerZXY(r, z, x, y);
-	assume(r.Equals(float3x3::RotateZ(z) * float3x3::RotateX(x) * float3x3::RotateY(y)));
+	mgl_assume(r.Equals(float3x3::RotateZ(z) * float3x3::RotateX(x) * float3x3::RotateY(y)));
 	return r;
 }
 
@@ -272,7 +272,7 @@ float3x3 float3x3::FromEulerZYX(float z, float y, float x)
 {
 	float3x3 r;
 	Set3x3PartRotateEulerZYX(r, z, y, x);
-	assume(r.Equals(float3x3::RotateZ(z) * float3x3::RotateY(y) * float3x3::RotateX(x)));
+	mgl_assume(r.Equals(float3x3::RotateZ(z) * float3x3::RotateY(y) * float3x3::RotateX(x)));
 	return r;
 }
 
@@ -303,8 +303,8 @@ float3 float3x3::GetScale() const
 
 float3x3 float3x3::ShearX(float yFactor, float zFactor)
 {
-	assume(MATH_NS::IsFinite(yFactor));
-	assume(MATH_NS::IsFinite(zFactor));
+	mgl_assume(MATH_NS::IsFinite(yFactor));
+	mgl_assume(MATH_NS::IsFinite(zFactor));
 	return float3x3(1.f, yFactor, zFactor,
 	                0.f,     1.f,     0.f,
 	                0.f,     0.f,     1.f);
@@ -312,8 +312,8 @@ float3x3 float3x3::ShearX(float yFactor, float zFactor)
 
 float3x3 float3x3::ShearY(float xFactor, float zFactor)
 {
-	assume(MATH_NS::IsFinite(xFactor));
-	assume(MATH_NS::IsFinite(zFactor));
+	mgl_assume(MATH_NS::IsFinite(xFactor));
+	mgl_assume(MATH_NS::IsFinite(zFactor));
 	return float3x3(1.f,     0.f,     0.f,
 	                xFactor, 1.f, zFactor,
 	                0.f,     0.f,     1.f);
@@ -321,8 +321,8 @@ float3x3 float3x3::ShearY(float xFactor, float zFactor)
 
 float3x3 float3x3::ShearZ(float xFactor, float yFactor)
 {
-	assume(MATH_NS::IsFinite(xFactor));
-	assume(MATH_NS::IsFinite(yFactor));
+	mgl_assume(MATH_NS::IsFinite(xFactor));
+	mgl_assume(MATH_NS::IsFinite(yFactor));
 	return float3x3(1.f,         0.f, 0.f,
 	                0.f,         1.f, 0.f,
 	                xFactor, yFactor, 1.f);
@@ -330,7 +330,7 @@ float3x3 float3x3::ShearZ(float xFactor, float yFactor)
 
 float3x3 float3x3::Mirror(const Plane &p)
 {
-	assume(p.PassesThroughOrigin() && "A 3x3 matrix cannot represent mirroring about planes which do not pass through the origin! Use float3x4::Mirror instead!");
+	mgl_assume(p.PassesThroughOrigin() && "A 3x3 matrix cannot represent mirroring about planes which do not pass through the origin! Use float3x4::Mirror instead!");
 	float3x3 v;
 	SetMatrix3x3LinearPlaneMirror(v, p.normal.x, p.normal.y, p.normal.z);
 	return v;
@@ -338,8 +338,8 @@ float3x3 float3x3::Mirror(const Plane &p)
 
 float3x3 float3x3::OrthographicProjection(const Plane &p)
 {
-	assume(p.normal.IsNormalized());
-	assume(p.PassesThroughOrigin() && "A 3x3 matrix cannot represent projection onto planes which do not pass through the origin! Use float3x4::OrthographicProjection instead!");
+	mgl_assume(p.normal.IsNormalized());
+	mgl_assume(p.PassesThroughOrigin() && "A 3x3 matrix cannot represent projection onto planes which do not pass through the origin! Use float3x4::OrthographicProjection instead!");
 	float3x3 v;
 	SetMatrix3x3LinearPlaneProject(v, p.normal.x, p.normal.y, p.normal.z);
 	return v;
@@ -368,10 +368,10 @@ float3x3 float3x3::OrthographicProjectionXY()
 
 float &float3x3::At(int row, int col)
 {
-	assume(row >= 0);
-	assume(row < Rows);
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 
 #ifdef MATH_COLMAJOR_MATRICES
 	return v[col][row];
@@ -382,10 +382,10 @@ float &float3x3::At(int row, int col)
 
 CONST_WIN32 float float3x3::At(int row, int col) const
 {
-	assume(row >= 0);
-	assume(row < Rows);
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 
 #ifdef MATH_COLMAJOR_MATRICES
 	return v[col][row];
@@ -397,44 +397,44 @@ CONST_WIN32 float float3x3::At(int row, int col) const
 #ifdef MATH_COLMAJOR_MATRICES
 float3 &float3x3::Col(int col)
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	return reinterpret_cast<float3 &>(v[col]);
 }
 
 const float3 &float3x3::Col(int col) const
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	return reinterpret_cast<const float3 &>(v[col]);
 }
 
 CONST_WIN32 float3 float3x3::Row(int row) const
 {
-	assume(row >= 0);
-	assume(row < Rows);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
 	return float3(At(row, 0), At(row, 1), At(row, 2));
 }
 
 #else
 float3 &float3x3::Row(int row)
 {
-	assume(row >= 0);
-	assume(row < Rows);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
 	return reinterpret_cast<float3 &>(v[row]);
 }
 
 const float3 &float3x3::Row(int row) const
 {
-	assume(row >= 0);
-	assume(row < Rows);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
 	return reinterpret_cast<const float3 &>(v[row]);
 }
 
 CONST_WIN32 float3 float3x3::Col(int col) const
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	return float3(At(0, col), At(1, col), At(2, col));
 }
 #endif
@@ -446,9 +446,9 @@ CONST_WIN32 float3 float3x3::Diagonal() const
 
 void float3x3::ScaleRow(int row, float scalar)
 {
-	assume(row >= 0);
-	assume(row < Rows);
-	assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
+	mgl_assume(MATH_NS::IsFinite(scalar));
 	At(row, 0) *= scalar;
 	At(row, 1) *= scalar;
 	At(row, 2) *= scalar;
@@ -456,8 +456,8 @@ void float3x3::ScaleRow(int row, float scalar)
 
 void float3x3::ScaleCol(int col, float scalar)
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	At(0, col) *= scalar;
 	At(1, col) *= scalar;
 	At(2, col) *= scalar;
@@ -480,11 +480,11 @@ float3 float3x3::WorldZ() const
 
 void float3x3::SetRow(int row, float x, float y, float z)
 {
-	assume(row >= 0);
-	assume(row < Rows);
-	assume(MATH_NS::IsFinite(x));
-	assume(MATH_NS::IsFinite(y));
-	assume(MATH_NS::IsFinite(z));
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
+	mgl_assume(MATH_NS::IsFinite(x));
+	mgl_assume(MATH_NS::IsFinite(y));
+	mgl_assume(MATH_NS::IsFinite(z));
 	At(row, 0) = x;
 	At(row, 1) = y;
 	At(row, 2) = z;
@@ -497,17 +497,17 @@ void float3x3::SetRow(int row, const float3 &rowVector)
 
 void float3x3::SetRow(int row, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	SetRow(row, data[0], data[1], data[2]);
 }
 
 void float3x3::SetCol(int column, float x, float y, float z)
 {
-	assume(column >= 0);
-	assume(column < Cols);
-	assume(MATH_NS::IsFinite(x));
-	assume(MATH_NS::IsFinite(y));
-	assume(MATH_NS::IsFinite(z));
+	mgl_assume(column >= 0);
+	mgl_assume(column < Cols);
+	mgl_assume(MATH_NS::IsFinite(x));
+	mgl_assume(MATH_NS::IsFinite(y));
+	mgl_assume(MATH_NS::IsFinite(z));
 	At(0, column) = x;
 	At(1, column) = y;
 	At(2, column) = z;
@@ -520,7 +520,7 @@ void float3x3::SetCol(int column, const float3 &columnVector)
 
 void float3x3::SetCol(int column, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	SetCol(column, data[0], data[1], data[2]);
 }
 
@@ -540,14 +540,14 @@ void float3x3::Set(const float3x3 &rhs)
 
 void float3x3::Set(const float *values)
 {
-	assume(values);
+	mgl_assume(values);
 	memcpy(this, values, sizeof(float)*9);
 }
 
 void float3x3::Set(int row, int col, float value)
 {
-	assume(0 <= row && row <= 2);
-	assume(0 <= col && col <= 2);
+	mgl_assume(0 <= row && row <= 2);
+	mgl_assume(0 <= col && col <= 2);
 	At(row, col) = value;
 }
 
@@ -560,10 +560,10 @@ void float3x3::SetIdentity()
 
 void float3x3::SwapColumns(int col1, int col2)
 {
-	assume(col1 >= 0);
-	assume(col1 < Cols);
-	assume(col2 >= 0);
-	assume(col2 < Cols);
+	mgl_assume(col1 >= 0);
+	mgl_assume(col1 < Cols);
+	mgl_assume(col2 >= 0);
+	mgl_assume(col2 < Cols);
 	Swap(At(0, col1), At(0, col2));
 	Swap(At(1, col1), At(1, col2));
 	Swap(At(2, col1), At(2, col2));
@@ -571,10 +571,10 @@ void float3x3::SwapColumns(int col1, int col2)
 
 void float3x3::SwapRows(int row1, int row2)
 {
-	assume(row1 >= 0);
-	assume(row1 < Rows);
-	assume(row2 >= 0);
-	assume(row2 < Rows);
+	mgl_assume(row1 >= 0);
+	mgl_assume(row1 < Rows);
+	mgl_assume(row2 >= 0);
+	mgl_assume(row2 < Rows);
 	Swap(At(row1, 0), At(row2, 0));
 	Swap(At(row1, 1), At(row2, 1));
 	Swap(At(row1, 2), At(row2, 2));
@@ -608,16 +608,16 @@ void float3x3::SetRotatePart(const Quat &q)
 float3x3 float3x3::LookAt(const float3 &localForward, const float3 &targetDirection, const float3 &localUp, const float3 &worldUp)
 {
 	// The user must have inputted proper normalized input direction vectors.
-	assume(localForward.IsNormalized());
-	assume(targetDirection.IsNormalized());
-	assume(localUp.IsNormalized());
-	assume(worldUp.IsNormalized());
+	mgl_assume(localForward.IsNormalized());
+	mgl_assume(targetDirection.IsNormalized());
+	mgl_assume(localUp.IsNormalized());
+	mgl_assume(worldUp.IsNormalized());
 
 	// In the local space, the forward and up directions must be perpendicular to be well-formed.
-	assume(localForward.IsPerpendicular(localUp));
+	mgl_assume(localForward.IsPerpendicular(localUp));
 
 	// In the world space, the targetDirection and worldUp cannot be degenerate (collinear)
-	assume(!targetDirection.Cross(worldUp).IsZero() && "Passed a degenerate coordinate frame to look towards in float3x3::LookAt!");
+	mgl_assume(!targetDirection.Cross(worldUp).IsZero() && "Passed a degenerate coordinate frame to look towards in float3x3::LookAt!");
 
 	// Generate the third basis vector in the local space.
 	float3 localRight = localUp.Cross(localForward).Normalized();
@@ -693,7 +693,7 @@ float3x3 &float3x3::operator =(const float3x3 &rhs)
 
 float float3x3::Determinant() const
 {
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	const float a = v[0][0];
 	const float b = v[0][1];
 	const float c = v[0][2];
@@ -714,7 +714,7 @@ float float3x3::Determinant() const
 
 float float3x3::DeterminantSymmetric() const
 {
-	assume(IsSymmetric());
+	mgl_assume(IsSymmetric());
 	const float a = v[0][0];
 	const float b = v[0][1];
 	const float c = v[0][2];
@@ -815,8 +815,8 @@ bool float3x3::InverseFast(float epsilon)
 #ifdef MATH_ASSERT_CORRECTNESS
 	float3x3 id = orig * i;
 	float3x3 id2 = i * orig;
-	mathassert(id.IsIdentity(0.5f));
-	mathassert(id2.IsIdentity(0.5f));
+	mgl_mathassert(id.IsIdentity(0.5f));
+	mgl_mathassert(id2.IsIdentity(0.5f));
 #endif
 
 	*this = i;
@@ -942,7 +942,7 @@ bool float3x3::InverseColOrthogonal()
 #ifdef MATH_ASSERT_CORRECTNESS
 	float3x3 orig = *this;
 #endif
-	assume(IsColOrthogonal());
+	mgl_assume(IsColOrthogonal());
 	float s1 = float3(At(0, 0), At(1, 0), At(2, 0)).LengthSq();
 	float s2 = float3(At(0, 1), At(1, 1), At(2, 1)).LengthSq();
 	float s3 = float3(At(0, 2), At(1, 2), At(2, 2)).LengthSq();
@@ -959,8 +959,8 @@ bool float3x3::InverseColOrthogonal()
 	At(1, 0) *= s2; At(1, 1) *= s2; At(1, 2) *= s2;
 	At(2, 0) *= s3; At(2, 1) *= s3; At(2, 2) *= s3;
 
-	mathassert(!orig.IsInvertible()|| (orig * *this).IsIdentity());
-	mathassert(IsRowOrthogonal());
+	mgl_mathassert(!orig.IsInvertible()|| (orig * *this).IsIdentity());
+	mgl_mathassert(IsRowOrthogonal());
 
 	return true;
 }
@@ -970,8 +970,8 @@ bool float3x3::InverseOrthogonalUniformScale()
 #ifdef MATH_ASSERT_CORRECTNESS
 	float3x3 orig = *this;
 #endif
-	assume(IsColOrthogonal());
-	assume(HasUniformScale());
+	mgl_assume(IsColOrthogonal());
+	mgl_assume(HasUniformScale());
 	float scale = float3(At(0, 0), At(1, 0), At(2, 0)).LengthSq();
 	if (scale < 1e-8f)
 		return false;
@@ -984,11 +984,11 @@ bool float3x3::InverseOrthogonalUniformScale()
 	At(1, 0) *= scale; At(1, 1) *= scale; At(1, 2) *= scale;
 	At(2, 0) *= scale; At(2, 1) *= scale; At(2, 2) *= scale;
 
-	assume(IsFinite());
-	assume(IsColOrthogonal());
-	assume(HasUniformScale());
+	mgl_assume(IsFinite());
+	mgl_assume(IsColOrthogonal());
+	mgl_assume(HasUniformScale());
 
-	mathassert(!orig.IsInvertible()|| (orig * *this).IsIdentity());
+	mgl_mathassert(!orig.IsInvertible()|| (orig * *this).IsIdentity());
 
 	return true;
 }
@@ -998,14 +998,14 @@ void float3x3::InverseOrthonormal()
 #ifdef MATH_ASSERT_CORRECTNESS
 	float3x3 orig = *this;
 #endif
-	assume(IsOrthonormal());
+	mgl_assume(IsOrthonormal());
 	Transpose();
-	mathassert(!orig.IsInvertible()|| (orig * *this).IsIdentity());
+	mgl_mathassert(!orig.IsInvertible()|| (orig * *this).IsIdentity());
 }
 
 bool float3x3::InverseSymmetric()
 {
-	assume(IsSymmetric());
+	mgl_assume(IsSymmetric());
 	const float a = v[0][0];
 	const float b = v[0][1];
 	const float c = v[0][2];
@@ -1079,8 +1079,8 @@ float float3x3::Trace() const
 
 void float3x3::Orthonormalize(int c0, int c1, int c2)
 {
-	assume(c0 != c1 && c0 != c2 && c1 != c2);
-	assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
+	mgl_assume(c0 != c1 && c0 != c2 && c1 != c2);
+	mgl_assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
 	///@todo Optimize away copies.
 	float3 v0 = Col(c0);
 	float3 v1 = Col(c1);
@@ -1093,7 +1093,7 @@ void float3x3::Orthonormalize(int c0, int c1, int c2)
 
 void float3x3::RemoveScale()
 {
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 #ifdef MATH_COLMAJOR_MATRICES
 	float3 row0 = Row(0);
 	float3 row1 = Row(1);
@@ -1106,7 +1106,7 @@ void float3x3::RemoveScale()
 	float y = Row(1).Normalize();
 	float z = Row(2).Normalize();
 #endif
-	assume(x != 0 && y != 0 && z != 0 && "float3x3::RemoveScale failed!");
+	mgl_assume(x != 0 && y != 0 && z != 0 && "float3x3::RemoveScale failed!");
 	MARK_UNUSED(x);
 	MARK_UNUSED(y);
 	MARK_UNUSED(z);
@@ -1152,15 +1152,15 @@ float4 float3x3::Transform(const float4 &vector) const
 
 void float3x3::BatchTransform(float3 *pointArray, int numPoints) const
 {
-	assume(pointArray || numPoints == 0);
+	mgl_assume(pointArray || numPoints == 0);
 	for(int i = 0; i < numPoints; ++i)
 		pointArray[i] = *this * pointArray[i];
 }
 
 void float3x3::BatchTransform(float3 *pointArray, int numPoints, int stride) const
 {
-	assume(pointArray || numPoints == 0);
-	assume(stride >= (int)sizeof(float3));
+	mgl_assume(pointArray || numPoints == 0);
+	mgl_assume(stride >= (int)sizeof(float3));
 	u8 *data = reinterpret_cast<u8*>(pointArray);
 	for(int i = 0; i < numPoints; ++i)
 	{
@@ -1171,15 +1171,15 @@ void float3x3::BatchTransform(float3 *pointArray, int numPoints, int stride) con
 
 void float3x3::BatchTransform(float4 *vectorArray, int numVectors) const
 {
-	assume(vectorArray || numVectors == 0);
+	mgl_assume(vectorArray || numVectors == 0);
 	for(int i = 0; i < numVectors; ++i)
 		vectorArray[i] = *this * vectorArray[i];
 }
 
 void float3x3::BatchTransform(float4 *vectorArray, int numVectors, int stride) const
 {
-	assume(vectorArray || numVectors == 0);
-	assume(stride >= (int)sizeof(float4));
+	mgl_assume(vectorArray || numVectors == 0);
+	mgl_assume(stride >= (int)sizeof(float4));
 	u8 *data = reinterpret_cast<u8*>(vectorArray);
 	for(int i = 0; i < numVectors; ++i)
 	{
@@ -1190,8 +1190,8 @@ void float3x3::BatchTransform(float4 *vectorArray, int numVectors, int stride) c
 
 float3x3 float3x3::operator *(const float3x3 &rhs) const
 {
-	assume(IsFinite());
-	assume(rhs.IsFinite());
+	mgl_assume(IsFinite());
+	mgl_assume(rhs.IsFinite());
 	float3x3 r;
 	r[0][0] = At(0, 0) * rhs.At(0, 0) + At(0, 1) * rhs.At(1, 0) + At(0, 2) * rhs.At(2, 0);
 	r[0][1] = At(0, 0) * rhs.At(0, 1) + At(0, 1) * rhs.At(1, 1) + At(0, 2) * rhs.At(2, 1);
@@ -1267,7 +1267,7 @@ float3x3 float3x3::operator -() const
 
 float3x3 &float3x3::operator *=(float scalar)
 {
-	assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(MATH_NS::IsFinite(scalar));
 	for(int y = 0; y < Rows; ++y)
 		for(int x = 0; x < Cols; ++x)
 			v[y][x] *= scalar;
@@ -1277,8 +1277,8 @@ float3x3 &float3x3::operator *=(float scalar)
 
 float3x3 &float3x3::operator /=(float scalar)
 {
-	assume(MATH_NS::IsFinite(scalar));
-	assume(!EqualAbs(scalar, 0));
+	mgl_assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(!EqualAbs(scalar, 0));
 	float invScalar = 1.f / scalar;
 	for(int y = 0; y < Rows; ++y)
 		for(int x = 0; x < Cols; ++x)
@@ -1289,7 +1289,7 @@ float3x3 &float3x3::operator /=(float scalar)
 
 float3x3 &float3x3::operator +=(const float3x3 &rhs)
 {
-	assume(rhs.IsFinite());
+	mgl_assume(rhs.IsFinite());
 	for(int y = 0; y < Rows; ++y)
 		for(int x = 0; x < Cols; ++x)
 			At(y, x) += rhs[y][x];
@@ -1299,7 +1299,7 @@ float3x3 &float3x3::operator +=(const float3x3 &rhs)
 
 float3x3 &float3x3::operator -=(const float3x3 &rhs)
 {
-	assume(rhs.IsFinite());
+	mgl_assume(rhs.IsFinite());
 	for(int y = 0; y < Rows; ++y)
 		for(int x = 0; x < Cols; ++x)
 			At(y, x) -= rhs[y][x];
@@ -1344,7 +1344,7 @@ bool float3x3::IsInvertible(float epsilon) const
 {
 	float d = Determinant();
 	bool isSingular = EqualAbs(d, 0.f, epsilon);
-	mathassert(float3x3(*this).Inverse(epsilon) != isSingular); // IsInvertible() and Inverse() must match!
+	mgl_mathassert(float3x3(*this).Inverse(epsilon) != isSingular); // IsInvertible() and Inverse() must match!
 	return !isSingular;
 }
 
@@ -1435,7 +1435,7 @@ StringT float3x3::SerializeToString() const
 	s = SerializeFloat(At(2, 0), s); *s = ','; ++s;
 	s = SerializeFloat(At(2, 1), s); *s = ','; ++s;
 	s = SerializeFloat(At(2, 2), s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -1472,33 +1472,33 @@ float3 float3x3::ExtractScale() const
 
 void float3x3::Decompose(Quat &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal());
+	mgl_assume(this->IsColOrthogonal());
 
 	float3x3 r;
 	Decompose(r, scale);
 	rotate = Quat(r);
 
 	// Test that composing back yields the original float3x3.
-	assume(float3x3::FromRS(rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float3x3::FromRS(rotate, scale).Equals(*this, 0.1f));
 }
 
 void float3x3::Decompose(float3x3 &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal());
+	mgl_assume(this->IsColOrthogonal());
 
 	rotate = *this;
 	scale.x = rotate.Col(0).Length();
 	scale.y = rotate.Col(1).Length();
 	scale.z = rotate.Col(2).Length();
-	assume(!EqualAbs(scale.x, 0));
-	assume(!EqualAbs(scale.y, 0));
-	assume(!EqualAbs(scale.z, 0));
+	mgl_assume(!EqualAbs(scale.x, 0));
+	mgl_assume(!EqualAbs(scale.y, 0));
+	mgl_assume(!EqualAbs(scale.z, 0));
 	rotate.ScaleCol(0, 1.f / scale.x);
 	rotate.ScaleCol(1, 1.f / scale.y);
 	rotate.ScaleCol(2, 1.f / scale.z);
 
 	// Test that composing back yields the original float3x3.
-	assume(float3x3::FromRS(rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float3x3::FromRS(rotate, scale).Equals(*this, 0.1f));
 }
 
 #ifdef MATH_ENABLE_STL_SUPPORT
@@ -1529,7 +1529,7 @@ float3 operator *(const float3 &lhs, const float3x3 &rhs)
 
 float4 operator *(const float4 &lhs, const float3x3 &rhs)
 {
-	assume(lhs.IsWZeroOrOne());
+	mgl_assume(lhs.IsWZeroOrOne());
 	return float4(rhs.TransformLeft(lhs.xyz()), lhs.w);
 }
 

--- a/src/Math/float3x3.h
+++ b/src/Math/float3x3.h
@@ -290,8 +290,8 @@ public:
 	 	whether MATH_COLMAJOR_MATRICES is set, i.e. the notation is always m[y][x]. */
 	FORCE_INLINE MatrixProxy<Rows, Cols> &operator[](int row)
 	{
-		assume(row >= 0);
-		assume(row < Rows);
+		mgl_assume(row >= 0);
+		mgl_assume(row < Rows);
 		
 #ifdef MATH_COLMAJOR_MATRICES
 		return *(reinterpret_cast<MatrixProxy<Rows, Cols>*>(&v[0][row]));
@@ -302,8 +302,8 @@ public:
 	
 	FORCE_INLINE const MatrixProxy<Rows, Cols> &operator[](int row) const
 	{
-		assume(row >= 0);
-		assume(row < Rows);
+		mgl_assume(row >= 0);
+		mgl_assume(row < Rows);
 		
 #ifdef MATH_COLMAJOR_MATRICES
 		return *(reinterpret_cast<const MatrixProxy<Rows, Cols>*>(&v[0][row]));
@@ -733,13 +733,13 @@ public:
 	float3 MulPos(const float3 &rhs) const { return Mul(rhs); }
 	float4 MulPos(const float4 &rhs) const
 	{
-		assume(!EqualAbs(rhs.w, 0.f));
+		mgl_assume(!EqualAbs(rhs.w, 0.f));
 		return Mul(rhs);
 	}
 	float3 MulDir(const float3 &rhs) const { return Mul(rhs); }
 	float4 MulDir(const float4 &rhs) const
 	{
-		assume(EqualAbs(rhs.w, 0.f));
+		mgl_assume(EqualAbs(rhs.w, 0.f));
 		return Mul(rhs);
 	}
 };

--- a/src/Math/float3x4.cpp
+++ b/src/Math/float3x4.cpp
@@ -150,8 +150,8 @@ float3x4 float3x4::RotateAxisAngle(const float3 &axisDirection, float angleRadia
 
 float3x4 float3x4::RotateFromTo(const float3 &sourceDirection, const float3 &targetDirection)
 {
-	assume(sourceDirection.IsNormalized());
-	assume(targetDirection.IsNormalized());
+	mgl_assume(sourceDirection.IsNormalized());
+	mgl_assume(targetDirection.IsNormalized());
 	float3x4 r;
 	r.SetRotatePart(Quat::RotateFromTo(sourceDirection, targetDirection));
 	r.SetTranslatePart(0, 0, 0);
@@ -219,7 +219,7 @@ float3x4 float3x4::FromEulerXYX(float x2, float y, float x)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerXYX(r, x2, y, x);
-	assume(r.Equals(float3x4::RotateX(x2) * float3x4::RotateY(y) * float3x4::RotateX(x)));
+	mgl_assume(r.Equals(float3x4::RotateX(x2) * float3x4::RotateY(y) * float3x4::RotateX(x)));
 	return r;
 }
 
@@ -228,7 +228,7 @@ float3x4 float3x4::FromEulerXZX(float x2, float z, float x)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerXZX(r, x2, z, x);
-	assume(r.Equals(float3x4::RotateX(x2) * float3x4::RotateZ(z) * float3x4::RotateX(x)));
+	mgl_assume(r.Equals(float3x4::RotateX(x2) * float3x4::RotateZ(z) * float3x4::RotateX(x)));
 	return r;
 }
 
@@ -237,7 +237,7 @@ float3x4 float3x4::FromEulerYXY(float y2, float x, float y)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerYXY(r, y2, x, y);
-	assume(r.Equals(float3x4::RotateY(y2) * float3x4::RotateX(x) * float3x4::RotateY(y)));
+	mgl_assume(r.Equals(float3x4::RotateY(y2) * float3x4::RotateX(x) * float3x4::RotateY(y)));
 	return r;
 }
 
@@ -246,7 +246,7 @@ float3x4 float3x4::FromEulerYZY(float y2, float z, float y)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerYZY(r, y2, z, y);
-	assume(r.Equals(float3x4::RotateY(y2) * float3x4::RotateZ(z) * float3x4::RotateY(y)));
+	mgl_assume(r.Equals(float3x4::RotateY(y2) * float3x4::RotateZ(z) * float3x4::RotateY(y)));
 	return r;
 }
 
@@ -255,7 +255,7 @@ float3x4 float3x4::FromEulerZXZ(float z2, float x, float z)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerZXZ(r, z2, x, z);
-	assume(r.Equals(float3x4::RotateZ(z2) * float3x4::RotateX(x) * float3x4::RotateZ(z)));
+	mgl_assume(r.Equals(float3x4::RotateZ(z2) * float3x4::RotateX(x) * float3x4::RotateZ(z)));
 	return r;
 }
 
@@ -264,7 +264,7 @@ float3x4 float3x4::FromEulerZYZ(float z2, float y, float z)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerZYZ(r, z2, y, z);
-	assume(r.Equals(float3x4::RotateZ(z2) * float3x4::RotateY(y) * float3x4::RotateZ(z)));
+	mgl_assume(r.Equals(float3x4::RotateZ(z2) * float3x4::RotateY(y) * float3x4::RotateZ(z)));
 	return r;
 }
 
@@ -273,7 +273,7 @@ float3x4 float3x4::FromEulerXYZ(float x, float y, float z)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerXYZ(r, x, y, z);
-	assume(r.Equals(float3x4::RotateX(x) * float3x4::RotateY(y) * float3x4::RotateZ(z)));
+	mgl_assume(r.Equals(float3x4::RotateX(x) * float3x4::RotateY(y) * float3x4::RotateZ(z)));
 	return r;
 }
 
@@ -282,7 +282,7 @@ float3x4 float3x4::FromEulerXZY(float x, float z, float y)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerXZY(r, x, z, y);
-	assume(r.Equals(float3x4::RotateX(x) * float3x4::RotateZ(z) * float3x4::RotateY(y)));
+	mgl_assume(r.Equals(float3x4::RotateX(x) * float3x4::RotateZ(z) * float3x4::RotateY(y)));
 	return r;
 }
 
@@ -291,7 +291,7 @@ float3x4 float3x4::FromEulerYXZ(float y, float x, float z)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerYXZ(r, y, x, z);
-	assume(r.Equals(float3x4::RotateY(y) * float3x4::RotateX(x) * float3x4::RotateZ(z)));
+	mgl_assume(r.Equals(float3x4::RotateY(y) * float3x4::RotateX(x) * float3x4::RotateZ(z)));
 	return r;
 }
 
@@ -300,7 +300,7 @@ float3x4 float3x4::FromEulerYZX(float y, float z, float x)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerYZX(r, y, z, x);
-	assume(r.Equals(float3x4::RotateY(y) * float3x4::RotateZ(z) * float3x4::RotateX(x)));
+	mgl_assume(r.Equals(float3x4::RotateY(y) * float3x4::RotateZ(z) * float3x4::RotateX(x)));
 	return r;
 }
 
@@ -309,7 +309,7 @@ float3x4 float3x4::FromEulerZXY(float z, float x, float y)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerZXY(r, z, x, y);
-	assume(r.Equals(float3x4::RotateZ(z) * float3x4::RotateX(x) * float3x4::RotateY(y)));
+	mgl_assume(r.Equals(float3x4::RotateZ(z) * float3x4::RotateX(x) * float3x4::RotateY(y)));
 	return r;
 }
 
@@ -318,7 +318,7 @@ float3x4 float3x4::FromEulerZYX(float z, float y, float x)
 	float3x4 r;
 	r.SetTranslatePart(0,0,0);
 	Set3x3PartRotateEulerZYX(r, z, y, x);
-	assume(r.Equals(float3x4::RotateZ(z) * float3x4::RotateY(y) * float3x4::RotateX(x)));
+	mgl_assume(r.Equals(float3x4::RotateZ(z) * float3x4::RotateY(y) * float3x4::RotateX(x)));
 	return r;
 }
 
@@ -430,10 +430,10 @@ float3x4 float3x4::OrthographicProjectionXY()
 
 float &float3x4::At(int rowIndex, int colIndex)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 #ifdef MATH_COLMAJOR_MATRICES
 	return v[colIndex][rowIndex];
 #else
@@ -443,10 +443,10 @@ float &float3x4::At(int rowIndex, int colIndex)
 
 const float &float3x4::At(int rowIndex, int colIndex) const
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 #ifdef MATH_COLMAJOR_MATRICES
 	return v[colIndex][rowIndex];
 #else
@@ -457,79 +457,79 @@ const float &float3x4::At(int rowIndex, int colIndex) const
 #ifdef MATH_COLMAJOR_MATRICES
 float3 &float3x4::Col(int col)
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	
 	return reinterpret_cast<float3 &>(v[col]);
 }
 
 const float3 &float3x4::Col(int col) const
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	
 	return reinterpret_cast<const float3 &>(v[col]);
 }
 
 float3 &float3x4::Col3(int col)
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	
 	return reinterpret_cast<float3 &>(v[col]);
 }
 
 const float3 &float3x4::Col3(int col) const
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	
 	return reinterpret_cast<const float3 &>(v[col]);
 }
 
 CONST_WIN32 float4 float3x4::Row(int row) const
 {
-	assume(row >= 0);
-	assume(row < Rows);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
 	return float4(At(row, 0), At(row, 1), At(row, 2), At(row, 3));
 }
 #else
 float4 &float3x4::Row(int rowIndex)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 
 	return reinterpret_cast<float4 &>(v[rowIndex]);
 }
 
 const float4 &float3x4::Row(int rowIndex) const
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 
 	return reinterpret_cast<const float4 &>(v[rowIndex]);
 }
 
 float3 &float3x4::Row3(int rowIndex)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 
 	return reinterpret_cast<float3 &>(v[rowIndex]);
 }
 
 const float3 &float3x4::Row3(int rowIndex) const
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 
 	return reinterpret_cast<const float3 &>(v[rowIndex]);
 }
 
 CONST_WIN32 float3 float3x4::Col(int colIndex) const
 {
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 	return float3(At(0, colIndex), At(1, colIndex), At(2, colIndex));
 }
 #endif
@@ -560,9 +560,9 @@ void float3x4::ScaleRow(int r, float scalar)
 
 void float3x4::ScaleCol(int colIndex, float scalar)
 {
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
-	assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
+	mgl_assume(MATH_NS::IsFinite(scalar));
 
 	At(0, colIndex) *= scalar;
 	At(1, colIndex) *= scalar;
@@ -603,12 +603,12 @@ float3 float3x4::WorldZ() const
 
 void float3x4::SetRow(int row, float m_r0, float m_r1, float m_r2, float m_r3)
 {
-	assume(row >= 0);
-	assume(row < Rows);
-	assume(MATH_NS::IsFinite(m_r0));
-	assume(MATH_NS::IsFinite(m_r1));
-	assume(MATH_NS::IsFinite(m_r2));
-	assume(MATH_NS::IsFinite(m_r3));
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
+	mgl_assume(MATH_NS::IsFinite(m_r0));
+	mgl_assume(MATH_NS::IsFinite(m_r1));
+	mgl_assume(MATH_NS::IsFinite(m_r2));
+	mgl_assume(MATH_NS::IsFinite(m_r3));
 
 #ifdef MATH_SIMD
 	this->row[row] = set_ps(m_r3, m_r2, m_r1, m_r0);
@@ -637,7 +637,7 @@ void float3x4::SetRow(int rowIndex, const float4 &rowVector)
 
 void float3x4::SetRow(int rowIndex, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 
 #ifdef MATH_SIMD
 
@@ -649,11 +649,11 @@ void float3x4::SetRow(int rowIndex, const float *data)
 
 void float3x4::SetCol(int column, float m_0c, float m_1c, float m_2c)
 {
-	assume(column >= 0);
-	assume(column < Cols);
-	assume(MATH_NS::IsFinite(m_0c));
-	assume(MATH_NS::IsFinite(m_1c));
-	assume(MATH_NS::IsFinite(m_2c));
+	mgl_assume(column >= 0);
+	mgl_assume(column < Cols);
+	mgl_assume(MATH_NS::IsFinite(m_0c));
+	mgl_assume(MATH_NS::IsFinite(m_1c));
+	mgl_assume(MATH_NS::IsFinite(m_2c));
 	At(0, column) = m_0c;
 	At(1, column) = m_1c;
 	At(2, column) = m_2c;
@@ -666,7 +666,7 @@ void float3x4::SetCol(int column, const float3 &columnVector)
 
 void float3x4::SetCol(int column, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	SetCol(column, data[0], data[1], data[2]);
 }
 
@@ -698,17 +698,17 @@ void float3x4::Set(const float3x4 &rhs)
 
 void float3x4::Set(const float *values)
 {
-	assume(values);
+	mgl_assume(values);
 	float *ptr = (float*)this;
 	memcpy(ptr, values, 12*sizeof(float));
 }
 
 void float3x4::Set(int rowIndex, int colIndex, float value)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 #ifdef MATH_COLMAJOR_MATRICES
 	v[colIndex][rowIndex] = value;
 #else
@@ -725,7 +725,7 @@ void float3x4::SetIdentity()
 
 void float3x4::Set3x3Part(const float3x3 &r)
 {
-	assume(r.IsFinite());
+	mgl_assume(r.IsFinite());
 	At(0, 0) = r[0][0]; At(0, 1) = r[0][1]; At(0, 2) = r[0][2];
 	At(1, 0) = r[1][0]; At(1, 1) = r[1][1]; At(1, 2) = r[1][2];
 	At(2, 0) = r[2][0]; At(2, 1) = r[2][1]; At(2, 2) = r[2][2];
@@ -733,10 +733,10 @@ void float3x4::Set3x3Part(const float3x3 &r)
 
 void float3x4::SwapColumns(int col1, int col2)
 {
-	assume(col1 >= 0);
-	assume(col1 < Cols);
-	assume(col2 >= 0);
-	assume(col2 < Cols);
+	mgl_assume(col1 >= 0);
+	mgl_assume(col1 < Cols);
+	mgl_assume(col2 >= 0);
+	mgl_assume(col2 < Cols);
 	Swap(At(0, col1), At(0, col2));
 	Swap(At(1, col1), At(1, col2));
 	Swap(At(2, col1), At(2, col2));
@@ -744,10 +744,10 @@ void float3x4::SwapColumns(int col1, int col2)
 
 void float3x4::SwapRows(int row1, int row2)
 {
-	assume(row1 >= 0);
-	assume(row1 < Rows);
-	assume(row2 >= 0);
-	assume(row2 < Rows);
+	mgl_assume(row1 >= 0);
+	mgl_assume(row1 < Rows);
+	mgl_assume(row2 >= 0);
+	mgl_assume(row2 < Rows);
 
 #ifdef MATH_SIMD
 	Swap(row[row1], row[row2]);
@@ -815,7 +815,7 @@ float3x4 &float3x4::operator =(const float3x4 &rhs)
 	// to copy around uninitialized matrices.
 	// But note that when assigning through a conversion above (float3x3 -> float3x4),
 	// we do assume the input matrix is finite.
-//	assume(rhs.IsFinite());
+//	mgl_assume(rhs.IsFinite());
 #ifdef MATH_SIMD
 	row[0] = rhs.row[0];
 	row[1] = rhs.row[1];
@@ -849,7 +849,7 @@ float3x4 &float3x4::operator =(const Quat &rhs)
 
 float float3x4::Determinant() const
 {
-	assume(Float3x3Part().IsFinite());
+	mgl_assume(Float3x3Part().IsFinite());
 //#if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	// 0,-2.873479127883911e-1,9.578263163566589e-1,1.1457166820764542e-1,1,0,0,1.101529598236084e-1,0,9.578263163566589e-1,2.873479127883911e-1,0.037929482758045197
 	// TODO: Temporarily disabled for numerical issues. Check this closer and re-enable.
@@ -900,7 +900,7 @@ bool float3x4::InverseColOrthogonal()
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	mat3x4_inverse_colorthogonal(row, row);
 #else
-	assume(IsColOrthogonal());
+	mgl_assume(IsColOrthogonal());
 	float s1 = float3(At(0, 0), At(1, 0), At(2, 0)).LengthSq();
 	float s2 = float3(At(0, 1), At(1, 1), At(2, 1)).LengthSq();
 	float s3 = float3(At(0, 2), At(1, 2), At(2, 2)).LengthSq();
@@ -918,7 +918,7 @@ bool float3x4::InverseColOrthogonal()
 	At(2, 0) *= s3; At(2, 1) *= s3; At(2, 2) *= s3;
 
 	SetTranslatePart(TransformDir(-At(0, 3), -At(1, 3), -At(2, 3)));
-	mathassert(IsRowOrthogonal());
+	mgl_mathassert(IsRowOrthogonal());
 #endif
 	return true;
 }
@@ -929,8 +929,8 @@ bool float3x4::InverseOrthogonalUniformScale()
 	mat3x4_inverse_orthogonal_uniformscale(row, row);
 	return true; ///\todo The return value is difficult here with SSE, figure out how to treat that.
 #else
-	assume(IsColOrthogonal(1e-3f));
-	assume(HasUniformScale());
+	mgl_assume(IsColOrthogonal(1e-3f));
+	mgl_assume(HasUniformScale());
 	Swap(At(0, 1), At(1, 0));
 	Swap(At(0, 2), At(2, 0));
 	Swap(At(1, 2), At(2, 1));
@@ -951,7 +951,7 @@ bool float3x4::InverseOrthogonalUniformScale()
 
 void float3x4::InverseOrthonormal()
 {
-	assume(IsOrthonormal());
+	mgl_assume(IsOrthonormal());
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	mat3x4_inverse_orthonormal(row, row);
@@ -1030,15 +1030,15 @@ float3x4 float3x4::InverseTransposed() const
 
 float float3x4::Trace() const
 {
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	return v[0][0] + v[1][1] + v[2][2];
 }
 
 void float3x4::Orthonormalize(int c0, int c1, int c2)
 {
 	///\todo SSE.
-	assume(c0 != c1 && c0 != c2 && c1 != c2);
-	assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
+	mgl_assume(c0 != c1 && c0 != c2 && c1 != c2);
+	mgl_assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
 
 	///@todo Optimize away copies.
 	float3 v0 = Col(c0);
@@ -1066,7 +1066,7 @@ void float3x4::RemoveScale()
 	float tz = Row3(2).Normalize();
 #endif
 
-	assume(tx != 0 && ty != 0 && tz != 0 && "float3x4::RemoveScale failed!");
+	mgl_assume(tx != 0 && ty != 0 && tz != 0 && "float3x4::RemoveScale failed!");
 	MARK_UNUSED(tx);
 	MARK_UNUSED(ty);
 	MARK_UNUSED(tz);
@@ -1086,7 +1086,7 @@ float2 float3x4::TransformPos(float tx, float ty) const
 #ifdef MATH_SSE
 	return mat3x4_mul_vec(row, set_ps(1.f, 0.f, ty, tx)).xy();
 #else
-	assume(Equal(At(2, 3), 0.f));
+	mgl_assume(Equal(At(2, 3), 0.f));
 	return float2(At(0, 0) * tx + At(0, 1) * ty + At(0, 3),
 	              At(1, 0) * tx + At(1, 1) * ty + At(1, 3));
 #endif
@@ -1153,7 +1153,7 @@ float3 float3x4::TransformDir(float tx, float ty, float tz) const
 
 float4 float3x4::TransformDir(const float4 &directionVector) const
 {
-	assume(EqualAbs(directionVector.w, 0.f));
+	mgl_assume(EqualAbs(directionVector.w, 0.f));
 	return Transform(directionVector);
 }
 
@@ -1171,15 +1171,15 @@ float4 float3x4::Transform(const float4 &vector) const
 
 void float3x4::BatchTransformPos(float3 *pointArray, int numPoints) const
 {
-	assume(pointArray);
+	mgl_assume(pointArray);
 	for(int i = 0; i < numPoints; ++i)
 		pointArray[i] = MulPos(pointArray[i]);
 }
 
 void float3x4::BatchTransformPos(float3 *pointArray, int numPoints, int stride) const
 {
-	assume(pointArray);
-	assume(stride >= (int)sizeof(float3));
+	mgl_assume(pointArray);
+	mgl_assume(stride >= (int)sizeof(float3));
 	u8 *data = reinterpret_cast<u8*>(pointArray);
 	for(int i = 0; i < numPoints; ++i)
 	{
@@ -1190,15 +1190,15 @@ void float3x4::BatchTransformPos(float3 *pointArray, int numPoints, int stride) 
 
 void float3x4::BatchTransformDir(float3 *dirArray, int numVectors) const
 {
-	assume(dirArray);
+	mgl_assume(dirArray);
 	for(int i = 0; i < numVectors; ++i)
 		dirArray[i] = MulPos(dirArray[i]);
 }
 
 void float3x4::BatchTransformDir(float3 *dirArray, int numVectors, int stride) const
 {
-	assume(dirArray);
-	assume(stride >= (int)sizeof(float3));
+	mgl_assume(dirArray);
+	mgl_assume(stride >= (int)sizeof(float3));
 	u8 *data = reinterpret_cast<u8*>(dirArray);
 	for(int i = 0; i < numVectors; ++i)
 	{
@@ -1209,15 +1209,15 @@ void float3x4::BatchTransformDir(float3 *dirArray, int numVectors, int stride) c
 
 void float3x4::BatchTransform(float4 *vectorArray, int numVectors) const
 {
-	assume(vectorArray);
+	mgl_assume(vectorArray);
 	for(int i = 0; i < numVectors; ++i)
 		vectorArray[i] = *this * vectorArray[i];
 }
 
 void float3x4::BatchTransform(float4 *vectorArray, int numVectors, int stride) const
 {
-	assume(vectorArray);
-	assume(stride >= (int)sizeof(float4));
+	mgl_assume(vectorArray);
+	mgl_assume(stride >= (int)sizeof(float4));
 	u8 *data = reinterpret_cast<u8*>(vectorArray);
 	for(int i = 0; i < numVectors; ++i)
 	{
@@ -1303,7 +1303,7 @@ float3x4 float3x4::operator *(float scalar) const
 
 float3x4 float3x4::operator /(float scalar) const
 {
-	assume(!EqualAbs(scalar, 0));
+	mgl_assume(!EqualAbs(scalar, 0));
 
 #ifdef MATH_SIMD
 	float3x4 r;
@@ -1387,7 +1387,7 @@ float3x4 &float3x4::operator *=(float scalar)
 
 float3x4 &float3x4::operator /=(float scalar)
 {
-	assume(!EqualAbs(scalar, 0));
+	mgl_assume(!EqualAbs(scalar, 0));
 
 #ifdef MATH_SIMD
 	simd4f s = set1_ps(scalar);
@@ -1478,7 +1478,7 @@ bool float3x4::IsInvertible(float epsilon) const
 	bool isSingular = EqualAbs(d, 0.f, epsilon);
 #ifdef MATH_ASSERT_CORRECTNESS
 	float3x3 temp = Float3x3Part();
-	mathassert(temp.Inverse(epsilon) != isSingular); // IsInvertible() and Inverse() must match!
+	mgl_mathassert(temp.Inverse(epsilon) != isSingular); // IsInvertible() and Inverse() must match!
 #endif
 	return !isSingular;
 }
@@ -1574,7 +1574,7 @@ StringT float3x4::SerializeToString() const
 	s = SerializeFloat(At(2, 1), s); *s = ','; ++s;
 	s = SerializeFloat(At(2, 2), s); *s = ','; ++s;
 	s = SerializeFloat(At(2, 3), s);
-	assert(s+1 - str < 512);
+	mgl_assert(s+1 - str < 512);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -1595,8 +1595,8 @@ bool IsNeutralCLocale();
 
 float3x4 float3x4::FromString(const char *str, const char **outEndStr)
 {
-	assert(IsNeutralCLocale());
-	assume(str);
+	mgl_assert(IsNeutralCLocale());
+	mgl_assume(str);
 	if (!str)
 		return float3x4::nan;
 	MATH_SKIP_WORD(str, "float3x4");
@@ -1639,39 +1639,39 @@ float3 float3x4::ExtractScale() const
 
 void float3x4::Decompose(float3 &translate, Quat &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal());
+	mgl_assume(this->IsColOrthogonal());
 
 	float3x3 r;
 	Decompose(translate, r, scale);
 	rotate = Quat(r);
 
 	// Test that composing back yields the original float3x4.
-	assume(float3x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float3x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
 }
 
 void float3x4::Decompose(float3 &translate, float3x3 &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal());
+	mgl_assume(this->IsColOrthogonal());
 
 	translate = Col(3);
 	rotate = RotatePart();
 	scale.x = rotate.Col(0).Length();
 	scale.y = rotate.Col(1).Length();
 	scale.z = rotate.Col(2).Length();
-	assume(!EqualAbs(scale.x, 0));
-	assume(!EqualAbs(scale.y, 0));
-	assume(!EqualAbs(scale.z, 0));
+	mgl_assume(!EqualAbs(scale.x, 0));
+	mgl_assume(!EqualAbs(scale.y, 0));
+	mgl_assume(!EqualAbs(scale.z, 0));
 	rotate.ScaleCol(0, 1.f / scale.x);
 	rotate.ScaleCol(1, 1.f / scale.y);
 	rotate.ScaleCol(2, 1.f / scale.z);
 
 	// Test that composing back yields the original float3x4.
-	assume(float3x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float3x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
 }
 
 void float3x4::Decompose(float3 &translate, float3x4 &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal());
+	mgl_assume(this->IsColOrthogonal());
 
 	float3x3 r;
 	Decompose(translate, r, scale);
@@ -1679,7 +1679,7 @@ void float3x4::Decompose(float3 &translate, float3x4 &rotate, float3 &scale) con
 	rotate.SetTranslatePart(0,0,0);
 
 	// Test that composing back yields the original float3x4.
-	assume(float3x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float3x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
 }
 
 #ifdef MATH_ENABLE_STL_SUPPORT
@@ -1718,14 +1718,14 @@ float2 float3x4::MulPos(const float2 &pointVector) const { return this->Transfor
 float3 float3x4::MulPos(const float3 &pointVector) const { return this->TransformPos(pointVector); }
 float4 float3x4::MulPos(const float4 &pointVector) const
 {
-	assume(!EqualAbs(pointVector.w, 0.f));
+	mgl_assume(!EqualAbs(pointVector.w, 0.f));
 	return this->Transform(pointVector);
 }
 float2 float3x4::MulDir(const float2 &directionVector) const { return this->TransformDir(directionVector); }
 float3 float3x4::MulDir(const float3 &directionVector) const { return this->TransformDir(directionVector); }
 float4 float3x4::MulDir(const float4 &directionVector) const
 {
-	assume(EqualAbs(directionVector.w, 0.f));
+	mgl_assume(EqualAbs(directionVector.w, 0.f));
 	return this->TransformDir(directionVector);
 }
 float4 float3x4::Mul(const float4 &vector) const { return *this * vector; }

--- a/src/Math/float3x4.h
+++ b/src/Math/float3x4.h
@@ -317,8 +317,8 @@ public:
 	 	whether MATH_COLMAJOR_MATRICES is set, i.e. the notation is always m[y][x]. */
 	FORCE_INLINE MatrixProxy<Rows, Cols> &operator[](int row)
 	{
-		assume(row >= 0);
-		assume(row < Rows);
+		mgl_assume(row >= 0);
+		mgl_assume(row < Rows);
 #ifdef MATH_COLMAJOR_MATRICES
 		return *(reinterpret_cast<MatrixProxy<Rows, Cols>*>(&v[0][row]));
 #else
@@ -328,8 +328,8 @@ public:
 
 	FORCE_INLINE const MatrixProxy<Rows, Cols> &operator[](int row) const
 	{
-		assume(row >= 0);
-		assume(row < Rows);		
+		mgl_assume(row >= 0);
+		mgl_assume(row < Rows);		
 #ifdef MATH_COLMAJOR_MATRICES
 		return *(reinterpret_cast<const MatrixProxy<Rows, Cols>*>(&v[0][row]));
 #else

--- a/src/Math/float4.cpp
+++ b/src/Math/float4.cpp
@@ -117,7 +117,7 @@ float4::float4(const float2 &xy, const float2 &zw)
 
 float4::float4(const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 #if defined(MATH_AUTOMATIC_SSE)
 	v = loadu_ps(data);
 #else
@@ -323,7 +323,7 @@ float float4::Normalize3()
 	v = vec4_safe_normalize3(v, origLength);
 	return s4f_x(origLength);
 #else
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	float lengthSq = LengthSq3();
 	if (lengthSq > 1e-6f)
 	{
@@ -350,7 +350,7 @@ float4 float4::Normalized3() const
 #else
 	float4 copy = *this;
 	float length = copy.Normalize3();
-	assume(length > 0);
+	mgl_assume(length > 0);
 	MARK_UNUSED(length);
 	return copy;
 #endif
@@ -362,7 +362,7 @@ float float4::Normalize4()
 	simd4f len = Normalize4_SSE();
 	return s4f_x(len);
 #else
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	float lengthSq = LengthSq4();
 	if (lengthSq > 1e-6f)
 	{
@@ -382,7 +382,7 @@ float4 float4::Normalized4() const
 {
 	float4 copy = *this;
 	float length = copy.Normalize4();
-	assume(length > 0);
+	mgl_assume(length > 0);
 	MARK_UNUSED(length);
 	return copy;
 }
@@ -460,7 +460,7 @@ float float4::ScaleToLength3(float newLength)
 
 float4 float4::ScaledToLength3(float newLength) const
 {
-	assume(!IsZero3());
+	mgl_assume(!IsZero3());
 
 	float4 vtx = *this;
 	vtx.ScaleToLength3(newLength);
@@ -516,7 +516,7 @@ StringT float4::SerializeToString() const
 	s = SerializeFloat(y, s); *s = ','; ++s;
 	s = SerializeFloat(z, s); *s = ','; ++s;
 	s = SerializeFloat(w, s);
-	assert(s+1 - str < 256);
+	mgl_assert(s+1 - str < 256);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -529,8 +529,8 @@ StringT float4::SerializeToCodeString() const
 
 float4 float4::FromString(const char *str, const char **outEndStr)
 {
-	assert(IsNeutralCLocale());
-	assume(str);
+	mgl_assert(IsNeutralCLocale());
+	mgl_assume(str);
 	if (!str)
 		return float4::nan;
 	MATH_SKIP_WORD(str, "float4");
@@ -849,8 +849,8 @@ float4 float4::Cross3(const float3 &rhs) const
 float4 float4::Cross3(const float4 &rhs) const
 {
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
-	assert((((uintptr_t)&rhs) & 15) == 0); // For SSE ops we must be 16-byte aligned.
-	assert((((uintptr_t)this) & 15) == 0);
+	mgl_assert((((uintptr_t)&rhs) & 15) == 0); // For SSE ops we must be 16-byte aligned.
+	mgl_assert((((uintptr_t)this) & 15) == 0);
 	return float4(cross_ps(v, rhs.v));
 #else
 	return Cross3(rhs.xyz());
@@ -869,10 +869,10 @@ float4x4 float4::OuterProduct(const float4 &rhs) const
 
 float4 float4::Perpendicular3(const float3 &hint, const float3 &hint2) const
 {
-	assume(!this->IsZero3());
-	assume(EqualAbs(w, 0));
-	assume(hint.IsNormalized());
-	assume(hint2.IsNormalized());
+	mgl_assume(!this->IsZero3());
+	mgl_assume(EqualAbs(w, 0));
+	mgl_assume(hint.IsNormalized());
+	mgl_assume(hint2.IsNormalized());
 	float3 perp = this->Cross3(hint).xyz();
 	float len = perp.Normalize();
 	if (len == 0)
@@ -883,10 +883,10 @@ float4 float4::Perpendicular3(const float3 &hint, const float3 &hint2) const
 
 float4 float4::Perpendicular(const float4 &hint, const float4 &hint2) const
 {
-	assume(!this->IsZero3());
-	assume(EqualAbs(w, 0));
-	assume(hint.IsNormalized());
-	assume(hint2.IsNormalized());
+	mgl_assume(!this->IsZero3());
+	mgl_assume(EqualAbs(w, 0));
+	mgl_assume(hint.IsNormalized());
+	mgl_assume(hint2.IsNormalized());
 	float4 perp = this->Cross(hint);
 	float len = perp.Normalize();
 	if (len == 0)
@@ -930,15 +930,15 @@ float4 float4::RandomPerpendicular(LCG &rng) const
 
 float4 float4::Reflect3(const float3 &normal) const
 {
-	assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
-	assume(EqualAbs(w, 0));
+	mgl_assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
+	mgl_assume(EqualAbs(w, 0));
 	return 2.f * this->ProjectToNorm3(normal) - *this;
 }
 
 float4 float4::Reflect(const float4 &normal) const
 {
-	assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
-	assume(EqualAbs(w, 0));
+	mgl_assume2(normal.IsNormalized(), normal.SerializeToCodeString(), normal.Length());
+	mgl_assume(EqualAbs(w, 0));
 	return 2.f * this->ProjectToNorm(normal) - *this;
 }
 
@@ -967,8 +967,8 @@ float float4::AngleBetween3(const float4 &other) const
 
 float float4::AngleBetweenNorm3(const float4 &other) const
 {
-	assume(this->IsNormalized3());
-	assume(other.IsNormalized3());
+	mgl_assume(this->IsNormalized3());
+	mgl_assume(other.IsNormalized3());
 	return acos(Dot3(other));
 }
 
@@ -985,36 +985,36 @@ float float4::AngleBetween4(const float4 &other) const
 
 float float4::AngleBetweenNorm4(const float4 &other) const
 {
-	assume(this->IsNormalized4());
-	assume(other.IsNormalized4());
+	mgl_assume(this->IsNormalized4());
+	mgl_assume(other.IsNormalized4());
 	return acos(Dot4(other));
 }
 
 float4 float4::ProjectTo3(const float3 &target) const
 {
-	assume(!target.IsZero());
-	assume(this->IsWZeroOrOne());
+	mgl_assume(!target.IsZero());
+	mgl_assume(this->IsWZeroOrOne());
 	return float4(target * MATH_NS::Dot(xyz(), target) / target.LengthSq(), w);
 }
 
 float4 float4::ProjectTo(const float4 &target) const
 {
-	assume(!target.IsZero());
-	assume(this->IsWZeroOrOne());
+	mgl_assume(!target.IsZero());
+	mgl_assume(this->IsWZeroOrOne());
 	return target * (this->Dot(target) / target.LengthSq());
 }
 
 float4 float4::ProjectToNorm3(const float3 &target) const
 {
-	assume(target.IsNormalized());
-	assume(this->IsWZeroOrOne());
+	mgl_assume(target.IsNormalized());
+	mgl_assume(this->IsWZeroOrOne());
 	return float4(target * MATH_NS::Dot(xyz(), target), w);
 }
 
 float4 float4::ProjectToNorm(const float4 &target) const
 {
-	assume(target.IsNormalized());
-	assume(this->IsWZeroOrOne());
+	mgl_assume(target.IsNormalized());
+	mgl_assume(this->IsWZeroOrOne());
 	return target * this->Dot(target);
 }
 
@@ -1025,8 +1025,8 @@ bool MUST_USE_RESULT float4::AreCollinear(const float4 &p1, const float4 &p2, co
 
 float4 float4::Lerp(const float4 &b, float t) const
 {
-	assume(EqualAbs(this->w, b.w));
-	assume(0.f <= t && t <= 1.f);
+	mgl_assume(EqualAbs(this->w, b.w));
+	mgl_assume(0.f <= t && t <= 1.f);
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	return vec4_lerp(v, b.v, t);
 #else
@@ -1053,8 +1053,8 @@ bool MUST_USE_RESULT float4::AreOrthogonal(const float4 &a, const float4 &b, con
 
 void float4::Orthonormalize(float4 &a, float4 &b)
 {
-	assume(!a.IsZero());
-	assume(!b.IsZero());
+	mgl_assume(!a.IsZero());
+	mgl_assume(!b.IsZero());
 	a.Normalize();
 	b -= b.ProjectToNorm(a);
 	b.Normalize();
@@ -1062,14 +1062,14 @@ void float4::Orthonormalize(float4 &a, float4 &b)
 
 void float4::Orthonormalize(float4 &a, float4 &b, float4 &c)
 {
-	assume(!a.IsZero());
+	mgl_assume(!a.IsZero());
 	a.Normalize();
 	b -= b.ProjectToNorm(a);
-	assume(!b.IsZero());
+	mgl_assume(!b.IsZero());
 	b.Normalize();
 	c -= c.ProjectToNorm(a);
 	c -= c.ProjectToNorm(b);
-	assume(!c.IsZero());
+	mgl_assume(!c.IsZero());
 	c.Normalize();
 }
 
@@ -1213,7 +1213,7 @@ float3 float4::ToSphericalCoordinates() const
 
 float2 float4::ToSphericalCoordinatesNormalized() const
 {
-	assume(IsNormalized());
+	mgl_assume(IsNormalized());
 	float azimuth = atan2(x, z);
 	float inclination = asin(-y);
 	return float2(azimuth, inclination);

--- a/src/Math/float4.h
+++ b/src/Math/float4.h
@@ -130,15 +130,15 @@ public:
 			this vector as well, e.g. vec.At(1) = 10.f; would set the y-component of this vector. */
 	FORCE_INLINE CONST_WIN32 float At(int index) const
 	{
-		assume(index >= 0);
-		assume(index < Size);
+		mgl_assume(index >= 0);
+		mgl_assume(index < Size);
 		return ptr()[index];
 	}
 	
 	FORCE_INLINE float &At(int index)
 	{
-		assume(index >= 0);
-		assume(index < Size);
+		mgl_assume(index >= 0);
+		mgl_assume(index < Size);
 		return ptr()[index];
 	}
 

--- a/src/Math/float4d.h
+++ b/src/Math/float4d.h
@@ -194,13 +194,13 @@ public:
 
 	vec ToPointVec() const
 	{
-		assert1(EqualAbs((float)w, 1.0), w);
+		mgl_assert1(EqualAbs((float)w, 1.0), w);
 		return POINT_VEC((float)x, (float)y, (float)z);
 	}
 
 	vec ToDirVec() const
 	{
-		assert1(EqualAbs((float)w, 0.0), w);
+		mgl_assert1(EqualAbs((float)w, 0.0), w);
 		return DIR_VEC((float)x, (float)y, (float)z);
 	}
 

--- a/src/Math/float4x4.cpp
+++ b/src/Math/float4x4.cpp
@@ -218,8 +218,8 @@ float4x4 float4x4::RotateFromTo(const float3 &sourceDirection, const float3 &tar
 
 float4x4 float4x4::RandomGeneral(LCG &lcg, float minElem, float maxElem)
 {
-	assume(MATH_NS::IsFinite(minElem));
-	assume(MATH_NS::IsFinite(maxElem));
+	mgl_assume(MATH_NS::IsFinite(minElem));
+	mgl_assume(MATH_NS::IsFinite(maxElem));
 	float4x4 m;
 	for(int y = 0; y < 4; ++y)
 		for(int x = 0; x < 4; ++x)
@@ -263,7 +263,7 @@ float4x4 float4x4::FromEulerXYX(float x2, float y, float x)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerXYX(r, x2, y, x);
-	assume(r.Equals(float4x4::RotateX(x2) * float4x4::RotateY(y) * float4x4::RotateX(x)));
+	mgl_assume(r.Equals(float4x4::RotateX(x2) * float4x4::RotateY(y) * float4x4::RotateX(x)));
 	return r;
 }
 
@@ -273,7 +273,7 @@ float4x4 float4x4::FromEulerXZX(float x2, float z, float x)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerXZX(r, x2, z, x);
-	assume(r.Equals(float4x4::RotateX(x2) * float4x4::RotateZ(z) * float4x4::RotateX(x)));
+	mgl_assume(r.Equals(float4x4::RotateX(x2) * float4x4::RotateZ(z) * float4x4::RotateX(x)));
 	return r;
 }
 
@@ -283,7 +283,7 @@ float4x4 float4x4::FromEulerYXY(float y2, float x, float y)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerYXY(r, y2, x, y);
-	assume(r.Equals(float4x4::RotateY(y2) * float4x4::RotateX(x) * float4x4::RotateY(y)));
+	mgl_assume(r.Equals(float4x4::RotateY(y2) * float4x4::RotateX(x) * float4x4::RotateY(y)));
 	return r;
 }
 
@@ -293,7 +293,7 @@ float4x4 float4x4::FromEulerYZY(float y2, float z, float y)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerYZY(r, y2, z, y);
-	assume(r.Equals(float4x4::RotateY(y2) * float4x4::RotateZ(z) * float4x4::RotateY(y)));
+	mgl_assume(r.Equals(float4x4::RotateY(y2) * float4x4::RotateZ(z) * float4x4::RotateY(y)));
 	return r;
 }
 
@@ -303,7 +303,7 @@ float4x4 float4x4::FromEulerZXZ(float z2, float x, float z)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerZXZ(r, z2, x, z);
-	assume(r.Equals(float4x4::RotateZ(z2) * float4x4::RotateX(x) * float4x4::RotateZ(z)));
+	mgl_assume(r.Equals(float4x4::RotateZ(z2) * float4x4::RotateX(x) * float4x4::RotateZ(z)));
 	return r;
 }
 
@@ -313,7 +313,7 @@ float4x4 float4x4::FromEulerZYZ(float z2, float y, float z)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerZYZ(r, z2, y, z);
-	assume(r.Equals(float4x4::RotateZ(z2) * float4x4::RotateY(y) * float4x4::RotateZ(z)));
+	mgl_assume(r.Equals(float4x4::RotateZ(z2) * float4x4::RotateY(y) * float4x4::RotateZ(z)));
 	return r;
 }
 
@@ -323,7 +323,7 @@ float4x4 float4x4::FromEulerXYZ(float x, float y, float z)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerXYZ(r, x, y, z);
-	assume(r.Equals(float4x4::RotateX(x) * float4x4::RotateY(y) * float4x4::RotateZ(z)));
+	mgl_assume(r.Equals(float4x4::RotateX(x) * float4x4::RotateY(y) * float4x4::RotateZ(z)));
 	return r;
 }
 
@@ -333,7 +333,7 @@ float4x4 float4x4::FromEulerXZY(float x, float z, float y)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerXZY(r, x, z, y);
-	assume(r.Equals(float4x4::RotateX(x) * float4x4::RotateZ(z) * float4x4::RotateY(y)));
+	mgl_assume(r.Equals(float4x4::RotateX(x) * float4x4::RotateZ(z) * float4x4::RotateY(y)));
 	return r;
 }
 
@@ -343,7 +343,7 @@ float4x4 float4x4::FromEulerYXZ(float y, float x, float z)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerYXZ(r, y, x, z);
-	assume(r.Equals(float4x4::RotateY(y) * float4x4::RotateX(x) * float4x4::RotateZ(z)));
+	mgl_assume(r.Equals(float4x4::RotateY(y) * float4x4::RotateX(x) * float4x4::RotateZ(z)));
 	return r;
 }
 
@@ -353,7 +353,7 @@ float4x4 float4x4::FromEulerYZX(float y, float z, float x)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerYZX(r, y, z, x);
-	assume(r.Equals(float4x4::RotateY(y) * float4x4::RotateZ(z) * float4x4::RotateX(x)));
+	mgl_assume(r.Equals(float4x4::RotateY(y) * float4x4::RotateZ(z) * float4x4::RotateX(x)));
 	return r;
 }
 
@@ -363,7 +363,7 @@ float4x4 float4x4::FromEulerZXY(float z, float x, float y)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerZXY(r, z, x, y);
-	assume(r.Equals(float4x4::RotateZ(z) * float4x4::RotateX(x) * float4x4::RotateY(y)));
+	mgl_assume(r.Equals(float4x4::RotateZ(z) * float4x4::RotateX(x) * float4x4::RotateY(y)));
 	return r;
 }
 
@@ -373,7 +373,7 @@ float4x4 float4x4::FromEulerZYX(float z, float y, float x)
 	r.SetTranslatePart(0,0,0);
 	r.SetRow(3, 0,0,0,1);
 	Set3x3PartRotateEulerZYX(r, z, y, x);
-	assume(r.Equals(float4x4::RotateZ(z) * float4x4::RotateY(y) * float4x4::RotateX(x)));
+	mgl_assume(r.Equals(float4x4::RotateZ(z) * float4x4::RotateY(y) * float4x4::RotateX(x)));
 	return r;
 }
 
@@ -601,17 +601,17 @@ float4x4 float4x4::OrthographicProjectionXY()
 
 float4x4 float4x4::ComplementaryProjection() const
 {
-	assume(IsIdempotent());
+	mgl_assume(IsIdempotent());
 
 	return float4x4::identity - *this;
 }
 
 float &float4x4::At(int rowIndex, int colIndex)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 #ifdef MATH_COLMAJOR_MATRICES
 	return v[colIndex][rowIndex];
 #else
@@ -621,10 +621,10 @@ float &float4x4::At(int rowIndex, int colIndex)
 
 CONST_WIN32 float float4x4::At(int rowIndex, int colIndex) const
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 #ifdef MATH_COLMAJOR_MATRICES
 	return v[colIndex][rowIndex];
 #else
@@ -635,85 +635,85 @@ CONST_WIN32 float float4x4::At(int rowIndex, int colIndex) const
 #ifdef MATH_COLMAJOR_MATRICES
 float4 &float4x4::Col(int col)
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	return reinterpret_cast<float4 &>(v[col]);
 }
 
 const float4 &float4x4::Col(int col) const
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	return reinterpret_cast<const float4 &>(v[col]);
 }
 
 float3 &float4x4::Col3(int col)
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	return reinterpret_cast<float3 &>(v[col]);
 }
 
 const float3 &float4x4::Col3(int col) const
 {
-	assume(col >= 0);
-	assume(col < Cols);
+	mgl_assume(col >= 0);
+	mgl_assume(col < Cols);
 	return reinterpret_cast<const float3 &>(v[col]);
 }
 
 CONST_WIN32 float4 float4x4::Row(int row) const
 {
-	assume(row >= 0);
-	assume(row < Rows);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
 	return float4(At(row, 0), At(row, 1), At(row, 2), At(row, 3));
 }
 
 CONST_WIN32 float3 float4x4::Row3(int row) const
 {
-	assume(row >= 0);
-	assume(row < Rows);
+	mgl_assume(row >= 0);
+	mgl_assume(row < Rows);
 	return float3(At(row, 0), At(row, 1), At(row, 2));
 }
 #else
 float4 &float4x4::Row(int rowIndex)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 	return reinterpret_cast<float4 &>(v[rowIndex]);
 }
 
 const float4 &float4x4::Row(int rowIndex) const
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 	return reinterpret_cast<const float4 &>(v[rowIndex]);
 }
 
 float3 &float4x4::Row3(int rowIndex)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 	return reinterpret_cast<float3 &>(v[rowIndex]);
 }
 
 const float3 &float4x4::Row3(int rowIndex) const
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
 	return reinterpret_cast<const float3 &>(v[rowIndex]);
 }
 
 CONST_WIN32 float4 float4x4::Col(int colIndex) const
 {
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 	return float4(v[0][colIndex], v[1][colIndex], v[2][colIndex], v[3][colIndex]);
 }
 
 CONST_WIN32 float3 float4x4::Col3(int colIndex) const
 {
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 	return float3(v[0][colIndex], v[1][colIndex], v[2][colIndex]);
 }
 #endif
@@ -730,7 +730,7 @@ CONST_WIN32 float3 float4x4::Diagonal3() const
 
 void float4x4::ScaleRow3(int r, float scalar)
 {
-	assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(MATH_NS::IsFinite(scalar));
 	At(r, 0) *= scalar;
 	At(r, 1) *= scalar;
 	At(r, 2) *= scalar;
@@ -738,7 +738,7 @@ void float4x4::ScaleRow3(int r, float scalar)
 
 void float4x4::ScaleRow(int r, float scalar)
 {
-	assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(MATH_NS::IsFinite(scalar));
 	At(r, 0) *= scalar;
 	At(r, 1) *= scalar;
 	At(r, 2) *= scalar;
@@ -747,9 +747,9 @@ void float4x4::ScaleRow(int r, float scalar)
 
 void float4x4::ScaleCol3(int colIndex, float scalar)
 {
-	assume(MATH_NS::IsFinite(scalar));
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 	At(0, colIndex) *= scalar;
 	At(1, colIndex) *= scalar;
 	At(2, colIndex) *= scalar;
@@ -757,9 +757,9 @@ void float4x4::ScaleCol3(int colIndex, float scalar)
 
 void float4x4::ScaleCol(int colIndex, float scalar)
 {
-	assume(MATH_NS::IsFinite(scalar));
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(MATH_NS::IsFinite(scalar));
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 	At(0, colIndex) *= scalar;
 	At(1, colIndex) *= scalar;
 	At(2, colIndex) *= scalar;
@@ -831,17 +831,17 @@ void float4x4::SetRow3(int rowIndex, const float3 &rowVector)
 
 void float4x4::SetRow3(int rowIndex, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	SetRow3(rowIndex, data[0], data[1], data[2]);
 }
 
 void float4x4::SetRow3(int rowIndex, float m_r0, float m_r1, float m_r2)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(MATH_NS::IsFinite(m_r0));
-	assume(MATH_NS::IsFinite(m_r1));
-	assume(MATH_NS::IsFinite(m_r2));
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(MATH_NS::IsFinite(m_r0));
+	mgl_assume(MATH_NS::IsFinite(m_r1));
+	mgl_assume(MATH_NS::IsFinite(m_r2));
 	At(rowIndex, 0) = m_r0;
 	At(rowIndex, 1) = m_r1;
 	At(rowIndex, 2) = m_r2;
@@ -859,18 +859,18 @@ void float4x4::SetRow(int rowIndex, const float4 &rowVector)
 
 void float4x4::SetRow(int rowIndex, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	SetRow(rowIndex, data[0], data[1], data[2], data[3]);
 }
 
 void float4x4::SetRow(int rowIndex, float m_r0, float m_r1, float m_r2, float m_r3)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(MATH_NS::IsFinite(m_r0));
-	assume(MATH_NS::IsFinite(m_r1));
-	assume(MATH_NS::IsFinite(m_r2));
-	assume(MATH_NS::IsFinite(m_r3));
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(MATH_NS::IsFinite(m_r0));
+	mgl_assume(MATH_NS::IsFinite(m_r1));
+	mgl_assume(MATH_NS::IsFinite(m_r2));
+	mgl_assume(MATH_NS::IsFinite(m_r3));
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	this->row[rowIndex] = set_ps(m_r3, m_r2, m_r1, m_r0);
@@ -889,17 +889,17 @@ void float4x4::SetCol3(int column, const float3 &columnVector)
 
 void float4x4::SetCol3(int column, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	SetCol3(column, data[0], data[1], data[2]);
 }
 
 void float4x4::SetCol3(int column, float m_0c, float m_1c, float m_2c)
 {
-	assume(column >= 0);
-	assume(column < Cols);
-	assume(MATH_NS::IsFinite(m_0c));
-	assume(MATH_NS::IsFinite(m_1c));
-	assume(MATH_NS::IsFinite(m_2c));
+	mgl_assume(column >= 0);
+	mgl_assume(column < Cols);
+	mgl_assume(MATH_NS::IsFinite(m_0c));
+	mgl_assume(MATH_NS::IsFinite(m_1c));
+	mgl_assume(MATH_NS::IsFinite(m_2c));
 	At(0, column) = m_0c;
 	At(1, column) = m_1c;
 	At(2, column) = m_2c;
@@ -917,18 +917,18 @@ void float4x4::SetCol(int column, const float4 &columnVector)
 
 void float4x4::SetCol(int column, const float *data)
 {
-	assume(data);
+	mgl_assume(data);
 	SetCol(column, data[0], data[1], data[2], data[3]);
 }
 
 void float4x4::SetCol(int column, float m_0c, float m_1c, float m_2c, float m_3c)
 {
-	assume(column >= 0);
-	assume(column < Cols);
-	assume(MATH_NS::IsFinite(m_0c));
-	assume(MATH_NS::IsFinite(m_1c));
-	assume(MATH_NS::IsFinite(m_2c));
-	assume(MATH_NS::IsFinite(m_3c));
+	mgl_assume(column >= 0);
+	mgl_assume(column < Cols);
+	mgl_assume(MATH_NS::IsFinite(m_0c));
+	mgl_assume(MATH_NS::IsFinite(m_1c));
+	mgl_assume(MATH_NS::IsFinite(m_2c));
+	mgl_assume(MATH_NS::IsFinite(m_3c));
 	At(0, column) = m_0c;
 	At(1, column) = m_1c;
 	At(2, column) = m_2c;
@@ -970,7 +970,7 @@ void float4x4::Set(const float4x4 &rhs)
 
 void float4x4::Set(const float *p)
 {
-	assume(p);
+	mgl_assume(p);
 	Set( p[0],  p[1],  p[2],  p[3],
 	     p[4],  p[5],  p[6],  p[7],
 	     p[8],  p[9], p[10], p[11],
@@ -979,10 +979,10 @@ void float4x4::Set(const float *p)
 
 void float4x4::Set(int rowIndex, int colIndex, float value)
 {
-	assume(rowIndex >= 0);
-	assume(rowIndex < Rows);
-	assume(colIndex >= 0);
-	assume(colIndex < Cols);
+	mgl_assume(rowIndex >= 0);
+	mgl_assume(rowIndex < Rows);
+	mgl_assume(colIndex >= 0);
+	mgl_assume(colIndex < Cols);
 	At(rowIndex, colIndex) = value;
 }
 
@@ -996,7 +996,7 @@ void float4x4::SetIdentity()
 
 void float4x4::Set3x3Part(const float3x3 &r)
 {
-	assume(r.IsFinite());
+	mgl_assume(r.IsFinite());
 	At(0, 0) = r[0][0]; At(0, 1) = r[0][1]; At(0, 2) = r[0][2];
 	At(1, 0) = r[1][0]; At(1, 1) = r[1][1]; At(1, 2) = r[1][2];
 	At(2, 0) = r[2][0]; At(2, 1) = r[2][1]; At(2, 2) = r[2][2];
@@ -1004,7 +1004,7 @@ void float4x4::Set3x3Part(const float3x3 &r)
 
 void float4x4::Set3x4Part(const float3x4 &r)
 {
-	assume(r.IsFinite());
+	mgl_assume(r.IsFinite());
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	row[0] = r.row[0];
@@ -1019,10 +1019,10 @@ void float4x4::Set3x4Part(const float3x4 &r)
 
 void float4x4::SwapColumns(int col1, int col2)
 {
-	assume(col1 >= 0);
-	assume(col1 < Cols);
-	assume(col2 >= 0);
-	assume(col2 < Cols);
+	mgl_assume(col1 >= 0);
+	mgl_assume(col1 < Cols);
+	mgl_assume(col2 >= 0);
+	mgl_assume(col2 < Cols);
 	Swap(At(0, col1), At(0, col2));
 	Swap(At(1, col1), At(1, col2));
 	Swap(At(2, col1), At(2, col2));
@@ -1031,10 +1031,10 @@ void float4x4::SwapColumns(int col1, int col2)
 
 void float4x4::SwapColumns3(int col1, int col2)
 {
-	assume(col1 >= 0);
-	assume(col1 < Cols);
-	assume(col2 >= 0);
-	assume(col2 < Cols);
+	mgl_assume(col1 >= 0);
+	mgl_assume(col1 < Cols);
+	mgl_assume(col2 >= 0);
+	mgl_assume(col2 < Cols);
 	Swap(At(0, col1), At(0, col2));
 	Swap(At(1, col1), At(1, col2));
 	Swap(At(2, col1), At(2, col2));
@@ -1042,10 +1042,10 @@ void float4x4::SwapColumns3(int col1, int col2)
 
 void float4x4::SwapRows(int r1, int r2)
 {
-	assume(r1 >= 0);
-	assume(r1 < Rows);
-	assume(r2 >= 0);
-	assume(r2 < Rows);
+	mgl_assume(r1 >= 0);
+	mgl_assume(r1 < Rows);
+	mgl_assume(r2 >= 0);
+	mgl_assume(r2 < Rows);
 
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	Swap(row[r1], row[r2]);
@@ -1059,10 +1059,10 @@ void float4x4::SwapRows(int r1, int r2)
 
 void float4x4::SwapRows3(int r1, int r2)
 {
-	assume(r1 >= 0);
-	assume(r1 < Rows);
-	assume(r2 >= 0);
-	assume(r2 < Rows);
+	mgl_assume(r1 >= 0);
+	mgl_assume(r1 < Rows);
+	mgl_assume(r2 >= 0);
+	mgl_assume(r2 < Rows);
 	Swap(At(r1, 0), At(r2, 0));
 	Swap(At(r1, 1), At(r2, 1));
 	Swap(At(r1, 2), At(r2, 2));
@@ -1087,7 +1087,7 @@ void float4x4::SetTranslatePart(const float4 &offset)
 	At(0, 3) = offset.x;
 	At(1, 3) = offset.y;
 	At(2, 3) = offset.z;
-	assume(EqualAbs(offset.w, 1.f) || EqualAbs(offset.w, 0.f));
+	mgl_assume(EqualAbs(offset.w, 1.f) || EqualAbs(offset.w, 0.f));
 }
 
 void float4x4::SetRotatePartX(float angle)
@@ -1180,12 +1180,12 @@ float4x4 &float4x4::operator =(const float4x4 &rhs)
 	// to copy around uninitialized matrices.
 	// But note that when assigning through a conversion above (float3x3 -> float4x4 or float3x4 -> float4x4),
 	// we do assume the input matrix is finite.
-//	assume(rhs.IsFinite());
+//	mgl_assume(rhs.IsFinite());
 
 /* // AVX path determined to be one clock cycle slower than SSE path: (6 clock cycles on AVX, 5 on SSE)
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_AVX)
-	assert(IS32ALIGNED(this));
-	assert(IS32ALIGNED(&rhs));
+	mgl_assert(IS32ALIGNED(this));
+	mgl_assert(IS32ALIGNED(&rhs));
 	row2[0] = rhs.row2[0];
 	row2[1] = rhs.row2[1];
 #elif defined(MATH_SSE) */
@@ -1193,8 +1193,8 @@ float4x4 &float4x4::operator =(const float4x4 &rhs)
 #if defined(MATH_AUTOMATIC_SSE)
 
 #if !defined(ANDROID) // Android NEON doesn't currently use aligned loads.
-	assert(IS16ALIGNED(this));
-	assert(IS16ALIGNED(&rhs));
+	mgl_assert(IS16ALIGNED(this));
+	mgl_assert(IS16ALIGNED(&rhs));
 #endif
 	row[0] = rhs.row[0];
 	row[1] = rhs.row[1];
@@ -1246,7 +1246,7 @@ float float4x4::Determinant3() const
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	return mat3x4_determinant(row);
 #else
-	assume(Float3x3Part().IsFinite());
+	mgl_assume(Float3x3Part().IsFinite());
 	const float a = v[0][0];
 	const float b = v[0][1];
 	const float c = v[0][2];
@@ -1266,7 +1266,7 @@ float float4x4::Determinant4() const
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SIMD)
 	return mat4x4_determinant(row);
 #else
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	return At(0, 0) * Minor(0,0) - At(0, 1) * Minor(0,1) + At(0, 2) * Minor(0,2) - At(0, 3) * Minor(0,3);
 #endif
 }
@@ -1355,7 +1355,7 @@ float4x4 float4x4::Inverted() const
 bool float4x4::InverseColOrthogonal()
 {
 	///\todo SSE
-	assume(!ContainsProjection());
+	mgl_assume(!ContainsProjection());
 #ifdef MATH_COLMAJOR_MATRICES
 	///\todo Optimize away redundant copies
 	float3x4 mat3x4 = Float3x4Part();
@@ -1370,9 +1370,9 @@ bool float4x4::InverseColOrthogonal()
 bool float4x4::InverseOrthogonalUniformScale()
 {
 	///\todo SSE
-	assume(!ContainsProjection());
-	assume(IsColOrthogonal3(1e-3f));
-	assume(HasUniformScale());
+	mgl_assume(!ContainsProjection());
+	mgl_assume(IsColOrthogonal3(1e-3f));
+	mgl_assume(HasUniformScale());
 	Swap(At(0, 1), At(1, 0));
 	Swap(At(0, 2), At(2, 0));
 	Swap(At(1, 2), At(2, 1));
@@ -1392,7 +1392,7 @@ bool float4x4::InverseOrthogonalUniformScale()
 
 void float4x4::InverseOrthonormal()
 {
-	assume(!ContainsProjection());
+	mgl_assume(!ContainsProjection());
 #ifdef MATH_SSE
 	mat3x4_inverse_orthonormal(row, row);
 #else
@@ -1453,15 +1453,15 @@ float4x4 float4x4::InverseTransposed() const
 
 float float4x4::Trace() const
 {
-	assume(IsFinite());
+	mgl_assume(IsFinite());
 	return v[0][0] + v[1][1] + v[2][2] + v[3][3];
 }
 
 void float4x4::Orthogonalize3(int c0, int c1, int c2)
 {
 	///\todo SSE
-	assume(c0 != c1 && c0 != c2 && c1 != c2);
-	assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
+	mgl_assume(c0 != c1 && c0 != c2 && c1 != c2);
+	mgl_assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
 	///@todo Optimize away copies.
 	float3 v0 = Col3(c0);
 	float3 v1 = Col3(c1);
@@ -1475,8 +1475,8 @@ void float4x4::Orthogonalize3(int c0, int c1, int c2)
 void float4x4::Orthonormalize3(int c0, int c1, int c2)
 {
 	///\todo SSE
-	assume(c0 != c1 && c0 != c2 && c1 != c2);
-	assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
+	mgl_assume(c0 != c1 && c0 != c2 && c1 != c2);
+	mgl_assume(c0 >= 0 && c1 >= 0 && c2 >= 0 && c0 < Cols && c1 < Cols && c2 < Cols);
 	///@todo Optimize away copies.
 	float3 v0 = Col3(c0);
 	float3 v1 = Col3(c1);
@@ -1502,7 +1502,7 @@ void float4x4::RemoveScale()
 	float ty = Row3(1).Normalize();
 	float tz = Row3(2).Normalize();
 #endif
-	assume(tx != 0 && ty != 0 && tz != 0 && "float4x4::RemoveScale failed!");
+	mgl_assume(tx != 0 && ty != 0 && tz != 0 && "float4x4::RemoveScale failed!");
 	MARK_UNUSED(tx);
 	MARK_UNUSED(ty);
 	MARK_UNUSED(tz);
@@ -1540,7 +1540,7 @@ void float4x4::Pivot()
 
 float3 float4x4::TransformPos(const float3 &pointVector) const
 {
-	assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
+	mgl_assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	return mat3x4_mul_vec(row, set_ps(1.f, pointVector.z, pointVector.y, pointVector.x));
 #else
@@ -1550,7 +1550,7 @@ float3 float4x4::TransformPos(const float3 &pointVector) const
 
 float3 float4x4::TransformPos(float tx, float ty, float tz) const
 {
-	assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
+	mgl_assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	return mat3x4_mul_vec(row, set_ps(1.f, tz, ty, tx));
 #else
@@ -1562,7 +1562,7 @@ float3 float4x4::TransformPos(float tx, float ty, float tz) const
 
 float3 float4x4::TransformDir(const float3 &directionVector) const
 {
-	assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
+	mgl_assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	return mat3x4_mul_vec(row, set_ps(0.f, directionVector.z, directionVector.y, directionVector.x));
 #else
@@ -1572,7 +1572,7 @@ float3 float4x4::TransformDir(const float3 &directionVector) const
 
 float3 float4x4::TransformDir(float tx, float ty, float tz) const
 {
-	assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
+	mgl_assume(!this->ContainsProjection()); // This function does not divide by w or output it, so cannot have projection.
 #if defined(MATH_AUTOMATIC_SSE) && defined(MATH_SSE)
 	return mat3x4_mul_vec(row, set_ps(0.f, tz, ty, tx));
 #else
@@ -1597,7 +1597,7 @@ float4 float4x4::Transform(const float4 &vector) const
 void float4x4::TransformPos(float3 *pointArray, int numPoints) const
 {
 	///\todo SSE.
-	assume(pointArray);
+	mgl_assume(pointArray);
 	for(int i = 0; i < numPoints; ++i)
 		pointArray[i] = this->TransformPos(pointArray[i]);
 }
@@ -1605,7 +1605,7 @@ void float4x4::TransformPos(float3 *pointArray, int numPoints) const
 void float4x4::TransformPos(float3 *pointArray, int numPoints, int strideBytes) const
 {
 	///\todo SSE.
-	assume(pointArray);
+	mgl_assume(pointArray);
 	u8 *data = reinterpret_cast<u8*>(pointArray);
 	for(int i = 0; i < numPoints; ++i)
 	{
@@ -1618,7 +1618,7 @@ void float4x4::TransformPos(float3 *pointArray, int numPoints, int strideBytes) 
 void float4x4::TransformDir(float3 *dirArray, int numVectors) const
 {
 	///\todo SSE.
-	assume(dirArray);
+	mgl_assume(dirArray);
 	for(int i = 0; i < numVectors; ++i)
 		dirArray[i] = this->TransformDir(dirArray[i]);
 }
@@ -1626,7 +1626,7 @@ void float4x4::TransformDir(float3 *dirArray, int numVectors) const
 void float4x4::TransformDir(float3 *dirArray, int numVectors, int strideBytes) const
 {
 	///\todo SSE.
-	assume(dirArray);
+	mgl_assume(dirArray);
 	u8 *data = reinterpret_cast<u8*>(dirArray);
 	for(int i = 0; i < numVectors; ++i)
 	{
@@ -1639,7 +1639,7 @@ void float4x4::TransformDir(float3 *dirArray, int numVectors, int strideBytes) c
 void float4x4::Transform(float4 *vectorArray, int numVectors) const
 {
 	///\todo SSE.
-	assume(vectorArray);
+	mgl_assume(vectorArray);
 	for(int i = 0; i < numVectors; ++i)
 		vectorArray[i] = *this * vectorArray[i];
 }
@@ -1647,7 +1647,7 @@ void float4x4::Transform(float4 *vectorArray, int numVectors) const
 void float4x4::Transform(float4 *vectorArray, int numVectors, int strideBytes) const
 {
 	///\todo SSE.
-	assume(vectorArray);
+	mgl_assume(vectorArray);
 	u8 *data = reinterpret_cast<u8*>(vectorArray);
 	for(int i = 0; i < numVectors; ++i)
 	{
@@ -1775,7 +1775,7 @@ float4x4 float4x4::operator *(float scalar) const
 
 float4x4 float4x4::operator /(float scalar) const
 {
-	assume(!EqualAbs(scalar, 0));
+	mgl_assume(!EqualAbs(scalar, 0));
 
 #ifdef MATH_AUTOMATIC_SSE
 	float4x4 r;
@@ -1840,7 +1840,7 @@ float4x4 &float4x4::operator *=(float s)
 
 float4x4 &float4x4::operator /=(float scalar)
 {
-	assume(!EqualAbs(scalar, 0));
+	mgl_assume(!EqualAbs(scalar, 0));
 	return *this *= (1.f / scalar);
 }
 
@@ -2023,7 +2023,7 @@ StringT float4x4::SerializeToString() const
 	s = SerializeFloat(At(3, 1), s); *s = ','; ++s;
 	s = SerializeFloat(At(3, 2), s); *s = ','; ++s;
 	s = SerializeFloat(At(3, 3), s);
-	assert(s+1 - str < 512);
+	mgl_assert(s+1 - str < 512);
 	MARK_UNUSED(s);
 	return str;
 }
@@ -2061,43 +2061,43 @@ float3 float4x4::ExtractScale() const
 
 void float4x4::Decompose(float3 &translate, Quat &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal3());
+	mgl_assume(this->IsColOrthogonal3());
 
 	float3x3 r;
 	Decompose(translate, r, scale);
 	rotate = Quat(r);
 
 	// Test that composing back yields the original float4x4.
-	assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
 }
 
 void float4x4::Decompose(float3 &translate, float3x3 &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal3());
+	mgl_assume(this->IsColOrthogonal3());
 
-	assume(Row(3).Equals(0,0,0,1));
+	mgl_assume(Row(3).Equals(0,0,0,1));
 
-	assume(this->IsColOrthogonal3());
+	mgl_assume(this->IsColOrthogonal3());
 	
 	translate = Col3(3);
 	rotate = RotatePart();
 	scale.x = rotate.Col3(0).Length();
 	scale.y = rotate.Col3(1).Length();
 	scale.z = rotate.Col3(2).Length();
-	assume(!EqualAbs(scale.x, 0));
-	assume(!EqualAbs(scale.y, 0));
-	assume(!EqualAbs(scale.z, 0));
+	mgl_assume(!EqualAbs(scale.x, 0));
+	mgl_assume(!EqualAbs(scale.y, 0));
+	mgl_assume(!EqualAbs(scale.z, 0));
 	rotate.ScaleCol(0, 1.f / scale.x);
 	rotate.ScaleCol(1, 1.f / scale.y);
 	rotate.ScaleCol(2, 1.f / scale.z);
 
 	// Test that composing back yields the original float4x4.
-	assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
 }
 
 void float4x4::Decompose(float3 &translate, float3x4 &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal3());
+	mgl_assume(this->IsColOrthogonal3());
 
 	float3x3 r;
 	Decompose(translate, r, scale);
@@ -2105,12 +2105,12 @@ void float4x4::Decompose(float3 &translate, float3x4 &rotate, float3 &scale) con
 	rotate.SetTranslatePart(0,0,0);
 
 	// Test that composing back yields the original float4x4.
-	assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
 }
 
 void float4x4::Decompose(float3 &translate, float4x4 &rotate, float3 &scale) const
 {
-	assume(this->IsColOrthogonal3());
+	mgl_assume(this->IsColOrthogonal3());
 
 	float3x3 r;
 	Decompose(translate, r, scale);
@@ -2119,7 +2119,7 @@ void float4x4::Decompose(float3 &translate, float4x4 &rotate, float3 &scale) con
 	rotate.SetRow(3, 0, 0, 0, 1);
 
 	// Test that composing back yields the original float4x4.
-	assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
+	mgl_assume(float4x4::FromTRS(translate, rotate, scale).Equals(*this, 0.1f));
 }
 
 float4x4 float4x4::Abs() const

--- a/src/Math/float4x4.h
+++ b/src/Math/float4x4.h
@@ -364,8 +364,8 @@ public:
 	 	whether MATH_COLMAJOR_MATRICES is set, i.e. the notation is always m[y][x]. */
 	FORCE_INLINE MatrixProxy<Rows, Cols> &operator[](int row)
 	{
-		assume(row >= 0);
-		assume(row < Rows);
+		mgl_assume(row >= 0);
+		mgl_assume(row < Rows);
 
 #ifdef MATH_COLMAJOR_MATRICES
 		return *(reinterpret_cast<MatrixProxy<Rows, Cols>*>(&v[0][row]));
@@ -376,8 +376,8 @@ public:
 	
 	FORCE_INLINE const MatrixProxy<Rows, Cols> &operator[](int row) const
 	{
-		assume(row >= 0);
-		assume(row < Rows);
+		mgl_assume(row >= 0);
+		mgl_assume(row < Rows);
 
 #ifdef MATH_COLMAJOR_MATRICES
 		return *(reinterpret_cast<const MatrixProxy<Rows, Cols>*>(&v[0][row]));
@@ -1003,9 +1003,9 @@ public:
 	float4x4 Mul(const Quat &rhs) const;
 	float2 MulPos(const float2 &pointVector) const;
 	float3 MulPos(const float3 &pointVector) const;
-	inline float4 MulPos(const float4 &pointVector) const { assume(!EqualAbs(pointVector.w, 0.f)); return Mul(pointVector); }
+	inline float4 MulPos(const float4 &pointVector) const { mgl_assume(!EqualAbs(pointVector.w, 0.f)); return Mul(pointVector); }
 	float3 MulDir(const float3 &directionVector) const;
-	inline float4 MulDir(const float4 &directionVector) const { assume(EqualAbs(directionVector.w, 0.f)); return Mul(directionVector); }
+	inline float4 MulDir(const float4 &directionVector) const { mgl_assume(EqualAbs(directionVector.w, 0.f)); return Mul(directionVector); }
 	float4 Mul(const float4 &vector) const;
 };
 

--- a/src/Math/myassert.h
+++ b/src/Math/myassert.h
@@ -22,8 +22,8 @@
 #include <sstream>
 #endif
 
-#ifdef assert
-#undef assert
+#ifdef mgl_assert
+#undef mgl_assert
 #endif
 
 #ifdef FAIL_USING_EXCEPTIONS
@@ -41,9 +41,9 @@
 
 #ifdef RUNTIME_FAILURE_DISABLED
 
-#define assert(x) ((void)0)
-#define asserteq(x,y) ((void)0)
-#define assertcmp(x, cmp, y) ((void)0)
+#define mgl_assert(x) ((void)0)
+#define mgl_asserteq(x,y) ((void)0)
+#define mgl_assertcmp(x, cmp, y) ((void)0)
 
 // If defined in a compilation unit, MATH_IGNORE_UNUSED_VARS_WARNING will kill all subsequent warnings about variables going unused.
 // This occurs commonly in unit tests that are also doubled as benchmarks - killing the use of assert() macro will leave variables
@@ -62,7 +62,7 @@
 
 #define MATH_IGNORE_UNUSED_VARS_WARNING
 
-#define assert(x) \
+#define mgl_assert(x) \
 	MULTI_LINE_MACRO_BEGIN \
 		if (!(x)) \
 		{ \
@@ -72,7 +72,7 @@
 		} \
 	MULTI_LINE_MACRO_END
 
-#define asserteq(x,y) \
+#define mgl_asserteq(x,y) \
 	MULTI_LINE_MACRO_BEGIN \
 		if ((x) != (y)) \
 		{ \
@@ -81,7 +81,7 @@
 		} \
 	MULTI_LINE_MACRO_END
 
-#define assertcmp(x, cmp, y) \
+#define mgl_assertcmp(x, cmp, y) \
 	MULTI_LINE_MACRO_BEGIN \
 		if (!((x) cmp (y))) \
 		{ \

--- a/src/Math/quat_simd.h
+++ b/src/Math/quat_simd.h
@@ -66,12 +66,12 @@ inline void quat_mul_quat_asm(const void *q1, const void *q2, void *out)
 	            x*r.y - y*r.x + z*r.w + w*r.z,
 	           -x*r.x - y*r.y - z*r.z + w*r.w); */
 #ifdef _DEBUG
-	assert(IS16ALIGNED(out));
-	assert(IS16ALIGNED(q1));
-	assert(IS16ALIGNED(q2));
-	assert(IS16ALIGNED(sx));
-	assert(IS16ALIGNED(sy));
-	assert(IS16ALIGNED(sz));
+	mgl_assert(IS16ALIGNED(out));
+	mgl_assert(IS16ALIGNED(q1));
+	mgl_assert(IS16ALIGNED(q2));
+	mgl_assert(IS16ALIGNED(sx));
+	mgl_assert(IS16ALIGNED(sy));
+	mgl_assert(IS16ALIGNED(sz));
 #endif
 	///\todo 128-bit aligned loads: [%1,:128]
 	asm(

--- a/src/Math/simd.h
+++ b/src/Math/simd.h
@@ -199,7 +199,7 @@ int FORCE_INLINE allzero_ps(simd4f x)
 	x = or_ps(x, y);
 #ifdef _DEBUG
 	// In this construction in SSE1, we can't detect NaNs, so test that those don't occur.
-	assume(ReinterpretAsU32(_mm_cvtss_f32(x)) == 0xFFFFFFFF || !IsNan(ReinterpretAsU32(_mm_cvtss_f32(x))));
+	mgl_assume(ReinterpretAsU32(_mm_cvtss_f32(x)) == 0xFFFFFFFF || !IsNan(ReinterpretAsU32(_mm_cvtss_f32(x))));
 #endif
 	return _mm_ucomige_ss(x, x);
 #endif
@@ -215,7 +215,7 @@ int FORCE_INLINE allone_ps(simd4f x)
 	x = and_ps(x, y);
 #ifdef _DEBUG
 	// In this construction in SSE1, we can't detect NaNs, so test that those don't occur.
-	assume(ReinterpretAsU32(_mm_cvtss_f32(x)) == 0xFFFFFFFF || !IsNan(ReinterpretAsU32(_mm_cvtss_f32(x))));
+	mgl_assume(ReinterpretAsU32(_mm_cvtss_f32(x)) == 0xFFFFFFFF || !IsNan(ReinterpretAsU32(_mm_cvtss_f32(x))));
 #endif
 	return !_mm_ucomige_ss(x, x);
 #endif

--- a/src/MathGeoLibFwd.h
+++ b/src/MathGeoLibFwd.h
@@ -56,9 +56,9 @@
 
 #endif
 
-#if !defined(MATH_ENABLE_STL_SUPPORT) && !defined(assert)
+#if !defined(MATH_ENABLE_STL_SUPPORT) && !defined(mgl_assert)
 #include <stdio.h>
-#define assert(x) do { if (!(x)) { printf("Error: assert(%s) failed!\n", #x); } } while(0)
+#define mgl_assert(x) do { if (!(x)) { printf("Error: assert(%s) failed!\n", #x); } } while(0)
 #endif
 
 MATH_BEGIN_NAMESPACE

--- a/src/Time/Clock.cpp
+++ b/src/Time/Clock.cpp
@@ -74,7 +74,7 @@ void Clock::InitClockData()
 	mach_timebase_info_data_t timeBaseInfo;
 	mach_timebase_info(&timeBaseInfo);
 	ticksPerSecond = 1000000000ULL * (uint64_t)timeBaseInfo.denom / (uint64_t)timeBaseInfo.numer;
-	assert(ticksPerSecond > (uint64_t)timeBaseInfo.denom/timeBaseInfo.numer); // Guard against overflow if OSX numer/denom change or similar.
+	mgl_assert(ticksPerSecond > (uint64_t)timeBaseInfo.denom/timeBaseInfo.numer); // Guard against overflow if OSX numer/denom change or similar.
 #endif
 }
 
@@ -217,7 +217,7 @@ tick_t Clock::Tick()
 #elif defined(WIN32)
 	LARGE_INTEGER ddwTimer;
 	BOOL success = QueryPerformanceCounter(&ddwTimer);
-	assume(success != 0);
+	mgl_assume(success != 0);
 	MARK_UNUSED(success);
 	return ddwTimer.QuadPart;
 #elif defined(__APPLE__)
@@ -240,7 +240,7 @@ unsigned long Clock::TickU32()
 #ifdef WIN32
 	LARGE_INTEGER ddwTimer;
 	BOOL success = QueryPerformanceCounter(&ddwTimer);
-	assume(success != 0);
+	mgl_assume(success != 0);
 	MARK_UNUSED(success);
 	return ddwTimer.LowPart;
 #else

--- a/tests/AABBTests.cpp
+++ b/tests/AABBTests.cpp
@@ -47,54 +47,54 @@ BENCHMARK_END
 UNIQUE_TEST(AABBContains)
 {
 	AABB a(POINT_VEC(0,0,0), POINT_VEC(10, 10, 10));
-	assert(a.Contains(POINT_VEC(0,0,0)));
-	assert(a.Contains(POINT_VEC(10,10,10)));
-	assert(a.Contains(POINT_VEC(1,2,3)));
-	assert(!a.Contains(POINT_VEC(-1,2,3)));
-	assert(!a.Contains(POINT_VEC(1,-2,3)));
-	assert(!a.Contains(POINT_VEC(1,2,-3)));
-	assert(!a.Contains(POINT_VEC(11,2,3)));
-	assert(!a.Contains(POINT_VEC(1,12,3)));
-	assert(!a.Contains(POINT_VEC(1,2,13)));
-	assert(!a.Contains(POINT_VEC(-1,-2,-3)));
-	assert(!a.Contains(POINT_VEC(11,12,13)));
+	mgl_assert(a.Contains(POINT_VEC(0,0,0)));
+	mgl_assert(a.Contains(POINT_VEC(10,10,10)));
+	mgl_assert(a.Contains(POINT_VEC(1,2,3)));
+	mgl_assert(!a.Contains(POINT_VEC(-1,2,3)));
+	mgl_assert(!a.Contains(POINT_VEC(1,-2,3)));
+	mgl_assert(!a.Contains(POINT_VEC(1,2,-3)));
+	mgl_assert(!a.Contains(POINT_VEC(11,2,3)));
+	mgl_assert(!a.Contains(POINT_VEC(1,12,3)));
+	mgl_assert(!a.Contains(POINT_VEC(1,2,13)));
+	mgl_assert(!a.Contains(POINT_VEC(-1,-2,-3)));
+	mgl_assert(!a.Contains(POINT_VEC(11,12,13)));
 }
 
 UNIQUE_TEST(AABBContainsAABB)
 {
 	AABB a(POINT_VEC(0,0,0), POINT_VEC(10, 10, 10));
-	assert(a.Contains(a));
-	assert(a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(6,6,6))));
-	assert(a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(10,6,6))));
-	assert(!a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(15,15,15))));
-	assert(!a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(5,15,5))));
-	assert(!a.Contains(AABB(POINT_VEC(-5,-5,-5), POINT_VEC(5,5,5))));
-	assert(!a.Contains(AABB(POINT_VEC(-5,-5,-5), POINT_VEC(0,0,0))));
+	mgl_assert(a.Contains(a));
+	mgl_assert(a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(6,6,6))));
+	mgl_assert(a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(10,6,6))));
+	mgl_assert(!a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(15,15,15))));
+	mgl_assert(!a.Contains(AABB(POINT_VEC(5,5,5), POINT_VEC(5,15,5))));
+	mgl_assert(!a.Contains(AABB(POINT_VEC(-5,-5,-5), POINT_VEC(5,5,5))));
+	mgl_assert(!a.Contains(AABB(POINT_VEC(-5,-5,-5), POINT_VEC(0,0,0))));
 }
 
 UNIQUE_TEST(AABBContainsLineSegment)
 {
 	AABB a(POINT_VEC(0,0,0), POINT_VEC(10, 10, 10));
-	assert(a.Contains(LineSegment(POINT_VEC(0,0,0), POINT_VEC(10, 10, 10))));
-	assert(a.Contains(LineSegment(POINT_VEC(10,10,10), POINT_VEC(0, 0, 0))));
-	assert(a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(6,6,6))));
-	assert(a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(10,6,6))));
-	assert(!a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(15,15,15))));
-	assert(!a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(5,15,5))));
-	assert(!a.Contains(LineSegment(POINT_VEC(-5,-5,-5), POINT_VEC(5,5,5))));
-	assert(!a.Contains(LineSegment(POINT_VEC(-5,-5,-5), POINT_VEC(0,0,0))));
-	assert(!a.Contains(LineSegment(POINT_VEC(15,15,15), POINT_VEC(-15,-15,-15))));
+	mgl_assert(a.Contains(LineSegment(POINT_VEC(0,0,0), POINT_VEC(10, 10, 10))));
+	mgl_assert(a.Contains(LineSegment(POINT_VEC(10,10,10), POINT_VEC(0, 0, 0))));
+	mgl_assert(a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(6,6,6))));
+	mgl_assert(a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(10,6,6))));
+	mgl_assert(!a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(15,15,15))));
+	mgl_assert(!a.Contains(LineSegment(POINT_VEC(5,5,5), POINT_VEC(5,15,5))));
+	mgl_assert(!a.Contains(LineSegment(POINT_VEC(-5,-5,-5), POINT_VEC(5,5,5))));
+	mgl_assert(!a.Contains(LineSegment(POINT_VEC(-5,-5,-5), POINT_VEC(0,0,0))));
+	mgl_assert(!a.Contains(LineSegment(POINT_VEC(15,15,15), POINT_VEC(-15,-15,-15))));
 }
 
 UNIQUE_TEST(AABBContainsSphere)
 {
 	AABB a(POINT_VEC(0,0,0), POINT_VEC(10, 10, 10));
-	assert(a.Contains(Sphere(POINT_VEC(0,0,0), 0.f)));
-	assert(a.Contains(Sphere(POINT_VEC(5,5,5), 1.f)));
-	assert(!a.Contains(Sphere(POINT_VEC(5,5,5), 15.f)));
-	assert(!a.Contains(Sphere(POINT_VEC(9,5,5), 2.f)));
-	assert(!a.Contains(Sphere(POINT_VEC(1,5,5), 2.f)));
-	assert(!a.Contains(Sphere(POINT_VEC(-10,-10,-10), 1000.f)));
+	mgl_assert(a.Contains(Sphere(POINT_VEC(0,0,0), 0.f)));
+	mgl_assert(a.Contains(Sphere(POINT_VEC(5,5,5), 1.f)));
+	mgl_assert(!a.Contains(Sphere(POINT_VEC(5,5,5), 15.f)));
+	mgl_assert(!a.Contains(Sphere(POINT_VEC(9,5,5), 2.f)));
+	mgl_assert(!a.Contains(Sphere(POINT_VEC(1,5,5), 2.f)));
+	mgl_assert(!a.Contains(Sphere(POINT_VEC(-10,-10,-10), 1000.f)));
 }
 
 UNIQUE_TEST(AABBIntersectsAABB)
@@ -104,11 +104,11 @@ UNIQUE_TEST(AABBIntersectsAABB)
 	AABB c(POINT_VEC(-5,-5,-5), POINT_VEC(0, 10, 0));
 	AABB d(POINT_VEC(20,20,20), POINT_VEC(30, 30, 30));
 	AABB e(POINT_VEC(1,1,1), POINT_VEC(9,9,9));
-	assert(a.Intersects(a));
-	assert(a.Intersects(b));
-	assert(!a.Intersects(c));
-	assert(!a.Intersects(d));
-	assert(a.Intersects(e));
+	mgl_assert(a.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(!a.Intersects(c));
+	mgl_assert(!a.Intersects(d));
+	mgl_assert(a.Intersects(e));
 }
 
 BENCHMARK(AABBIntersectsAABB_positive, "AABB::Intersects(AABB) positive")
@@ -135,7 +135,7 @@ RANDOMIZED_TEST(AABBTransformAsAABB)
 	AABB x = a;
 	x.TransformAsAABB(m);
 	AABB y = o.MinimalEnclosingAABB();
-	assert(x.Equals(y));
+	mgl_assert(x.Equals(y));
 }
 
 BENCHMARK(AABBTransformOBBToAABB_BM, "AABB::Transform to OBB and convert back to AABB")
@@ -163,7 +163,7 @@ RANDOMIZED_TEST(AABBTransformAsAABB_SIMD)
 	AABB x = a;
 	AABBTransformAsAABB_SIMD(x, m);
 	AABB y = o.MinimalEnclosingAABB();
-	assert2(x.Equals(y, 1e-2f), x.SerializeToCodeString(), y.SerializeToCodeString());
+	mgl_assert2(x.Equals(y, 1e-2f), x.SerializeToCodeString(), y.SerializeToCodeString());
 }
 
 BENCHMARK(AABBTransformAsAABB_SIMD_BM, "AABB::TransformAsAABB SIMD")
@@ -176,93 +176,93 @@ BENCHMARK_END
 UNIQUE_TEST(AABBIsDegenerate)
 {
 	AABB a(vec::nan, vec::nan);
-	assert(a.IsDegenerate());
-	assert(!a.IsFinite());
+	mgl_assert(a.IsDegenerate());
+	mgl_assert(!a.IsFinite());
 
 	a = AABB(vec::zero, vec::nan);
-	assert(a.IsDegenerate());
-	assert(!a.IsFinite());
+	mgl_assert(a.IsDegenerate());
+	mgl_assert(!a.IsFinite());
 
 	a = AABB(vec::zero, vec::one);
-	assert(!a.IsDegenerate());
-	assert(a.IsFinite());
+	mgl_assert(!a.IsDegenerate());
+	mgl_assert(a.IsFinite());
 
 	a = AABB(vec::zero, vec::inf);
-	assert(!a.IsDegenerate());
-	assert(!a.IsFinite());
+	mgl_assert(!a.IsDegenerate());
+	mgl_assert(!a.IsFinite());
 
 	a = AABB(vec::zero, vec::zero);
-	assert(a.IsDegenerate());
-	assert(a.IsFinite());
+	mgl_assert(a.IsDegenerate());
+	mgl_assert(a.IsFinite());
 
 	a = AABB(vec::zero, -vec::zero);
-	assert(a.IsDegenerate());
-	assert(a.IsFinite());
+	mgl_assert(a.IsDegenerate());
+	mgl_assert(a.IsFinite());
 
 	a = AABB(vec::zero, -vec::one);
-	assert(a.IsDegenerate());
-	assert(a.IsFinite());
+	mgl_assert(a.IsDegenerate());
+	mgl_assert(a.IsFinite());
 
 	a = AABB(vec::zero, -vec::inf);
-	assert(a.IsDegenerate());
-	assert(!a.IsFinite());
+	mgl_assert(a.IsDegenerate());
+	mgl_assert(!a.IsFinite());
 
 	a = AABB(vec::inf, -vec::inf);
-	assert(a.IsDegenerate());
-	assert(!a.IsFinite());
+	mgl_assert(a.IsDegenerate());
+	mgl_assert(!a.IsFinite());
 
 	a = AABB(-vec::inf, vec::inf);
-	assert(!a.IsDegenerate());
-	assert(!a.IsFinite());
+	mgl_assert(!a.IsDegenerate());
+	mgl_assert(!a.IsFinite());
 }
 
 UNIQUE_TEST(OBBIsDegenerate)
 {
 	OBB o = AABB(vec::nan, vec::nan);
-	assert(o.IsDegenerate());
-	assert(!o.IsFinite());
+	mgl_assert(o.IsDegenerate());
+	mgl_assert(!o.IsFinite());
 
 	o = OBB(AABB(vec::zero, vec::nan));
-	assert(o.IsDegenerate());
-	assert(!o.IsFinite());
+	mgl_assert(o.IsDegenerate());
+	mgl_assert(!o.IsFinite());
 
 	o = OBB(AABB(vec::zero, vec::one));
-	assert(!o.IsDegenerate());
-	assert(o.IsFinite());
+	mgl_assert(!o.IsDegenerate());
+	mgl_assert(o.IsFinite());
 
 	o = OBB(AABB(vec::zero, vec::inf));
-	assert(!o.IsDegenerate());
-	assert(!o.IsFinite());
+	mgl_assert(!o.IsDegenerate());
+	mgl_assert(!o.IsFinite());
 
 	o = OBB(AABB(vec::zero, vec::zero));
-	assert(o.IsDegenerate());
-	assert(o.IsFinite());
+	mgl_assert(o.IsDegenerate());
+	mgl_assert(o.IsFinite());
 
 	o = OBB(AABB(vec::zero, -vec::zero));
-	assert(o.IsDegenerate());
-	assert(o.IsFinite());
+	mgl_assert(o.IsDegenerate());
+	mgl_assert(o.IsFinite());
 
 	o = OBB(AABB(vec::zero, -vec::one));
-	assert(o.IsDegenerate());
-	assert(o.IsFinite());
+	mgl_assert(o.IsDegenerate());
+	mgl_assert(o.IsFinite());
 
 	o = OBB(AABB(vec::zero, -vec::inf));
-	assert(o.IsDegenerate());
-	assert(!o.IsFinite());
+	mgl_assert(o.IsDegenerate());
+	mgl_assert(!o.IsFinite());
 
 	o = OBB(AABB(vec::inf, -vec::inf));
-	assert(o.IsDegenerate());
-	assert(!o.IsFinite());
+	mgl_assert(o.IsDegenerate());
+	mgl_assert(!o.IsFinite());
 
 	o = OBB(AABB(-vec::inf, vec::inf));
-	assert(!o.IsDegenerate());
-	assert(!o.IsFinite());
+	mgl_assert(!o.IsDegenerate());
+	mgl_assert(!o.IsFinite());
 }
 
 UNIQUE_TEST(AABB_Volume)
 {
 	AABB a(POINT_VEC_SCALAR(-1.f), POINT_VEC_SCALAR(1.f));
-	assert(a.Volume() == 8.f);
+	mgl_assert(a.Volume() == 8.f);
 }
 
 MATH_END_NAMESPACE

--- a/tests/CallstackTests.cpp
+++ b/tests/CallstackTests.cpp
@@ -16,6 +16,6 @@ UNIQUE_TEST(CaptureCallstack)
 	LOGI("-- begin callstack -- ");
 	printf("%s", callstack.c_str());
 	LOGI("-- end callstack -- ");
-	assert1(callstack.find("CapturingCallstacksWorks") != std::string::npos, callstack);
+	mgl_assert1(callstack.find("CapturingCallstacksWorks") != std::string::npos, callstack);
 }
 #endif

--- a/tests/Circle2DTests.cpp
+++ b/tests/Circle2DTests.cpp
@@ -16,13 +16,13 @@ RANDOMIZED_TEST(Circle2D_OptimalEnclosingCircle_Random_3)
 		pts.push_back(c.RandomPointInside(rng));
 
 	Circle2D optimalEnclosingCircle = Circle2D::OptimalEnclosingCircle(pts[0], pts[1], pts[2]);
-	assert2(optimalEnclosingCircle.r <= c.r + 1e-2f, optimalEnclosingCircle.r, c.r);
+	mgl_assert2(optimalEnclosingCircle.r <= c.r + 1e-2f, optimalEnclosingCircle.r, c.r);
 	for (size_t i = 0; i < pts.size(); ++i)
 	{
 		if (!optimalEnclosingCircle.Contains(pts[i]))
 			for (size_t j = 0; j < pts.size(); ++j)
 				LOGI("%d %f %s", (int)j, optimalEnclosingCircle.SignedDistance(pts[i]), pts[j].SerializeToCodeString().c_str());
-		assert3(optimalEnclosingCircle.Contains(pts[i], 1e-3f), optimalEnclosingCircle, pts[i], optimalEnclosingCircle.SignedDistance(pts[i]));
+		mgl_assert3(optimalEnclosingCircle.Contains(pts[i], 1e-3f), optimalEnclosingCircle, pts[i], optimalEnclosingCircle.SignedDistance(pts[i]));
 	}
 }
 
@@ -34,9 +34,9 @@ RANDOMIZED_TEST(Circle2D_OptimalEnclosingCircle_Random_N)
 		pts.push_back(c.RandomPointInside(rng));
 
 	Circle2D optimalEnclosingCircle = Circle2D::OptimalEnclosingCircle(&pts[0], (int)pts.size());
-	assert2(optimalEnclosingCircle.r <= c.r + 1e-2f, optimalEnclosingCircle.r, c.r);
+	mgl_assert2(optimalEnclosingCircle.r <= c.r + 1e-2f, optimalEnclosingCircle.r, c.r);
 	for (size_t i = 0; i < pts.size(); ++i)
-		assert3(optimalEnclosingCircle.Contains(pts[i], 1e-3f), optimalEnclosingCircle, pts[i], optimalEnclosingCircle.SignedDistance(pts[i]));
+		mgl_assert3(optimalEnclosingCircle.Contains(pts[i], 1e-3f), optimalEnclosingCircle, pts[i], optimalEnclosingCircle.SignedDistance(pts[i]));
 }
 
 UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case1)
@@ -45,9 +45,9 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case1)
 	float2 b(49.150211f, 58.530991f);
 	float2 c(-55.001110f, 82.599510f);
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(a, b, c);
-	assert(EqualAbs(circle.pos.Distance(a), 56.53574f));
-	assert(EqualAbs(circle.pos.Distance(b), 56.53574f));
-	assert(EqualAbs(circle.pos.Distance(c), 56.53574f));
+	mgl_assert(EqualAbs(circle.pos.Distance(a), 56.53574f));
+	mgl_assert(EqualAbs(circle.pos.Distance(b), 56.53574f));
+	mgl_assert(EqualAbs(circle.pos.Distance(c), 56.53574f));
 }
 
 UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case2)
@@ -61,9 +61,9 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case2)
 	};
 
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(pts, 5);
-	assert1(EqualAbs(circle.r, 12.8316f), circle.r);
-	assert(EqualAbs(circle.pos.x, -5.778261184692383f));
-	assert(EqualAbs(circle.pos.y, -4.908695220947266f));
+	mgl_assert1(EqualAbs(circle.r, 12.8316f), circle.r);
+	mgl_assert(EqualAbs(circle.pos.x, -5.778261184692383f));
+	mgl_assert(EqualAbs(circle.pos.y, -4.908695220947266f));
 }
 
 UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case3)
@@ -79,9 +79,9 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case3)
 
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(pts, 6);
 
-	assert1(EqualAbs(circle.r, 25.2722f), circle.r);
-	assert(EqualAbs(circle.pos.x, -103.81974792480469f));
-	assert(EqualAbs(circle.pos.y, 63.85783767700195f));
+	mgl_assert1(EqualAbs(circle.r, 25.2722f), circle.r);
+	mgl_assert(EqualAbs(circle.pos.x, -103.81974792480469f));
+	mgl_assert(EqualAbs(circle.pos.y, 63.85783767700195f));
 
 }
 
@@ -99,9 +99,9 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case4)
 
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(pts, 7);
 
-	assert1(EqualAbs(circle.r, 62.6996f), circle.r);
-	assert(EqualAbs(circle.pos.x, 133.76840209960938f));
-	assert(EqualAbs(circle.pos.y, 41.58528137207031f));
+	mgl_assert1(EqualAbs(circle.r, 62.6996f), circle.r);
+	mgl_assert(EqualAbs(circle.pos.x, 133.76840209960938f));
+	mgl_assert(EqualAbs(circle.pos.y, 41.58528137207031f));
 }
 
 UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case5)
@@ -113,9 +113,9 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case5)
 	};
 
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(pts, 3);
-	assert1(EqualAbs(circle.r, 0.5f, 1e-2f), circle.r);
-	assert(EqualAbs(circle.pos.x, 0.5f));
-	assert(EqualAbs(circle.pos.y, 0.f));
+	mgl_assert1(EqualAbs(circle.r, 0.5f, 1e-2f), circle.r);
+	mgl_assert(EqualAbs(circle.pos.x, 0.5f));
+	mgl_assert(EqualAbs(circle.pos.y, 0.f));
 }
 
 UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case6)
@@ -127,12 +127,12 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case6)
 	};
 
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(pts[0], pts[1], pts[2]);
-	assert(circle.Contains(pts[0]));
-	assert(circle.Contains(pts[1]));
-	assert(circle.Contains(pts[2]));
-	assert1(EqualAbs(circle.r, 79.829f), circle.r);
-	assert(EqualAbs(circle.pos.x, -127.111092f));
-	assert(EqualAbs(circle.pos.y, 57.3470802f));
+	mgl_assert(circle.Contains(pts[0]));
+	mgl_assert(circle.Contains(pts[1]));
+	mgl_assert(circle.Contains(pts[2]));
+	mgl_assert1(EqualAbs(circle.r, 79.829f), circle.r);
+	mgl_assert(EqualAbs(circle.pos.x, -127.111092f));
+	mgl_assert(EqualAbs(circle.pos.y, 57.3470802f));
 }
 
 UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case7)
@@ -141,9 +141,9 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case7)
 	float2 b(-26.206756591796875f, -49.47246170043945f);
 	float2 c(-25.87479591369629f, -49.58361053466797f);
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(a, b, c);
-	assert2(circle.Contains(a), circle.SignedDistance(a), circle);
-	assert2(circle.Contains(b), circle.SignedDistance(b), circle);
-	assert2(circle.Contains(c), circle.SignedDistance(c), circle);
+	mgl_assert2(circle.Contains(a), circle.SignedDistance(a), circle);
+	mgl_assert2(circle.Contains(b), circle.SignedDistance(b), circle);
+	mgl_assert2(circle.Contains(c), circle.SignedDistance(c), circle);
 }
 
 UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case8)
@@ -152,9 +152,9 @@ UNIQUE_TEST(Circle2D_OptimalEnclosingCircle_Case8)
 	float2 b(95.8228759765625f, -74.76484680175781f);
 	float2 c(96.95646667480469f, -73.947662353515625f);
 	Circle2D circle = Circle2D::OptimalEnclosingCircle(a, b, c);
-	assert2(circle.Contains(a), circle.SignedDistance(a), circle);
-	assert2(circle.Contains(b), circle.SignedDistance(b), circle);
-	assert2(circle.Contains(c), circle.SignedDistance(c), circle);
+	mgl_assert2(circle.Contains(a), circle.SignedDistance(a), circle);
+	mgl_assert2(circle.Contains(b), circle.SignedDistance(b), circle);
+	mgl_assert2(circle.Contains(c), circle.SignedDistance(c), circle);
 }
 
 BENCHMARK(Circle2D_OptimalEnclosingCircle3_bench, "Circle2D::OptimalEnclosingCircle(a,b,c)")

--- a/tests/ClockTests.cpp
+++ b/tests/ClockTests.cpp
@@ -13,12 +13,12 @@ TEST(MonotonousClock)
 	{
 		tick_t now = Clock::Tick();
 		tick_t diff = Clock::TicksInBetween(now, prev);
-		assert(diff < Clock::TicksPerSec());
+		mgl_assert(diff < Clock::TicksPerSec());
 		prev = now;
 		maxDiff = Max(diff, maxDiff);
 	}
 
-	assert(maxDiff > 0); // The clock must proceed at least some amount.
+	mgl_assert(maxDiff > 0); // The clock must proceed at least some amount.
 }
 
 UNIQUE_TEST(ClockPrecision)
@@ -50,7 +50,7 @@ UNIQUE_TEST(SubMillisecondPrecision)
 	tick_t ticksPerMillisecond = Clock::TicksPerMillisecond();
 	MARK_UNUSED(ticksPerMillisecond);
 #ifndef MATH_TICK_IS_FLOAT
-	assert1(ticksPerMillisecond > 1, (u32)ticksPerMillisecond);
+	mgl_assert1(ticksPerMillisecond > 1, (u32)ticksPerMillisecond);
 #endif
 
 	tick_t minDiff = Clock::TicksPerSec();
@@ -69,10 +69,10 @@ UNIQUE_TEST(SubMillisecondPrecision)
 		prev = now;
 	}
 
-	LOGI("Smallest observed non-zero delta in Clock::Tick() is %d ticks. A zero delta was observed %d times (out of %d tests)", 
+	LOGI("Smallest observed non-zero delta in Clock::Tick() is %d ticks. A zero delta was observed %d times (out of %d tests)",
 		(int)minDiff, numTimesZeroDiff, numIters);
-	assert(minDiff > 0);
-	assert(minDiff < ticksPerMillisecond/2); // Smallest met quantity must be less than half a millisecond.
+	mgl_assert(minDiff > 0);
+	mgl_assert(minDiff < ticksPerMillisecond/2); // Smallest met quantity must be less than half a millisecond.
 }
 
 volatile tick_t dummyGlobalTicks = 0;

--- a/tests/ConversionTests.cpp
+++ b/tests/ConversionTests.cpp
@@ -104,7 +104,7 @@ int U32ToString_SSE(u32 i, char *str)
 	// 4e9 / 1e8 -> [ 42 (64), 94967295 (64) ]
 	//     / 1e4 -> [ .. (32), 42 (32), 9496 (32), 7295 (32) ]
 	//     / 1e2 -> [ (16), (16), (16), 42 (16), 94 (16), 96 (16), 72 (16), 95 (16) ]
-	//     / 10  -> [ 
+	//     / 10  -> [
 
 	__m128i v = INT_TO_M128((int)i);
 
@@ -155,7 +155,7 @@ RANDOMIZED_TEST(U32ToString_SSE)
 		u32 n = rng.Int();
 		U32ToString_SSE(n+m, str);
 		U32ToString(n+m, str2);
-		assert2(!strcmp(str, str2), std::string(str), std::string(str2));
+		mgl_assert2(!strcmp(str, str2), std::string(str), std::string(str2));
 	}
 }
 
@@ -218,13 +218,13 @@ RANDOMIZED_TEST(IntToString)
 		if (i == 42) i = rng.Int();
 		char str[32] = {};
 		int len = IntToString(i, str);
-		assert(len > 0);
+		mgl_assert(len > 0);
 		MARK_UNUSED(len);
-		assert(strlen(str) == (size_t)len);
+		mgl_assert(strlen(str) == (size_t)len);
 		char str2[32] = {};
 		sprintf(str2, "%d", i);
 	//	printf("i: %d, str: %s, str2: %s\n", i, str, str2);
-		assert(!strcmp(str, str2));
+		mgl_assert(!strcmp(str, str2));
 	}
 }
 
@@ -261,13 +261,13 @@ RANDOMIZED_TEST(U32ToString)
 		if (i == 42) i = (u32)rng.Int();
 		char str[32] = {};
 		int len = U32ToString(i, str);
-		assert(len > 0);
+		mgl_assert(len > 0);
 		MARK_UNUSED(len);
-		assert(strlen(str) == (size_t)len);
+		mgl_assert(strlen(str) == (size_t)len);
 		char str2[32] = {};
 		sprintf(str2, "%lu", (unsigned long)i);
 	//	printf("i: %d, str: %s, str2: %s\n", i, str, str2);
-		assert(!strcmp(str, str2));
+		mgl_assert(!strcmp(str, str2));
 	}
 }
 

--- a/tests/DegenerateTests.cpp
+++ b/tests/DegenerateTests.cpp
@@ -9,47 +9,47 @@ TEST(AABB_Degenerate)
 {
 	AABB a;
 	a.SetNegativeInfinity();
-	assert(a.IsDegenerate());
+	mgl_assert(a.IsDegenerate());
 
 	a = AABB(POINT_VEC_SCALAR(0.f), POINT_VEC_SCALAR(1.f));
-	assert(!a.IsDegenerate());
+	mgl_assert(!a.IsDegenerate());
 }
 
 TEST(OBB_Degenerate)
 {
 	OBB o;
 	o.SetNegativeInfinity();
-	assert(o.IsDegenerate());
+	mgl_assert(o.IsDegenerate());
 
 	o = OBB(AABB(POINT_VEC_SCALAR(0.f), POINT_VEC_SCALAR(1.f)));
-	assert1(!o.IsDegenerate(), o);
+	mgl_assert1(!o.IsDegenerate(), o);
 }
 
 TEST(Capsule_Degenerate)
 {
 	Capsule c;
 	c.SetDegenerate();
-	assert(c.IsDegenerate());
+	mgl_assert(c.IsDegenerate());
 
 	c = Capsule(POINT_VEC_SCALAR(0.f), POINT_VEC_SCALAR(1.f), 1.f);
-	assert(!c.IsDegenerate());
+	mgl_assert(!c.IsDegenerate());
 }
 /* ///\todo Implement.
 TEST(Circle_Degenerate)
 {
 	Circle c;
 	c.SetDegenerate();
-	assert(c.IsDegenerate());
+	mgl_assert(c.IsDegenerate());
 
 	c = Circle(float3::zero, float3::unitX, 1.f);
-	assert(!c.IsDegenerate());
+	mgl_assert(!c.IsDegenerate());
 }
 
 TEST(Frustum_Degenerate)
 {
 	Frustum f;
 	f.SetDegenerate();
-	assert(f.IsDegenerate());
+	mgl_assert(f.IsDegenerate());
 
 	f.type = OrthographicFrustum;
 	f.pos = float3::zero;
@@ -59,87 +59,87 @@ TEST(Frustum_Degenerate)
 	f.farPlaneDistance = 1.f;
 	f.orthographicWidth = 1.f;
 	f.orthographicHeight = 1.f;
-	assert(!f.IsDegenerate());
+	mgl_assert(!f.IsDegenerate());
 }
 
 TEST(Line_Degenerate)
 {
 	Line l;
 	l.SetDegenerate();
-	assert(l.IsDegenerate());
+	mgl_assert(l.IsDegenerate());
 
 	l = Line(float3::zero, float3::unitX);
-	assert(!l.IsDegenerate());
+	mgl_assert(!l.IsDegenerate());
 }
 
 TEST(LineSegment_Degenerate)
 {
 	LineSegment l;
 	l.SetDegenerate();
-	assert(l.IsDegenerate());
+	mgl_assert(l.IsDegenerate());
 
 	l = LineSegment(float3::zero, float3::unitX);
-	assert(!l.IsDegenerate());
+	mgl_assert(!l.IsDegenerate());
 }
 
 TEST(Plane_Degenerate)
 {
 	Plane p;
 	p.SetDegenerate();
-	assert(p.IsDegenerate());
+	mgl_assert(p.IsDegenerate());
 
 	p = Plane(float3::unitX, 1.f);
-	assert(!p.IsDegenerate());
+	mgl_assert(!p.IsDegenerate());
 }
 
 TEST(Polygon_Degenerate)
 {
 	Polygon p;
 	p.SetDegenerate();
-	assert(p.IsDegenerate());
+	mgl_assert(p.IsDegenerate());
 
 	p = Triangle(float3::unitX, float3::unitY, float3::unitZ).ToPolygon();
-	assert(!p.IsDegenerate());
+	mgl_assert(!p.IsDegenerate());
 }
 
 TEST(Polyhedron_Degenerate)
 {
 	Polyhedron p;
 	p.SetDegenerate();
-	assert(p.IsDegenerate());
+	mgl_assert(p.IsDegenerate());
 
 	p = Polyhedron::Tetrahedron();
-	assert(!p.IsDegenerate());
+	mgl_assert(!p.IsDegenerate());
 }
 
 TEST(Ray_Degenerate)
 {
 	Ray r;
 	r.SetDegenerate();
-	assert(r.IsDegenerate());
+	mgl_assert(r.IsDegenerate());
 
 	r = Ray(float3::zero, float3::unitX);
-	assert(!r.IsDegenerate());
+	mgl_assert(!r.IsDegenerate());
 }
 */
 TEST(Sphere_Degenerate)
 {
 	Sphere s;
 	s.SetDegenerate();
-	assert(s.IsDegenerate());
+	mgl_assert(s.IsDegenerate());
 
 	s = Sphere(POINT_VEC_SCALAR(0.f), POINT_VEC(float3::unitX));
-	assert(!s.IsDegenerate());
+	mgl_assert(!s.IsDegenerate());
 }
 /* ///\todo Implement.
 TEST(Triangle_Degenerate)
 {
 	Triangle t;
 	t.SetDegenerate();
-	assert(t.IsDegenerate());
+	mgl_assert(t.IsDegenerate());
 
 	t = Triangle(float3::unitX, float3::unitY, float3::unitZ);
-	assert(!t.IsDegenerate());
+	mgl_assert(!t.IsDegenerate());
 }
 */
 

--- a/tests/EncloseTests.cpp
+++ b/tests/EncloseTests.cpp
@@ -71,17 +71,17 @@ RANDOMIZED_TEST(AABB_Enclose_point)
 	vec pt = RandomPointNearOrigin(DISTSCALE);
 	aabb.Enclose(pt);
 
-	assert(aabb.Contains(pt));
+	mgl_assert(aabb.Contains(pt));
 }
 
-/** @bug Improve numerical stability of the test with epsilon and enable this test. 
+/** @bug Improve numerical stability of the test with epsilon and enable this test.
 RANDOMIZED_TEST(OBB_Enclose_point)
 {
 	OBB obb = RandomOBBNearOrigin(DISTSCALE, SIZESCALE);
 	vec pt = RandomPointNearOrigin(DISTSCALE);
 	obb.Enclose(pt);
 
-	assert(obb.Contains(pt));
+	mgl_assert(obb.Contains(pt));
 } */
 
 RANDOMIZED_TEST(AABB_Enclose_LineSegment)
@@ -90,7 +90,7 @@ RANDOMIZED_TEST(AABB_Enclose_LineSegment)
 	LineSegment ls = RandomLineSegmentNearOrigin(DISTSCALE);
 	aabb.Enclose(ls);
 
-	assert(aabb.Contains(ls));
+	mgl_assert(aabb.Contains(ls));
 }
 
 RANDOMIZED_TEST(AABB_Enclose_AABB)
@@ -99,17 +99,17 @@ RANDOMIZED_TEST(AABB_Enclose_AABB)
 	AABB aabb2 = RandomAABBNearOrigin(DISTSCALE, SIZESCALE);
 	aabb.Enclose(aabb2);
 
-	assert(aabb.Contains(aabb2));
+	mgl_assert(aabb.Contains(aabb2));
 }
 
-/** @bug Improve numerical stability of the test with epsilon and enable this test. 
+/** @bug Improve numerical stability of the test with epsilon and enable this test.
 RANDOMIZED_TEST(AABB_Enclose_OBB)
 {
 	AABB aabb = RandomAABBNearOrigin(DISTSCALE, SIZESCALE);
 	OBB obb = RandomOBBNearOrigin(DISTSCALE, SIZESCALE);
 	aabb.Enclose(obb);
 
-	assert(aabb.Contains(obb));
+	mgl_assert(aabb.Contains(obb));
 } */
 
 RANDOMIZED_TEST(AABB_Enclose_Sphere)
@@ -118,7 +118,7 @@ RANDOMIZED_TEST(AABB_Enclose_Sphere)
 	Sphere s = RandomSphereNearOrigin(DISTSCALE, SIZESCALE);
 	aabb.Enclose(s);
 
-	assert(aabb.Contains(s));
+	mgl_assert(aabb.Contains(s));
 }
 
 RANDOMIZED_TEST(AABB_Enclose_Triangle)
@@ -127,7 +127,7 @@ RANDOMIZED_TEST(AABB_Enclose_Triangle)
 	Triangle t = RandomTriangleNearOrigin(DISTSCALE);
 	aabb.Enclose(t);
 
-	assert(aabb.Contains(t));
+	mgl_assert(aabb.Contains(t));
 }
 
 RANDOMIZED_TEST(AABB_Enclose_Capsule)
@@ -136,7 +136,7 @@ RANDOMIZED_TEST(AABB_Enclose_Capsule)
 	Capsule c = RandomCapsuleNearOrigin(DISTSCALE);
 	aabb.Enclose(c);
 
-	assert(aabb.Contains(c));
+	mgl_assert(aabb.Contains(c));
 }
 
 RANDOMIZED_TEST(AABB_Enclose_Frustum)
@@ -145,7 +145,7 @@ RANDOMIZED_TEST(AABB_Enclose_Frustum)
 	Frustum f = RandomFrustumNearOrigin(DISTSCALE);
 	aabb.Enclose(f);
 
-	assert(aabb.Contains(f));
+	mgl_assert(aabb.Contains(f));
 }
 
 RANDOMIZED_TEST(AABB_Enclose_Polygon)
@@ -154,7 +154,7 @@ RANDOMIZED_TEST(AABB_Enclose_Polygon)
 	Polygon p = RandomPolygonNearOrigin(DISTSCALE);
 	aabb.Enclose(p);
 
-	assert2(aabb.Contains(p), aabb, p);
+	mgl_assert2(aabb.Contains(p), aabb, p);
 }
 
 RANDOMIZED_TEST(AABB_Enclose_Polyhedron)
@@ -163,7 +163,7 @@ RANDOMIZED_TEST(AABB_Enclose_Polyhedron)
 	Polyhedron p = RandomPolyhedronNearOrigin(DISTSCALE);
 	aabb.Enclose(p);
 
-	assert2(aabb.Contains(p), aabb, p);
+	mgl_assert2(aabb.Contains(p), aabb, p);
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_point)
@@ -172,7 +172,7 @@ RANDOMIZED_TEST(Sphere_Enclose_point)
 	vec pt = RandomPointNearOrigin(DISTSCALE);
 	s.Enclose(pt);
 
-	assert3(s.Contains(pt), s, pt, s.Distance(pt));
+	mgl_assert3(s.Contains(pt), s, pt, s.Distance(pt));
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_LineSegment)
@@ -181,7 +181,7 @@ RANDOMIZED_TEST(Sphere_Enclose_LineSegment)
 	LineSegment ls = RandomLineSegmentNearOrigin(DISTSCALE);
 	s.Enclose(ls);
 
-	assert(s.Contains(ls));
+	mgl_assert(s.Contains(ls));
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_AABB)
@@ -190,7 +190,7 @@ RANDOMIZED_TEST(Sphere_Enclose_AABB)
 	Sphere aabb = RandomSphereNearOrigin(DISTSCALE, SIZESCALE);
 	s.Enclose(aabb);
 
-	assert(s.Contains(aabb));
+	mgl_assert(s.Contains(aabb));
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_OBB)
@@ -199,7 +199,7 @@ RANDOMIZED_TEST(Sphere_Enclose_OBB)
 	OBB obb = RandomOBBNearOrigin(DISTSCALE, SIZESCALE);
 	s.Enclose(obb);
 
-	assert(s.Contains(obb));
+	mgl_assert(s.Contains(obb));
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_Sphere)
@@ -208,7 +208,7 @@ RANDOMIZED_TEST(Sphere_Enclose_Sphere)
 	Sphere s2 = RandomSphereNearOrigin(DISTSCALE, SIZESCALE);
 	s.Enclose(s2);
 
-	assert(s.Contains(s2));
+	mgl_assert(s.Contains(s2));
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_Triangle)
@@ -217,7 +217,7 @@ RANDOMIZED_TEST(Sphere_Enclose_Triangle)
 	Triangle t = RandomTriangleNearOrigin(DISTSCALE);
 	s.Enclose(t);
 
-	assert(s.Contains(t));
+	mgl_assert(s.Contains(t));
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_Capsule)
@@ -226,7 +226,7 @@ RANDOMIZED_TEST(Sphere_Enclose_Capsule)
 	Capsule c = RandomCapsuleNearOrigin(DISTSCALE);
 	s.Enclose(c);
 
-	assert2(s.Contains(c), s.SerializeToCodeString(), c.SerializeToCodeString());
+	mgl_assert2(s.Contains(c), s.SerializeToCodeString(), c.SerializeToCodeString());
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_Frustum)
@@ -235,7 +235,7 @@ RANDOMIZED_TEST(Sphere_Enclose_Frustum)
 	Frustum f = RandomFrustumNearOrigin(DISTSCALE);
 	s.Enclose(f);
 
-	assert2(s.Contains(f), s, f);
+	mgl_assert2(s.Contains(f), s, f);
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_Polygon)
@@ -244,7 +244,7 @@ RANDOMIZED_TEST(Sphere_Enclose_Polygon)
 	Polygon p = RandomPolygonNearOrigin(DISTSCALE);
 	s.Enclose(p);
 
-	assert2(s.Contains(p), s, p);
+	mgl_assert2(s.Contains(p), s, p);
 }
 
 RANDOMIZED_TEST(Sphere_Enclose_Polyhedron)
@@ -253,5 +253,5 @@ RANDOMIZED_TEST(Sphere_Enclose_Polyhedron)
 	Polyhedron p = RandomPolyhedronNearOrigin(DISTSCALE);
 	s.Enclose(p);
 
-	assert2(s.Contains(p), s, p);
+	mgl_assert2(s.Contains(p), s, p);
 }

--- a/tests/Float4dTests.cpp
+++ b/tests/Float4dTests.cpp
@@ -17,7 +17,7 @@ TEST(Float4dDot)
 {
 	float4d f(-1.f, 2.f, 3.f, -4.f);
 	float4d f2(2.f, -1.f, 0.f, 4.f);
-	assert(EqualAbs((float)f.Dot(f2), -20.f));
+	mgl_assert(EqualAbs((float)f.Dot(f2), -20.f));
 }
 
 TEST(Float4dOpAdd)
@@ -25,7 +25,7 @@ TEST(Float4dOpAdd)
 	float4d f = float4d(1,2,3,4);
 	float4d f2 = float4d(-5.f, -6.f, -7.f, -8.f);
 	float4d f3 = f + f2;
-	assert(f3.Equals(float4d(-4.f, -4.f, -4.f, -4.f)));
+	mgl_assert(f3.Equals(float4d(-4.f, -4.f, -4.f, -4.f)));
 }
 
 TEST(Float4dOpSub)
@@ -33,7 +33,7 @@ TEST(Float4dOpSub)
 	float4d f = float4d(1,2,3,4);
 	float4d f2 = float4d(-5.f, -6.f, -7.f, -8.f);
 	float4d f3 = f - f2;
-	assert(f3.Equals(float4d(6.f, 8.f, 10.f, 12.f)));
+	mgl_assert(f3.Equals(float4d(6.f, 8.f, 10.f, 12.f)));
 }
 
 TEST(Float4dOpMul)
@@ -42,8 +42,8 @@ TEST(Float4dOpMul)
 	float scalar = -2.f;
 
 	float4d f2 = scalar * f;
-	
-	assert(f2.Equals(float4d(-2.f, -4.f, -6.f, -8.f)));
+
+	mgl_assert(f2.Equals(float4d(-2.f, -4.f, -6.f, -8.f)));
 }
 
 TEST(Float4dCross)
@@ -52,14 +52,14 @@ TEST(Float4dCross)
 	float4d f2(2.f, -1.f, 0.f, 4.f);
 
 	float4d f3 = f.Cross(f2);
-	assert(f3.Equals(float4d(3.f, 6.f, -3.f, 0.f)));
+	mgl_assert(f3.Equals(float4d(3.f, 6.f, -3.f, 0.f)));
 
 	float4d z = float4d::unitX.Cross(float4d::unitY);
 	float4d y = float4d::unitZ.Cross(float4d::unitX);
 	float4d x = float4d::unitY.Cross(float4d::unitZ);
-	assert(x.Equals(float4d(1,0,0,0)));
-	assert(y.Equals(float4d(0,1,0,0)));
-	assert(z.Equals(float4d(0,0,1,0)));
+	mgl_assert(x.Equals(float4d(1,0,0,0)));
+	mgl_assert(y.Equals(float4d(0,1,0,0)));
+	mgl_assert(z.Equals(float4d(0,0,1,0)));
 }
 
 RANDOMIZED_TEST(Float4dCross_random)
@@ -72,70 +72,70 @@ RANDOMIZED_TEST(Float4dCross_random)
 
 	float4d d3 = d1.Cross(d2);
 	float4 f3 = f1.Cross(f2);
-	assert(float4d(f3).Equals(d3));
+	mgl_assert(float4d(f3).Equals(d3));
 }
 
 TEST(Float4dDistance4Sq)
 {
 	float4d f(1.f, 2.f, 3.f, 4.f);
 	float4d f2(-1.f, -2.f, -3.f, -4.f);
-	assert(EqualAbs((float)f.Distance4Sq(f2), 120.f));
+	mgl_assert(EqualAbs((float)f.Distance4Sq(f2), 120.f));
 }
 
 TEST(Float4dDistance3Sq)
 {
 	float4d f(1.f, 2.f, 3.f, 4.f);
 	float4d f2(-1.f, -2.f, -3.f, -4.f);
-	assert(EqualAbs((float)f.Distance3Sq(f2), 56.f));
+	mgl_assert(EqualAbs((float)f.Distance3Sq(f2), 56.f));
 }
 
 TEST(Float4dNormalize4)
 {
 	float4d f(-1.f, 2.f, 3.f, 4.f);
 	double oldLength = f.Normalize();
-	assert2(EqualAbs((float)oldLength, Sqrt(30.f)), (float)oldLength, Sqrt(30.f));
-	assert2(EqualAbs((float)f.x, -1.f / Sqrt(30.f)), (float)f.x, -1.f / Sqrt(30.f));
-	assert2(EqualAbs((float)f.y, 2.f / Sqrt(30.f)), (float)f.y, 2.f / Sqrt(30.f));
-	assert2(EqualAbs((float)f.z, 3.f / Sqrt(30.f)), (float)f.z, 3.f / Sqrt(30.f));
-	assert2(EqualAbs((float)f.w, 4.f / Sqrt(30.f)), (float)f.w, 4.f / Sqrt(30.f));
+	mgl_assert2(EqualAbs((float)oldLength, Sqrt(30.f)), (float)oldLength, Sqrt(30.f));
+	mgl_assert2(EqualAbs((float)f.x, -1.f / Sqrt(30.f)), (float)f.x, -1.f / Sqrt(30.f));
+	mgl_assert2(EqualAbs((float)f.y, 2.f / Sqrt(30.f)), (float)f.y, 2.f / Sqrt(30.f));
+	mgl_assert2(EqualAbs((float)f.z, 3.f / Sqrt(30.f)), (float)f.z, 3.f / Sqrt(30.f));
+	mgl_assert2(EqualAbs((float)f.w, 4.f / Sqrt(30.f)), (float)f.w, 4.f / Sqrt(30.f));
 
 	float4d f2(0,0,0, 0.f);
 	oldLength = f2.Normalize();
 	MARK_UNUSED(oldLength);
-	assert(oldLength == 0.f);
+	mgl_assert(oldLength == 0.f);
 
-  assert(EqualAbs((float)float4d(-1.f, 2.f, 3.f, 4.f).Normalize(), (float)float4d(-1.f, 2.f, 3.f, 4.f).Normalize4()));
+  mgl_assert(EqualAbs((float)float4d(-1.f, 2.f, 3.f, 4.f).Normalize(), (float)float4d(-1.f, 2.f, 3.f, 4.f).Normalize4()));
 }
 
 TEST(Float4dNormalize3)
 {
 	float4d f(-1.f, 2.f, 3.f, 4.f);
 	double oldLength = f.Normalize3();
-	assert2(EqualAbs((float)oldLength, Sqrt(14.f)), (float)oldLength, Sqrt(14.f));
-	assert2(EqualAbs((float)f.x, -1.f / Sqrt(14.f)), (float)f.x, -1.f / Sqrt(14.f));
-	assert2(EqualAbs((float)f.y, 2.f / Sqrt(14.f)), (float)f.y, 2.f / Sqrt(14.f));
-	assert2(EqualAbs((float)f.z, 3.f / Sqrt(14.f)), (float)f.z, 3.f / Sqrt(14.f));
-	assert2(EqualAbs((float)f.w, 4.f), (float)f.w, 4.f);
+	mgl_assert2(EqualAbs((float)oldLength, Sqrt(14.f)), (float)oldLength, Sqrt(14.f));
+	mgl_assert2(EqualAbs((float)f.x, -1.f / Sqrt(14.f)), (float)f.x, -1.f / Sqrt(14.f));
+	mgl_assert2(EqualAbs((float)f.y, 2.f / Sqrt(14.f)), (float)f.y, 2.f / Sqrt(14.f));
+	mgl_assert2(EqualAbs((float)f.z, 3.f / Sqrt(14.f)), (float)f.z, 3.f / Sqrt(14.f));
+	mgl_assert2(EqualAbs((float)f.w, 4.f), (float)f.w, 4.f);
 
 	float4d f2(0,0,0, 0.f);
 	oldLength = f2.Normalize3();
 	MARK_UNUSED(oldLength);
-	assert(oldLength == 0.f);
+	mgl_assert(oldLength == 0.f);
 }
 
 TEST(Float4dOpNeg)
 {
 	float4d f = float4d(1,2,3,4);
 	float4d f3 = -f;
-	assert(f3.Equals(float4d(-1.f, -2.f, -3.f, -4.f)));
+	mgl_assert(f3.Equals(float4d(-1.f, -2.f, -3.f, -4.f)));
 }
 
 TEST(Float4dToFloat4)
 {
 	float4d d = float4d(1,2,3,4);
 	float4 f = d.ToFloat4();
-	assert1(f.x == 1.f, f.x);
-	assert1(f.y == 2.f, f.y);
-	assert1(f.z == 3.f, f.z);
-	assert1(f.w == 4.f, f.w);
+	mgl_assert1(f.x == 1.f, f.x);
+	mgl_assert1(f.y == 2.f, f.y);
+	mgl_assert1(f.z == 3.f, f.z);
+	mgl_assert1(f.w == 4.f, f.w);
 }

--- a/tests/FrustumTests.cpp
+++ b/tests/FrustumTests.cpp
@@ -40,12 +40,12 @@ Frustum GenIdFrustum(FrustumType t, FrustumHandedness h, FrustumProjectiveSpace 
 		case 6: f = GenIdFrustum(OrthographicFrustum, FrustumLeftHanded, FrustumSpaceD3D); break; \
 		case 7: f = GenIdFrustum(OrthographicFrustum, FrustumRightHanded, FrustumSpaceD3D); break; \
 		} \
-		
+
 UNIQUE_TEST(Frustum_AspectRatio)
 {
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
-		assert(EqualAbs(f.AspectRatio(), 1.f));
+		mgl_assert(EqualAbs(f.AspectRatio(), 1.f));
 	}
 }
 
@@ -54,9 +54,9 @@ UNIQUE_TEST(Frustum_WorldRight)
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
 		if (f.Handedness() == FrustumRightHanded)
-			assert(f.WorldRight().Equals(DIR_VEC(1, 0, 0)));
+			mgl_assert(f.WorldRight().Equals(DIR_VEC(1, 0, 0)));
 		else // In the test func, all cameras look down to -Z, so left-handed cameras need to point their right towards -X then.
-			assert(f.WorldRight().Equals(DIR_VEC(-1, 0, 0)));
+			mgl_assert(f.WorldRight().Equals(DIR_VEC(-1, 0, 0)));
 	}
 }
 
@@ -64,12 +64,12 @@ UNIQUE_TEST(Frustum_Chirality)
 {
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
-		assert(f.WorldMatrix().Determinant() > 0.f);
-		assert(f.ViewMatrix().Determinant() > 0.f);
+		mgl_assert(f.WorldMatrix().Determinant() > 0.f);
+		mgl_assert(f.ViewMatrix().Determinant() > 0.f);
 		if (f.Handedness() == FrustumLeftHanded)
-			assert(f.ProjectionMatrix().Determinant4() > 0.f); // left-handed view -> projection space transform does not change handedness.
+			mgl_assert(f.ProjectionMatrix().Determinant4() > 0.f); // left-handed view -> projection space transform does not change handedness.
 		else
-			assert(f.ProjectionMatrix().Determinant4() < 0.f); // but right-handed transform should.
+			mgl_assert(f.ProjectionMatrix().Determinant4() < 0.f); // but right-handed transform should.
 	}
 }
 
@@ -77,11 +77,11 @@ UNIQUE_TEST(Frustum_Planes)
 {
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
-		assert(f.NearPlane().normal.Equals(DIR_VEC(0, 0, 1)));
-		assert(EqualAbs(f.NearPlane().d, -1.f));
+		mgl_assert(f.NearPlane().normal.Equals(DIR_VEC(0, 0, 1)));
+		mgl_assert(EqualAbs(f.NearPlane().d, -1.f));
 
-		assert(f.FarPlane().normal.Equals(DIR_VEC(0, 0, -1)));
-		assert(EqualAbs(f.FarPlane().d, 100.f));
+		mgl_assert(f.FarPlane().normal.Equals(DIR_VEC(0, 0, -1)));
+		mgl_assert(EqualAbs(f.FarPlane().d, 100.f));
 
 		for(int i = 0; i < 9; ++i)
 		{
@@ -90,13 +90,13 @@ UNIQUE_TEST(Frustum_Planes)
 				pt = f.CenterPoint();
 			else
 				pt = f.CornerPoint(i);
-			assert(f.NearPlane().SignedDistance(pt) < 1e-3f);
-			assert(f.FarPlane().SignedDistance(pt) < 1e-3f);
-			assert(f.LeftPlane().SignedDistance(pt) < 1e-3f);
-			assert(f.RightPlane().SignedDistance(pt) < 1e-3f);
-			assert(f.TopPlane().SignedDistance(pt) < 1e-3f);
-			assert(f.BottomPlane().SignedDistance(pt) < 1e-3f);
-			assert(f.Contains(pt));
+			mgl_assert(f.NearPlane().SignedDistance(pt) < 1e-3f);
+			mgl_assert(f.FarPlane().SignedDistance(pt) < 1e-3f);
+			mgl_assert(f.LeftPlane().SignedDistance(pt) < 1e-3f);
+			mgl_assert(f.RightPlane().SignedDistance(pt) < 1e-3f);
+			mgl_assert(f.TopPlane().SignedDistance(pt) < 1e-3f);
+			mgl_assert(f.BottomPlane().SignedDistance(pt) < 1e-3f);
+			mgl_assert(f.Contains(pt));
 		}
 	}
 }
@@ -109,47 +109,47 @@ UNIQUE_TEST(Frustum_Corners)
 		// Corner points are returned in XYZ order: 0: ---, 1: --+, 2: -+-, 3: -++, 4: +--, 5: +-+, 6: ++-, 7: +++
 		if (f.Type() == PerspectiveFrustum && f.Handedness() == FrustumLeftHanded)
 		{
-			assert(f.CornerPoint(0).Equals(POINT_VEC(1.f, -1.f, -1.f)));
-			assert(f.CornerPoint(1).Equals(POINT_VEC(100.f, -100.f, -100.f)));
-			assert(f.CornerPoint(2).Equals(POINT_VEC(1.f, 1, -1.f)));
-			assert(f.CornerPoint(3).Equals(POINT_VEC(100.f, 100.f, -100.f)));
-			assert(f.CornerPoint(4).Equals(POINT_VEC(-1.f, -1.f, -1.f)));
-			assert(f.CornerPoint(5).Equals(POINT_VEC(-100.f, -100.f, -100.f)));
-			assert(f.CornerPoint(6).Equals(POINT_VEC(-1.f, 1.f, -1.f)));
-			assert(f.CornerPoint(7).Equals(POINT_VEC(-100.f, 100.f, -100.f)));
+			mgl_assert(f.CornerPoint(0).Equals(POINT_VEC(1.f, -1.f, -1.f)));
+			mgl_assert(f.CornerPoint(1).Equals(POINT_VEC(100.f, -100.f, -100.f)));
+			mgl_assert(f.CornerPoint(2).Equals(POINT_VEC(1.f, 1, -1.f)));
+			mgl_assert(f.CornerPoint(3).Equals(POINT_VEC(100.f, 100.f, -100.f)));
+			mgl_assert(f.CornerPoint(4).Equals(POINT_VEC(-1.f, -1.f, -1.f)));
+			mgl_assert(f.CornerPoint(5).Equals(POINT_VEC(-100.f, -100.f, -100.f)));
+			mgl_assert(f.CornerPoint(6).Equals(POINT_VEC(-1.f, 1.f, -1.f)));
+			mgl_assert(f.CornerPoint(7).Equals(POINT_VEC(-100.f, 100.f, -100.f)));
 		}
 		else if (f.Type() == PerspectiveFrustum && f.Handedness() == FrustumRightHanded)
 		{
-			assert(f.CornerPoint(0).Equals(POINT_VEC(-1.f, -1.f, -1.f)));
-			assert(f.CornerPoint(1).Equals(POINT_VEC(-100.f, -100.f, -100.f)));
-			assert(f.CornerPoint(2).Equals(POINT_VEC(-1.f, 1, -1.f)));
-			assert(f.CornerPoint(3).Equals(POINT_VEC(-100.f, 100.f, -100.f)));
-			assert(f.CornerPoint(4).Equals(POINT_VEC(1.f, -1.f, -1.f)));
-			assert(f.CornerPoint(5).Equals(POINT_VEC(100.f, -100.f, -100.f)));
-			assert(f.CornerPoint(6).Equals(POINT_VEC(1.f, 1.f, -1.f)));
-			assert(f.CornerPoint(7).Equals(POINT_VEC(100.f, 100.f, -100.f)));
+			mgl_assert(f.CornerPoint(0).Equals(POINT_VEC(-1.f, -1.f, -1.f)));
+			mgl_assert(f.CornerPoint(1).Equals(POINT_VEC(-100.f, -100.f, -100.f)));
+			mgl_assert(f.CornerPoint(2).Equals(POINT_VEC(-1.f, 1, -1.f)));
+			mgl_assert(f.CornerPoint(3).Equals(POINT_VEC(-100.f, 100.f, -100.f)));
+			mgl_assert(f.CornerPoint(4).Equals(POINT_VEC(1.f, -1.f, -1.f)));
+			mgl_assert(f.CornerPoint(5).Equals(POINT_VEC(100.f, -100.f, -100.f)));
+			mgl_assert(f.CornerPoint(6).Equals(POINT_VEC(1.f, 1.f, -1.f)));
+			mgl_assert(f.CornerPoint(7).Equals(POINT_VEC(100.f, 100.f, -100.f)));
 		}
 		else if (f.Type() == OrthographicFrustum && f.Handedness() == FrustumLeftHanded)
 		{
-			assert(f.CornerPoint(0).Equals(POINT_VEC(50.f, -50.f, -1.f)));
-			assert(f.CornerPoint(1).Equals(POINT_VEC(50.f, -50.f, -100.f)));
-			assert(f.CornerPoint(2).Equals(POINT_VEC(50.f, 50.f, -1.f)));
-			assert(f.CornerPoint(3).Equals(POINT_VEC(50.f, 50.f, -100.f)));
-			assert(f.CornerPoint(4).Equals(POINT_VEC(-50.f, -50.f, -1.f)));
-			assert(f.CornerPoint(5).Equals(POINT_VEC(-50.f, -50.f, -100.f)));
-			assert(f.CornerPoint(6).Equals(POINT_VEC(-50.f, 50.f, -1.f)));
-			assert(f.CornerPoint(7).Equals(POINT_VEC(-50.f, 50.f, -100.f)));
+			mgl_assert(f.CornerPoint(0).Equals(POINT_VEC(50.f, -50.f, -1.f)));
+			mgl_assert(f.CornerPoint(1).Equals(POINT_VEC(50.f, -50.f, -100.f)));
+			mgl_assert(f.CornerPoint(2).Equals(POINT_VEC(50.f, 50.f, -1.f)));
+			mgl_assert(f.CornerPoint(3).Equals(POINT_VEC(50.f, 50.f, -100.f)));
+			mgl_assert(f.CornerPoint(4).Equals(POINT_VEC(-50.f, -50.f, -1.f)));
+			mgl_assert(f.CornerPoint(5).Equals(POINT_VEC(-50.f, -50.f, -100.f)));
+			mgl_assert(f.CornerPoint(6).Equals(POINT_VEC(-50.f, 50.f, -1.f)));
+			mgl_assert(f.CornerPoint(7).Equals(POINT_VEC(-50.f, 50.f, -100.f)));
 		}
 		else if (f.Type() == OrthographicFrustum && f.Handedness() == FrustumRightHanded)
 		{
-			assert(f.CornerPoint(0).Equals(POINT_VEC(-50.f, -50.f, -1.f)));
-			assert(f.CornerPoint(1).Equals(POINT_VEC(-50.f, -50.f, -100.f)));
-			assert(f.CornerPoint(2).Equals(POINT_VEC(-50.f, 50.f, -1.f)));
-			assert(f.CornerPoint(3).Equals(POINT_VEC(-50.f, 50.f, -100.f)));
-			assert(f.CornerPoint(4).Equals(POINT_VEC(50.f, -50.f, -1.f)));
-			assert(f.CornerPoint(5).Equals(POINT_VEC(50.f, -50.f, -100.f)));
-			assert(f.CornerPoint(6).Equals(POINT_VEC(50.f, 50.f, -1.f)));
-			assert(f.CornerPoint(7).Equals(POINT_VEC(50.f, 50.f, -100.f)));
+			mgl_assert(f.CornerPoint(0).Equals(POINT_VEC(-50.f, -50.f, -1.f)));
+			mgl_assert(f.CornerPoint(1).Equals(POINT_VEC(-50.f, -50.f, -100.f)));
+			mgl_assert(f.CornerPoint(2).Equals(POINT_VEC(-50.f, 50.f, -1.f)));
+			mgl_assert(f.CornerPoint(3).Equals(POINT_VEC(-50.f, 50.f, -100.f)));
+			mgl_assert(f.CornerPoint(4).Equals(POINT_VEC(50.f, -50.f, -1.f)));
+			mgl_assert(f.CornerPoint(5).Equals(POINT_VEC(50.f, -50.f, -100.f)));
+			mgl_assert(f.CornerPoint(6).Equals(POINT_VEC(50.f, 50.f, -1.f)));
+			mgl_assert(f.CornerPoint(7).Equals(POINT_VEC(50.f, 50.f, -100.f)));
 		}
 	}
 }
@@ -172,15 +172,15 @@ UNIQUE_TEST(Frustum_Project_Unproject_Symmetry)
 				float2 pt = float2::RandomBox(rng, -1.f, 1.f);
 				vec pos = f.NearPlanePos(pt);
 				vec pt2 = f.Project(pos);
-				assert2(pt.Equals(pt2.xy()), pt, pt2.xy());
+				mgl_assert2(pt.Equals(pt2.xy()), pt, pt2.xy());
 
 				pos = f.FarPlanePos(pt);
 				pt2 = f.Project(pos);
-				assert2(pt.Equals(pt2.xy()), pt, pt2.xy());
+				mgl_assert2(pt.Equals(pt2.xy()), pt, pt2.xy());
 
 				pos = f.PointInside(pt.x, pt.y, rng.Float());
 				pt2 = f.Project(pos);
-				assert2(pt.Equals(pt2.xy()), pt, pt2.xy());
+				mgl_assert2(pt.Equals(pt2.xy()), pt, pt2.xy());
 			}
 		}
 	}
@@ -196,10 +196,10 @@ UNIQUE_TEST(Frustum_Plane_Normals_Are_Correct)
 		f.GetCornerPoints(corners);
 		f.GetPlanes(planes);
 		for(int i = 0; i < 8; ++i)
-			assert(pb.Contains(corners[i]));
+			mgl_assert(pb.Contains(corners[i]));
 		for(int i = 0; i < 6; ++i)
 			for(int j = 0; j < 8; ++j)
-				assert(planes[i].SignedDistance(corners[j]) <= 0.f);
+				mgl_assert(planes[i].SignedDistance(corners[j]) <= 0.f);
 	}
 }
 
@@ -213,12 +213,12 @@ UNIQUE_TEST(Frustum_IsConvex)
 		{
 			Plane p1 = f.GetPlane(i);
 			Plane p2 = p.FacePlane(i);
-			assert3(p1.Equals(p2), i, p1, p2);
+			mgl_assert3(p1.Equals(p2), i, p1, p2);
 		}
-		assert(p.EulerFormulaHolds());
-		assert(p.IsClosed());
-		assert(p.IsConvex());
-		assert(!p.IsNull());
+		mgl_assert(p.EulerFormulaHolds());
+		mgl_assert(p.IsClosed());
+		mgl_assert(p.IsConvex());
+		mgl_assert(!p.IsNull());
 	}
 }
 
@@ -228,11 +228,11 @@ UNIQUE_TEST(Plane_ProjectToNegativeHalf)
 
 	vec neg = POINT_VEC(0,-100.f, 0);
 	vec pos = POINT_VEC(0, 100.f, 0);
-	assert(neg.Equals(p.ProjectToNegativeHalf(neg)));
-	assert(!neg.Equals(p.ProjectToPositiveHalf(neg)));
+	mgl_assert(neg.Equals(p.ProjectToNegativeHalf(neg)));
+	mgl_assert(!neg.Equals(p.ProjectToPositiveHalf(neg)));
 
-	assert(pos.Equals(p.ProjectToPositiveHalf(pos)));
-	assert(!pos.Equals(p.ProjectToNegativeHalf(pos)));
+	mgl_assert(pos.Equals(p.ProjectToPositiveHalf(pos)));
+	mgl_assert(!pos.Equals(p.ProjectToNegativeHalf(pos)));
 }
 
 UNIQUE_TEST(Frustum_Contains)
@@ -246,11 +246,11 @@ UNIQUE_TEST(Frustum_Contains)
 			float distance = f.Distance(corner);
 			if (!f.Contains(corner) || distance > 1e-4f)
 				LOGE("Closest point to %s: %s", corner.ToString().c_str(), closestPoint.ToString().c_str());
-			assert4(f.Contains(corner), i, corner, f, distance);
-			assert1(distance < 10.f, distance);
+			mgl_assert4(f.Contains(corner), i, corner, f, distance);
+			mgl_assert1(distance < 10.f, distance);
 		}
 
-		assert3(f.Contains(f.CenterPoint()), f, f.CenterPoint(), f.Distance(f.CenterPoint()));
+		mgl_assert3(f.Contains(f.CenterPoint()), f, f.CenterPoint(), f.Distance(f.CenterPoint()));
 	}
 }
 
@@ -263,13 +263,13 @@ RANDOMIZED_TEST(Frustum_Contains_Corners)
 	{
 		vec point = (i == 8) ? b.CenterPoint() : b.CornerPoint(i);
 
-		assert(b.NearPlane().SignedDistance(point) < 1e-3f);
-		assert(b.FarPlane().SignedDistance(point) < 1e-3f);
-		assert(b.LeftPlane().SignedDistance(point) < 1e-3f);
-		assert(b.RightPlane().SignedDistance(point) < 1e-3f);
-		assert(b.TopPlane().SignedDistance(point) < 1e-3f);
-		assert(b.BottomPlane().SignedDistance(point) < 1e-3f);
-		assert1(b.Contains(point), b.Distance(point));
+		mgl_assert(b.NearPlane().SignedDistance(point) < 1e-3f);
+		mgl_assert(b.FarPlane().SignedDistance(point) < 1e-3f);
+		mgl_assert(b.LeftPlane().SignedDistance(point) < 1e-3f);
+		mgl_assert(b.RightPlane().SignedDistance(point) < 1e-3f);
+		mgl_assert(b.TopPlane().SignedDistance(point) < 1e-3f);
+		mgl_assert(b.BottomPlane().SignedDistance(point) < 1e-3f);
+		mgl_assert1(b.Contains(point), b.Distance(point));
 	}
 }
 
@@ -280,18 +280,18 @@ UNIQUE_TEST(Frustum_Matrices)
 		if (f.Handedness() == FrustumRightHanded)
 		{
 			float3x4 wm = f.WorldMatrix();
-			assert(wm.IsIdentity());
+			mgl_assert(wm.IsIdentity());
 
 			float3x4 vm = f.ViewMatrix();
-			assert(vm.IsIdentity());
+			mgl_assert(vm.IsIdentity());
 		}
 		else
 		{
 			float3x4 wm = f.WorldMatrix() * float3x4::RotateY(pi);
-			assert(wm.IsIdentity());
+			mgl_assert(wm.IsIdentity());
 
 			float3x4 vm = f.ViewMatrix() * float3x4::RotateY(pi);
-			assert(vm.IsIdentity());
+			mgl_assert(vm.IsIdentity());
 		}
 	}
 }
@@ -303,14 +303,14 @@ UNIQUE_TEST(Frustum_Projection)
 		const float nearD = (f.ProjectiveSpace() == FrustumSpaceD3D) ? 0.f : -1.f;
 
 		// Corner points are returned in XYZ order: 0: ---, 1: --+, 2: -+-, 3: -++, 4: +--, 5: +-+, 6: ++-, 7: +++
-		assert(f.Project(f.CornerPoint(0)).Equals(POINT_VEC(-1, -1, nearD)));
-		assert(f.Project(f.CornerPoint(1)).Equals(POINT_VEC(-1, -1, 1)));
-		assert(f.Project(f.CornerPoint(2)).Equals(POINT_VEC(-1, 1, nearD)));
-		assert(f.Project(f.CornerPoint(3)).Equals(POINT_VEC(-1, 1, 1)));
-		assert(f.Project(f.CornerPoint(4)).Equals(POINT_VEC(1, -1, nearD)));
-		assert(f.Project(f.CornerPoint(5)).Equals(POINT_VEC(1, -1, 1)));
-		assert(f.Project(f.CornerPoint(6)).Equals(POINT_VEC(1, 1, nearD)));
-		assert(f.Project(f.CornerPoint(7)).Equals(POINT_VEC(1, 1, 1)));
+		mgl_assert(f.Project(f.CornerPoint(0)).Equals(POINT_VEC(-1, -1, nearD)));
+		mgl_assert(f.Project(f.CornerPoint(1)).Equals(POINT_VEC(-1, -1, 1)));
+		mgl_assert(f.Project(f.CornerPoint(2)).Equals(POINT_VEC(-1, 1, nearD)));
+		mgl_assert(f.Project(f.CornerPoint(3)).Equals(POINT_VEC(-1, 1, 1)));
+		mgl_assert(f.Project(f.CornerPoint(4)).Equals(POINT_VEC(1, -1, nearD)));
+		mgl_assert(f.Project(f.CornerPoint(5)).Equals(POINT_VEC(1, -1, 1)));
+		mgl_assert(f.Project(f.CornerPoint(6)).Equals(POINT_VEC(1, 1, nearD)));
+		mgl_assert(f.Project(f.CornerPoint(7)).Equals(POINT_VEC(1, 1, 1)));
 		MARK_UNUSED(nearD);
 	}
 }
@@ -322,19 +322,19 @@ UNIQUE_TEST(Frustum_UnProject)
 		if (f.Type() == PerspectiveFrustum)
 		{
 			Ray r = f.UnProject(0, 0);
-			assert(r.pos.Equals(f.Pos()));
-			assert(r.pos.Equals(POINT_VEC(0, 0, 0)));
-			assert(r.dir.Equals(DIR_VEC(0,0,-1)));
+			mgl_assert(r.pos.Equals(f.Pos()));
+			mgl_assert(r.pos.Equals(POINT_VEC(0, 0, 0)));
+			mgl_assert(r.dir.Equals(DIR_VEC(0,0,-1)));
 
 			r = f.UnProject(-1, -1);
-			assert(r.pos.Equals(f.Pos()));
-			assert(r.pos.Equals(POINT_VEC(0, 0, 0)));
-			assert(r.dir.Equals((f.CornerPoint(1)-f.CornerPoint(0)).Normalized()));
+			mgl_assert(r.pos.Equals(f.Pos()));
+			mgl_assert(r.pos.Equals(POINT_VEC(0, 0, 0)));
+			mgl_assert(r.dir.Equals((f.CornerPoint(1)-f.CornerPoint(0)).Normalized()));
 
 			r = f.UnProject(1, 1);
-			assert(r.pos.Equals(f.Pos()));
-			assert(r.pos.Equals(POINT_VEC(0, 0, 0)));
-			assert(r.dir.Equals((f.CornerPoint(7)-f.CornerPoint(6)).Normalized()));
+			mgl_assert(r.pos.Equals(f.Pos()));
+			mgl_assert(r.pos.Equals(POINT_VEC(0, 0, 0)));
+			mgl_assert(r.dir.Equals((f.CornerPoint(7)-f.CornerPoint(6)).Normalized()));
 		}
 	}
 }
@@ -344,16 +344,16 @@ UNIQUE_TEST(Frustum_UnProjectFromNearPlane)
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
 		Ray r = f.UnProjectFromNearPlane(0, 0);
-		assert(r.pos.Equals(POINT_VEC(0,0,-1)));
-		assert(r.dir.Equals(DIR_VEC(0,0,-1)));
+		mgl_assert(r.pos.Equals(POINT_VEC(0,0,-1)));
+		mgl_assert(r.dir.Equals(DIR_VEC(0,0,-1)));
 
 		r = f.UnProjectFromNearPlane(-1, -1);
-		assert(r.pos.Equals(f.CornerPoint(0)));
-		assert(r.dir.Equals((f.CornerPoint(1)-f.CornerPoint(0)).Normalized()));
+		mgl_assert(r.pos.Equals(f.CornerPoint(0)));
+		mgl_assert(r.dir.Equals((f.CornerPoint(1)-f.CornerPoint(0)).Normalized()));
 
 		r = f.UnProjectFromNearPlane(1, 1);
-		assert(r.pos.Equals(f.CornerPoint(6)));
-		assert(r.dir.Equals((f.CornerPoint(7)-f.CornerPoint(6)).Normalized()));
+		mgl_assert(r.pos.Equals(f.CornerPoint(6)));
+		mgl_assert(r.dir.Equals((f.CornerPoint(7)-f.CornerPoint(6)).Normalized()));
 	}
 }
 
@@ -362,16 +362,16 @@ UNIQUE_TEST(Frustum_UnProjectLineSegment)
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
 		LineSegment ls = f.UnProjectLineSegment(0, 0);
-		assert(ls.a.Equals(POINT_VEC(0,0,-1)));
-		assert(ls.b.Equals(POINT_VEC(0,0,-100)));
+		mgl_assert(ls.a.Equals(POINT_VEC(0,0,-1)));
+		mgl_assert(ls.b.Equals(POINT_VEC(0,0,-100)));
 
 		ls = f.UnProjectLineSegment(-1, -1);
-		assert(ls.a.Equals(f.CornerPoint(0)));
-		assert(ls.b.Equals(f.CornerPoint(1)));
+		mgl_assert(ls.a.Equals(f.CornerPoint(0)));
+		mgl_assert(ls.b.Equals(f.CornerPoint(1)));
 
 		ls = f.UnProjectLineSegment(1, 1);
-		assert(ls.a.Equals(f.CornerPoint(6)));
-		assert(ls.b.Equals(f.CornerPoint(7)));
+		mgl_assert(ls.a.Equals(f.CornerPoint(6)));
+		mgl_assert(ls.b.Equals(f.CornerPoint(7)));
 	}
 }
 
@@ -383,15 +383,15 @@ UNIQUE_TEST(Frustum_NearPlanePos)
 		{
 			if (f.Handedness() == FrustumLeftHanded)
 			{
-				assert(f.NearPlanePos(1,-1).Equals(POINT_VEC(-1,-1,-1)));
-				assert(f.NearPlanePos(-1,1).Equals(POINT_VEC(1,1,-1)));
+				mgl_assert(f.NearPlanePos(1,-1).Equals(POINT_VEC(-1,-1,-1)));
+				mgl_assert(f.NearPlanePos(-1,1).Equals(POINT_VEC(1,1,-1)));
 			}
 			else
 			{
-				assert(f.NearPlanePos(-1,-1).Equals(POINT_VEC(-1,-1,-1)));
-				assert(f.NearPlanePos(1,1).Equals(POINT_VEC(1,1,-1)));
+				mgl_assert(f.NearPlanePos(-1,-1).Equals(POINT_VEC(-1,-1,-1)));
+				mgl_assert(f.NearPlanePos(1,1).Equals(POINT_VEC(1,1,-1)));
 			}
-			assert(f.NearPlanePos(0,0).Equals(POINT_VEC(0,0,-1)));
+			mgl_assert(f.NearPlanePos(0,0).Equals(POINT_VEC(0,0,-1)));
 		}
 	}
 }
@@ -404,15 +404,15 @@ UNIQUE_TEST(Frustum_FarPlanePos)
 		{
 			if (f.Handedness() == FrustumLeftHanded)
 			{
-				assert(f.FarPlanePos(1,-1).Equals(POINT_VEC(-100,-100,-100)));
-				assert(f.FarPlanePos(-1,1).Equals(POINT_VEC(100,100,-100)));
+				mgl_assert(f.FarPlanePos(1,-1).Equals(POINT_VEC(-100,-100,-100)));
+				mgl_assert(f.FarPlanePos(-1,1).Equals(POINT_VEC(100,100,-100)));
 			}
 			else
 			{
-				assert(f.FarPlanePos(-1,-1).Equals(POINT_VEC(-100,-100,-100)));
-				assert(f.FarPlanePos(1,1).Equals(POINT_VEC(100,100,-100)));
+				mgl_assert(f.FarPlanePos(-1,-1).Equals(POINT_VEC(-100,-100,-100)));
+				mgl_assert(f.FarPlanePos(1,1).Equals(POINT_VEC(100,100,-100)));
 			}
-			assert(f.FarPlanePos(0,0).Equals(POINT_VEC(0,0,-100)));
+			mgl_assert(f.FarPlanePos(0,0).Equals(POINT_VEC(0,0,-100)));
 		}
 	}
 }
@@ -421,7 +421,7 @@ UNIQUE_TEST(Frustum_Finite)
 {
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
-		assert(f.IsFinite());
+		mgl_assert(f.IsFinite());
 	}
 }
 
@@ -430,7 +430,7 @@ UNIQUE_TEST(Frustum_MinimalEnclosingAABB)
 	Frustum f;
 	FOR_EACH_FRUSTUM_CONVENTION(f)
 		AABB a = f.MinimalEnclosingAABB();
-		assert(a.Contains(f));
+		mgl_assert(a.Contains(f));
 	}
 }
 
@@ -444,7 +444,7 @@ UNIQUE_TEST(Frustum_MinimalEnclosingOBB)
 			LOGE("OBB: %s", o.ToString().c_str());
 			LOGE("Frustum: %s", f.ToString().c_str());
 		}
-		assert(o.Contains(f));
+		mgl_assert(o.Contains(f));
 	}
 }
 
@@ -456,11 +456,11 @@ UNIQUE_TEST(Frustum_AspectRatio_NearPlanePos)
 	f.SetFrame(POINT_VEC_SCALAR(0.f), DIR_VEC(0, 0, -1), DIR_VEC(0, 1, 0));
 	f.SetViewPlaneDistances(0.5f, 10.f);
 
-	assert(EqualAbs(f.NearPlaneWidth(), 0.5f*Tan(DegToRad(140.f)/2.f)*2.f));
-	assert(EqualAbs(f.NearPlaneHeight(), 0.5f*Tan(DegToRad(30.f)/2.f)*2.f));
+	mgl_assert(EqualAbs(f.NearPlaneWidth(), 0.5f*Tan(DegToRad(140.f)/2.f)*2.f));
+	mgl_assert(EqualAbs(f.NearPlaneHeight(), 0.5f*Tan(DegToRad(30.f)/2.f)*2.f));
 
 	float aspect = f.NearPlaneWidth() / f.NearPlaneHeight();
-	assert(EqualAbs(aspect, f.AspectRatio()));
+	mgl_assert(EqualAbs(aspect, f.AspectRatio()));
 	MARK_UNUSED(aspect);
 }
 
@@ -471,27 +471,27 @@ RANDOMIZED_TEST(Frustum_ToPbVolume_And_Back)
 	PBVolume<6> pbvol = f.ToPBVolume();
 
 	Polyhedron ph2 = f.ToPolyhedron();
-	assert(ph2.EulerFormulaHolds());
+	mgl_assert(ph2.EulerFormulaHolds());
 	///\todo Due to numeric instability, this condition does not always hold, but would be nice to have it.
-//	assert(ph2.IsConvex());
-	assert(ph2.IsClosed());
+//	mgl_assert(ph2.IsConvex());
+	mgl_assert(ph2.IsClosed());
 	Polyhedron ph = pbvol.ToPolyhedron();
-	assert(ph.EulerFormulaHolds());
-	assert(ph.SetEquals(ph2));
-	assert(ph.IsClosed());
-//	assert(ph.IsConvex());
-	assert(!ph.IsNull());
+	mgl_assert(ph.EulerFormulaHolds());
+	mgl_assert(ph.SetEquals(ph2));
+	mgl_assert(ph.IsClosed());
+//	mgl_assert(ph.IsConvex());
+	mgl_assert(!ph.IsNull());
 
-	assert(ph.SetEquals(ph2));
+	mgl_assert(ph.SetEquals(ph2));
 
-	// .SetEquals() canonicalizes the Polyhedrons, so run the assert()s again to ensure it didn't change anything for real.
-	assert(ph2.EulerFormulaHolds());
-	assert(ph.EulerFormulaHolds());
-//	assert(ph2.IsConvex());
-	assert(ph2.IsClosed());
-	assert(ph.IsClosed());
-//	assert(ph.IsConvex());
-	assert(!ph.IsNull());
+	// .SetEquals() canonicalizes the Polyhedrons, so run the mgl_assert()s again to ensure it didn't change anything for real.
+	mgl_assert(ph2.EulerFormulaHolds());
+	mgl_assert(ph.EulerFormulaHolds());
+//	mgl_assert(ph2.IsConvex());
+	mgl_assert(ph2.IsClosed());
+	mgl_assert(ph.IsClosed());
+//	mgl_assert(ph.IsConvex());
+	mgl_assert(!ph.IsNull());
 }
 
 // This tests the ability to compute the set intersection of two convex objects (Frustums) represented as PBVolumes.
@@ -514,66 +514,66 @@ RANDOMIZED_TEST(Intersect_Two_Frustums)
 	Polyhedron ph = intersection.ToPolyhedron();
 
 	// ph is the set intersection of a and b, so must be contained in both a and b.
-	assert(a.Contains(ph));
-	assert(b.Contains(ph));
+	mgl_assert(a.Contains(ph));
+	mgl_assert(b.Contains(ph));
 
 	// ph must be valid in itself.
-	assert(!ph.IsNull());
-	assert(ph.IsClosed());
-	assert(ph.Contains(pt));
+	mgl_assert(!ph.IsNull());
+	mgl_assert(ph.IsClosed());
+	mgl_assert(ph.Contains(pt));
 }
 
 RANDOMIZED_TEST(Frustum_Contains_LineSegment)
 {
 	vec pt = POINT_VEC_SCALAR(0.f);
 	Frustum f = RandomFrustumContainingPoint(rng, pt);
-	assert(f.Contains(LineSegment(pt, pt)));
+	mgl_assert(f.Contains(LineSegment(pt, pt)));
 	vec pt2 = POINT_VEC_SCALAR(1e9f);
-	assert(!f.Contains(LineSegment(pt2, pt2)));
+	mgl_assert(!f.Contains(LineSegment(pt2, pt2)));
 
 	// Must contain the line segment passing from the center of near plane to the far plane.
 	vec n = f.NearPlanePos(0.f, 0.f);
 	vec d = f.FarPlanePos(0.f, 0.f);
 	LineSegment l(n, d);
-	assert(f.Contains(l));
+	mgl_assert(f.Contains(l));
 
 	// Must not contain the eye position (unless an orthographic frustum with zero near plane distance)
 	vec p = f.Pos();
 	vec front = f.Front();
-	assert(!f.Contains(LineSegment(p, p)) || (f.NearPlaneDistance() <= 0.f && f.Type() == OrthographicFrustum));
+	mgl_assert(!f.Contains(LineSegment(p, p)) || (f.NearPlaneDistance() <= 0.f && f.Type() == OrthographicFrustum));
 
 	// Must not contain line segment between eye and behind it.
 	vec out = (p + n)*0.5f;
-	assert(!f.Contains(LineSegment(out, out - front)));
+	mgl_assert(!f.Contains(LineSegment(out, out - front)));
 
 	// Must not contain line segment past the far plane.
-	assert(!f.Contains(LineSegment(d + front, d + 2.f*front)));
+	mgl_assert(!f.Contains(LineSegment(d + front, d + 2.f*front)));
 
 	// Must not contain a line segment that straddles the Frustum.
-	assert(!f.Contains(LineSegment(p, d + 2.f * front)));
+	mgl_assert(!f.Contains(LineSegment(p, d + 2.f * front)));
 }
 
 RANDOMIZED_TEST(Frustum_Contains_Triangle)
 {
 	vec pt = POINT_VEC_SCALAR(0.f);
 	Frustum f = RandomFrustumContainingPoint(rng, pt);
-	assert(f.Contains(LineSegment(pt, pt)));
+	mgl_assert(f.Contains(LineSegment(pt, pt)));
 	vec pt2 = POINT_VEC_SCALAR(1e9f);
-	assert(!f.Contains(LineSegment(pt2, pt2)));
+	mgl_assert(!f.Contains(LineSegment(pt2, pt2)));
 
 	// Test containment inside the Frustum.
 	vec n = f.NearPlanePos(-1.f, 0.f);
 	vec n2 = f.NearPlanePos(1.f, 0.f);
 	vec d = f.FarPlanePos(0.f, 0.f);
-	assert(f.Contains(Triangle(n, n2, d)));
+	mgl_assert(f.Contains(Triangle(n, n2, d)));
 
 	// Must not contain the eye position (unless an orthographic frustum with zero near plane distance) or a Triangle that straddles the Frustum.
 	vec p = f.Pos();
-	assert(!f.Contains(Triangle(p, n, d)));
+	mgl_assert(!f.Contains(Triangle(p, n, d)));
 
 	// Must not contain a Triangle that's completely outside the Frustum.
 	vec front = f.Front();
-	assert(!f.Contains(Triangle(p - front, p - front, p - front)));
+	mgl_assert(!f.Contains(Triangle(p - front, p - front, p - front)));
 }
 
 BENCHMARK(Frustum_Contains_Point, "Frustum::Contains(point)")
@@ -601,26 +601,26 @@ RANDOMIZED_TEST(Frustum_ClosestPoint_Point)
 {
 	vec pt = POINT_VEC_SCALAR(0.f);
 	Frustum f = RandomFrustumContainingPoint(rng, pt);
-	assert(f.ClosestPoint(pt).Equals(pt));
+	mgl_assert(f.ClosestPoint(pt).Equals(pt));
 
 	vec n = f.NearPlanePos(0.f, 0.f);
-	assert(f.ClosestPoint(n).Equals(n));
+	mgl_assert(f.ClosestPoint(n).Equals(n));
 	vec p = f.Pos();
 	vec cp = f.ClosestPoint(p);
 #ifdef MATH_VEC_IS_FLOAT4
-	assert(EqualAbs(cp.w, 1.f));
+	mgl_assert(EqualAbs(cp.w, 1.f));
 #endif
-	assert3(cp.Equals(n), p, cp, n);
+	mgl_assert3(cp.Equals(n), p, cp, n);
 
 	vec d = f.FarPlanePos(0.f, 0.f);
 	vec front = f.Front();
-	assert(f.ClosestPoint(d + front).Equals(d));
+	mgl_assert(f.ClosestPoint(d + front).Equals(d));
 
 	vec pt2 = vec::RandomSphere(rng, pt, 1000.f);
 	cp = f.ClosestPoint(pt2);
 
 	vec cp2 = f.ToPolyhedron().ClosestPoint(pt2); // This is known to be correct.
-	assert2(cp.Equals(cp2), cp, cp2);
+	mgl_assert2(cp.Equals(cp2), cp, cp2);
 }
 
 BENCHMARK(Frustum_ClosestPoint_Point, "Frustum::ClosestPoint(point)")

--- a/tests/GJKTests.cpp
+++ b/tests/GJKTests.cpp
@@ -18,23 +18,23 @@ UNIQUE_TEST(TrickyAABBCapsuleNoIntersect)
 	LOGI("D: %f", b.Distance(a.Centroid()));
 	LOGI("D: %f", b.Distance(a.SphereA()));
 	LOGI("D: %f", b.Distance(a.SphereB()));
-	assert(!a.Intersects(b));
+	mgl_assert(!a.Intersects(b));
 }
 
 UNIQUE_TEST(TrickyGJKSphereSphereIntersect)
 {
 	Sphere a = Sphere(POINT_VEC(-14.740263f, 8.2647991f, 64.282227f), 7.6029987f);
 	Sphere b = Sphere(POINT_VEC(-23.840866f, 9.4233770f, 66.399742f), 1.9519407f);
-	assert(GJKIntersect(a, b));
-	assert(GJKIntersect(b, a));
+	mgl_assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(b, a));
 }
 
 UNIQUE_TEST(TrickyGJKSphereSphereIntersect2)
 {
 	Sphere a = Sphere(POINT_VEC(57.166256f, 99.426201f, 75.735786f), 2.3808355f);
 	Sphere b = Sphere(POINT_VEC(54.087727f, 94.719139f, 75.188812f), 3.3114955f);
-	assert(GJKIntersect(a, b));
-	assert(GJKIntersect(b, a));
+	mgl_assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(b, a));
 }
 /*
 UNIQUE_TEST(TrickyGJKCapsuleTriangleNoIntersect)
@@ -47,8 +47,8 @@ UNIQUE_TEST(TrickyGJKCapsuleTriangleNoIntersect)
 	t.a = POINT_VEC(-104.49078f, 26.969154f, 132.72052f);
 	t.b = POINT_VEC(-80.549988f, 9.9734116f, 7.7765503f);
 	t.c = POINT_VEC(65.374435f, 15.144905f, 149.00766f);
-	assert(!GJKIntersect(c, t));
-	assert(!GJKIntersect(t, c));
+	mgl_assert(!GJKIntersect(c, t));
+	mgl_assert(!GJKIntersect(t, c));
 }
 */
 
@@ -56,22 +56,22 @@ UNIQUE_TEST(TrickyGJKAABBAABBIntersect)
 {
 	AABB a(POINT_VEC_SCALAR(-10.f), POINT_VEC_SCALAR(10.f));
 	AABB b(POINT_VEC_SCALAR(8.f), POINT_VEC_SCALAR(20.f));
-	assert(GJKIntersect(a, b));
-	assert(GJKIntersect(b, a));
+	mgl_assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(b, a));
 }
 
 UNIQUE_TEST(GJKAABBSphereIntersectCase)
 {
 	AABB a(POINT_VEC(37.1478767f,-71.9611969f,-51.1293259f),POINT_VEC(42.8975906f,-67.3180618f,-44.9161682f));
 	Sphere b(POINT_VEC(41.9271927f,-71.1957016f,-56.7100677f),7.20756626f);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 UNIQUE_TEST(GJKAABBSphereIntersectCase2)
 {
 	AABB a(POINT_VEC(-6.17850494f,-1.09283221f,-85.2101898f),POINT_VEC(-3.21846271f,-0.564386666f,-84.2947693f));
 	Sphere b(POINT_VEC(-2.29130507f,-1.87549007f,-83.2377472f),2.09292078f);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBShereNoIntersect)
@@ -81,8 +81,8 @@ RANDOMIZED_TEST(GJKAABBShereNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Sphere b = RandomSphereInHalfspace(p, 10.f);
-	assert(!GJKIntersect(a, b));
-	assert(!GJKIntersect(b, a));
+	mgl_assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(b, a));
 }
 
 RANDOMIZED_TEST(GJKAABBAABBIntersect)
@@ -90,7 +90,7 @@ RANDOMIZED_TEST(GJKAABBAABBIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	AABB b = RandomAABBContainingPoint(pt, 10.f);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBOBBIntersect)
@@ -98,7 +98,7 @@ RANDOMIZED_TEST(GJKAABBOBBIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	OBB b = RandomOBBContainingPoint(pt, 10.f);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBLineSegmentIntersect)
@@ -108,7 +108,7 @@ RANDOMIZED_TEST(GJKAABBLineSegmentIntersect)
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
 	try
 	{
-		assert(GJKIntersect(a, b));
+		mgl_assert(GJKIntersect(a, b));
 	} catch(...)
 	{
 		LOGI("a: %s", a.SerializeToCodeString().c_str());
@@ -122,7 +122,7 @@ RANDOMIZED_TEST(GJKAABBSphereIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Sphere b = RandomSphereContainingPoint(pt, SCALE);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBCapsuleIntersect)
@@ -130,7 +130,7 @@ RANDOMIZED_TEST(GJKAABBCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBTriangleIntersect)
@@ -138,7 +138,7 @@ RANDOMIZED_TEST(GJKAABBTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBFrustumIntersect)
@@ -146,7 +146,7 @@ RANDOMIZED_TEST(GJKAABBFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBOBBIntersect)
@@ -154,7 +154,7 @@ RANDOMIZED_TEST(GJKOBBOBBIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	OBB b = RandomOBBContainingPoint(pt, 10.f);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBLineSegmentIntersect)
@@ -162,7 +162,7 @@ RANDOMIZED_TEST(GJKOBBLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBSphereIntersect)
@@ -170,7 +170,7 @@ RANDOMIZED_TEST(GJKOBBSphereIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Sphere b = RandomSphereContainingPoint(pt, SCALE);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBCapsuleIntersect)
@@ -178,7 +178,7 @@ RANDOMIZED_TEST(GJKOBBCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBTriangleIntersect)
@@ -186,7 +186,7 @@ RANDOMIZED_TEST(GJKOBBTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBFrustumIntersect)
@@ -194,7 +194,7 @@ RANDOMIZED_TEST(GJKOBBFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereSphereIntersect)
@@ -202,7 +202,7 @@ RANDOMIZED_TEST(GJKSphereSphereIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Sphere b = RandomSphereContainingPoint(pt, 10.f);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 /*
@@ -210,7 +210,7 @@ UNIQUE_TEST(GJKSphereLineSegmentIntersectCase)
 {
 	Sphere a(POINT_VEC(52.4970627f,45.4888649f,-7.32828188f),9.61045837f);
 	LineSegment b(POINT_VEC(90.447998f,30.0441036f,-46.333149f),POINT_VEC(35.6951218f,38.615181f,4.10816383f));
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 */
 
@@ -221,7 +221,7 @@ RANDOMIZED_TEST(GJKSphereLineSegmentIntersect)
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
 	try
 	{
-		assert(GJKIntersect(a, b));
+		mgl_assert(GJKIntersect(a, b));
 	} catch(...)
 	{
 		LOGI("%s", a.SerializeToCodeString().c_str());
@@ -235,7 +235,7 @@ RANDOMIZED_TEST(GJKSphereCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereTriangleIntersect)
@@ -243,7 +243,7 @@ RANDOMIZED_TEST(GJKSphereTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereFrustumIntersect)
@@ -251,7 +251,7 @@ RANDOMIZED_TEST(GJKSphereFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumLineSegmentIntersect)
@@ -259,7 +259,7 @@ RANDOMIZED_TEST(GJKFrustumLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumCapsuleIntersect)
@@ -267,7 +267,7 @@ RANDOMIZED_TEST(GJKFrustumCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumTriangleIntersect)
@@ -275,7 +275,7 @@ RANDOMIZED_TEST(GJKFrustumTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumFrustumIntersect)
@@ -283,7 +283,7 @@ RANDOMIZED_TEST(GJKFrustumFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKCapsuleLineSegmentIntersect)
@@ -291,7 +291,7 @@ RANDOMIZED_TEST(GJKCapsuleLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKCapsuleCapsuleIntersect)
@@ -299,7 +299,7 @@ RANDOMIZED_TEST(GJKCapsuleCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKCapsuleTriangleIntersect)
@@ -307,7 +307,7 @@ RANDOMIZED_TEST(GJKCapsuleTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKTriangleLineSegmentIntersect)
@@ -315,7 +315,7 @@ RANDOMIZED_TEST(GJKTriangleLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle a = RandomTriangleContainingPoint(pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKTriangleTriangleIntersect)
@@ -323,7 +323,7 @@ RANDOMIZED_TEST(GJKTriangleTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle a = RandomTriangleContainingPoint(pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(GJKIntersect(a, b));
+	mgl_assert(GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBAABBNoIntersect)
@@ -333,7 +333,7 @@ RANDOMIZED_TEST(GJKAABBAABBNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	AABB b = RandomAABBInHalfspace(p, 10.f);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBOBBNoIntersect)
@@ -342,7 +342,7 @@ RANDOMIZED_TEST(GJKAABBOBBNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	OBB b = RandomOBBInHalfspace(p, 10.f);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBLineSegmentNoIntersect)
@@ -351,7 +351,7 @@ RANDOMIZED_TEST(GJKAABBLineSegmentNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBSphereNoIntersect)
@@ -360,7 +360,7 @@ RANDOMIZED_TEST(GJKAABBSphereNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Sphere b = RandomSphereInHalfspace(p, SCALE);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBCapsuleNoIntersect)
@@ -369,7 +369,7 @@ RANDOMIZED_TEST(GJKAABBCapsuleNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBTriangleNoIntersect)
@@ -378,7 +378,7 @@ RANDOMIZED_TEST(GJKAABBTriangleNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKAABBFrustumNoIntersect)
@@ -387,7 +387,7 @@ RANDOMIZED_TEST(GJKAABBFrustumNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBOBBNoIntersect)
@@ -396,7 +396,7 @@ RANDOMIZED_TEST(GJKOBBOBBNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	OBB b = RandomOBBInHalfspace(p, 10.f);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBLineSegmentNoIntersect)
@@ -405,7 +405,7 @@ RANDOMIZED_TEST(GJKOBBLineSegmentNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBSphereNoIntersect)
@@ -414,7 +414,7 @@ RANDOMIZED_TEST(GJKOBBSphereNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Sphere b = RandomSphereInHalfspace(p, SCALE);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBCapsuleNoIntersect)
@@ -423,7 +423,7 @@ RANDOMIZED_TEST(GJKOBBCapsuleNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBTriangleNoIntersect)
@@ -432,7 +432,7 @@ RANDOMIZED_TEST(GJKOBBTriangleNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKOBBFrustumNoIntersect)
@@ -441,7 +441,7 @@ RANDOMIZED_TEST(GJKOBBFrustumNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereSphereNoIntersect)
@@ -450,7 +450,7 @@ RANDOMIZED_TEST(GJKSphereSphereNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Sphere b = RandomSphereInHalfspace(p, 10.f);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereLineSegmentNoIntersect)
@@ -459,7 +459,7 @@ RANDOMIZED_TEST(GJKSphereLineSegmentNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereCapsuleNoIntersect)
@@ -468,7 +468,7 @@ RANDOMIZED_TEST(GJKSphereCapsuleNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereTriangleNoIntersect)
@@ -477,7 +477,7 @@ RANDOMIZED_TEST(GJKSphereTriangleNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKSphereFrustumNoIntersect)
@@ -486,7 +486,7 @@ RANDOMIZED_TEST(GJKSphereFrustumNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumLineSegmentNoIntersect)
@@ -495,7 +495,7 @@ RANDOMIZED_TEST(GJKFrustumLineSegmentNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumCapsuleNoIntersect)
@@ -504,7 +504,7 @@ RANDOMIZED_TEST(GJKFrustumCapsuleNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumTriangleNoIntersect)
@@ -513,7 +513,7 @@ RANDOMIZED_TEST(GJKFrustumTriangleNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKFrustumFrustumNoIntersect)
@@ -522,7 +522,7 @@ RANDOMIZED_TEST(GJKFrustumFrustumNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKCapsuleLineSegmentNoIntersect)
@@ -531,7 +531,7 @@ RANDOMIZED_TEST(GJKCapsuleLineSegmentNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKCapsuleCapsuleNoIntersect)
@@ -540,7 +540,7 @@ RANDOMIZED_TEST(GJKCapsuleCapsuleNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKCapsuleTriangleNoIntersect)
@@ -549,7 +549,7 @@ RANDOMIZED_TEST(GJKCapsuleTriangleNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKTriangleLineSegmentNoIntersect)
@@ -558,7 +558,7 @@ RANDOMIZED_TEST(GJKTriangleLineSegmentNoIntersect)
 	Triangle a = RandomTriangleInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }
 
 RANDOMIZED_TEST(GJKTriangleTriangleNoIntersect)
@@ -567,5 +567,5 @@ RANDOMIZED_TEST(GJKTriangleTriangleNoIntersect)
 	Triangle a = RandomTriangleInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert(!GJKIntersect(a, b));
+	mgl_assert(!GJKIntersect(a, b));
 }

--- a/tests/KdTreeTests.cpp
+++ b/tests/KdTreeTests.cpp
@@ -24,11 +24,11 @@ UNIQUE_TEST(KdTree_SingleTriangle_AABBQuery)
 	{
 		auto bucket = tree.Bucket(leaf.bucketIndex);
 		auto triangle = tree.Object(*bucket);
-		
+
 		// ... do stuff with triangle ...
 		intersected = true;
 		return false;
 	};
 	tree.AABBQuery(bbox, callback);
-	assert(intersected);
+	mgl_assert(intersected);
 }

--- a/tests/LCGTests.cpp
+++ b/tests/LCGTests.cpp
@@ -14,7 +14,7 @@ RANDOMIZED_TEST(LCG_IntFast)
 	for(int i = 0; i < 1000; ++i)
 	{
 		u32 next = lcg.IntFast();
-		assert(next != prev);
+		mgl_assert(next != prev);
 		MARK_UNUSED(prev);
 		MARK_UNUSED(next);
 		prev = next;
@@ -24,18 +24,18 @@ RANDOMIZED_TEST(LCG_IntFast)
 RANDOMIZED_TEST(LCG_Int)
 {
 	LCG lcg;
-	assert4((lcg.lastNumber != 0 || lcg.increment != 0) && "Default-seeded LCG should be functional!", lcg.lastNumber, lcg.increment, lcg.multiplier, lcg.modulus);
+	mgl_assert4((lcg.lastNumber != 0 || lcg.increment != 0) && "Default-seeded LCG should be functional!", lcg.lastNumber, lcg.increment, lcg.multiplier, lcg.modulus);
 	bool allEqual = true;
 	for(int i = 0; i < 1000; ++i)
 	{
 		int prev = lcg.Int();
 		int next = lcg.Int();
-		assert4(prev != 0 || next != 0, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
+		mgl_assert4(prev != 0 || next != 0, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
 		MARK_UNUSED(allEqual);
 		if (prev != next)
 			allEqual = false;
 	}
-	assert(!allEqual);
+	mgl_assert(!allEqual);
 }
 
 RANDOMIZED_TEST(LCG_Int_A_B)
@@ -48,8 +48,8 @@ RANDOMIZED_TEST(LCG_Int_A_B)
 		if (b < a)
 			Swap(a, b);
 		int val = lcg.Int(a, b);
-		assert(a <= val);
-		assert(val <= b);
+		mgl_assert(a <= val);
+		mgl_assert(val <= b);
 		MARK_UNUSED(a);
 		MARK_UNUSED(b);
 		MARK_UNUSED(val);
@@ -64,15 +64,15 @@ RANDOMIZED_TEST(LCG_Float)
 	{
 		float f = lcg.Float();
 		float f2 = lcg.Float();
-		assert1(f < 1.f, f);
-		assert1(f >= 0.f, f);
-		assert4(f != 0.f || f2 != 0.f, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
+		mgl_assert1(f < 1.f, f);
+		mgl_assert1(f >= 0.f, f);
+		mgl_assert4(f != 0.f || f2 != 0.f, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
 		MARK_UNUSED(f);
 		MARK_UNUSED(f2);
 		if (f != f2)
 			allEqual = false;
 	}
-	assert(!allEqual);
+	mgl_assert(!allEqual);
 	MARK_UNUSED(allEqual);
 }
 
@@ -84,13 +84,13 @@ RANDOMIZED_TEST(LCG_Float01Incl)
 	{
 		float f = lcg.Float01Incl();
 		float f2 = lcg.Float01Incl();
-		assert(f <= 1.f);
-		assert(f >= 0.f);
-		assert4(f != 0.f || f2 != 0.f, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
+		mgl_assert(f <= 1.f);
+		mgl_assert(f >= 0.f);
+		mgl_assert4(f != 0.f || f2 != 0.f, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
 		if (f != f2)
 			allEqual = false;
 	}
-	assert(!allEqual);
+	mgl_assert(!allEqual);
 	MARK_UNUSED(allEqual);
 }
 
@@ -102,13 +102,13 @@ RANDOMIZED_TEST(LCG_FloatNeg1_1)
 	{
 		float f = lcg.FloatNeg1_1();
 		float f2 = lcg.FloatNeg1_1();
-		assert1(f < 1.f, f);
-		assert1(f > -1.f, f);
-		assert4(f != 0.f || f2 != 0.f, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
+		mgl_assert1(f < 1.f, f);
+		mgl_assert1(f > -1.f, f);
+		mgl_assert4(f != 0.f || f2 != 0.f, lcg.multiplier, lcg.increment, lcg.modulus, lcg.lastNumber);
 		if (f != f2)
 			allEqual = false;
 	}
-	assert(!allEqual);
+	mgl_assert(!allEqual);
 	MARK_UNUSED(allEqual);
 }
 
@@ -125,8 +125,8 @@ RANDOMIZED_TEST(LCG_Float_A_B)
 			Swap(a, b);
 
 		float f = lcg.Float(a, b);
-		assert2(a <= f, a, b);
-		assert2(f < b, f, b);
+		mgl_assert2(a <= f, a, b);
+		mgl_assert2(f < b, f, b);
 	}
 }
 
@@ -141,8 +141,8 @@ RANDOMIZED_TEST(LCG_Float_A_B_Incl)
 			Swap(a, b);
 
 		float f = lcg.FloatIncl(a, b);
-		assert2(a <= f, a, b);
-		assert2(f <= b, f, b);
+		mgl_assert2(a <= f, a, b);
+		mgl_assert2(f <= b, f, b);
 	}
 }
 

--- a/tests/LineTests.cpp
+++ b/tests/LineTests.cpp
@@ -23,7 +23,7 @@ RANDOMIZED_TEST(ParallelLineLineClosestPoint)
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointB = b.GetPoint(d2);
 	vec perpDistance = displacement - displacement.ProjectTo(a.dir);
-	assert2(EqualAbs(closestPointA.Distance(closestPointB), perpDistance.Length()), closestPointA.Distance(closestPointB), perpDistance.Length());
+	mgl_assert2(EqualAbs(closestPointA.Distance(closestPointB), perpDistance.Length()), closestPointA.Distance(closestPointB), perpDistance.Length());
 }
 
 RANDOMIZED_TEST(ParallelLineRayClosestPoint)
@@ -39,7 +39,7 @@ RANDOMIZED_TEST(ParallelLineRayClosestPoint)
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointB = b.GetPoint(d2);
 	vec perpDistance = displacement - displacement.ProjectTo(a.dir);
-	assert2(EqualAbs(closestPointA.Distance(closestPointB), perpDistance.Length()), closestPointA.Distance(closestPointB), perpDistance.Length());
+	mgl_assert2(EqualAbs(closestPointA.Distance(closestPointB), perpDistance.Length()), closestPointA.Distance(closestPointB), perpDistance.Length());
 }
 
 RANDOMIZED_TEST(ParallelLineLineSegmentClosestPoint)
@@ -56,7 +56,7 @@ RANDOMIZED_TEST(ParallelLineLineSegmentClosestPoint)
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointB = b.GetPoint(d2);
 	vec perpDistance = displacement - displacement.ProjectTo(a.dir);
-	assert2(EqualAbs(closestPointA.Distance(closestPointB), perpDistance.Length()), closestPointA.Distance(closestPointB), perpDistance.Length());
+	mgl_assert2(EqualAbs(closestPointA.Distance(closestPointB), perpDistance.Length()), closestPointA.Distance(closestPointB), perpDistance.Length());
 }
 
 RANDOMIZED_TEST(ParallelRayRayClosestPoint)
@@ -71,11 +71,11 @@ RANDOMIZED_TEST(ParallelRayRayClosestPoint)
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointB = b.GetPoint(d2);
 	float cpd = closestPointA.Distance(closestPointB);
-	assert(cpd <= displacement.Length()+1e-4f);
+	mgl_assert(cpd <= displacement.Length()+1e-4f);
 	MARK_UNUSED(cpd);
 
 	float t = a.pos.Distance(b.pos);
-	assert(cpd <= t+1e-4f);
+	mgl_assert(cpd <= t+1e-4f);
 	MARK_UNUSED(t);
 }
 
@@ -94,13 +94,13 @@ RANDOMIZED_TEST(ParallelRayLineSegmentClosestPoint)
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointB = b.GetPoint(d2);
 	float cpd = closestPointA.Distance(closestPointB);
-	assert(cpd <= displacement.Length()+1e-4f);
+	mgl_assert(cpd <= displacement.Length()+1e-4f);
 	MARK_UNUSED(cpd);
 
 	float t1 = a.pos.Distance(b.a);
 	float t2 = a.pos.Distance(b.b);
-	assert(cpd <= t1+1e-4f);
-	assert(cpd <= t2+1e-4f);
+	mgl_assert(cpd <= t1+1e-4f);
+	mgl_assert(cpd <= t2+1e-4f);
 	MARK_UNUSED(t1);
 	MARK_UNUSED(t2);
 }
@@ -129,17 +129,17 @@ RANDOMIZED_TEST(ParallelLineSegmentLineSegmentClosestPoint)
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointB = b.GetPoint(d2);
 	float cpd = closestPointA.Distance(closestPointB);
-	assert(cpd <= displacement.Length()+1e-4f);
+	mgl_assert(cpd <= displacement.Length()+1e-4f);
 	MARK_UNUSED(cpd);
 
 	float t1 = a.a.Distance(b.a);
 	float t2 = a.a.Distance(b.b);
 	float t3 = a.b.Distance(b.a);
 	float t4 = a.b.Distance(b.b);
-	assert(cpd <= t1+1e-4f);
-	assert(cpd <= t2+1e-4f);
-	assert(cpd <= t3+1e-4f);
-	assert(cpd <= t4+1e-4f);
+	mgl_assert(cpd <= t1+1e-4f);
+	mgl_assert(cpd <= t2+1e-4f);
+	mgl_assert(cpd <= t3+1e-4f);
+	mgl_assert(cpd <= t4+1e-4f);
 	MARK_UNUSED(t1);
 	MARK_UNUSED(t2);
 	MARK_UNUSED(t3);
@@ -155,19 +155,19 @@ RANDOMIZED_TEST(LineLineClosestPoint)
 
 	float d, d2;
 	vec closestPointA = a.ClosestPoint(b, d, d2);
-	assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
+	mgl_assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
 	vec closestPointB = b.GetPoint(d2);
 	float D, D2;
 	vec closestPointB2 = b.ClosestPoint(a, D, D2);
-	assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
-	assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
-	assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
+	mgl_assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
+	mgl_assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
+	mgl_assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
 	vec closestPointA2 = a.GetPoint(D2);
-	assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
+	mgl_assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
-	assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
-	assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
+	mgl_assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
 }
 
 RANDOMIZED_TEST(LineRayClosestPoint)
@@ -180,22 +180,22 @@ RANDOMIZED_TEST(LineRayClosestPoint)
 	float d, d2;
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointAd = a.GetPoint(d);
-	assert3(closestPointA.Equals(closestPointAd, 1e-1f), closestPointA, closestPointAd, closestPointA.Distance(closestPointAd));
+	mgl_assert3(closestPointA.Equals(closestPointAd, 1e-1f), closestPointA, closestPointAd, closestPointA.Distance(closestPointAd));
 	vec closestPointB = b.GetPoint(d2);
 	float D, D2;
 	vec closestPointB2 = b.ClosestPoint(a, D, D2);
-//	assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
-//	assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
-	assert(closestPointB.Equals(closestPointB2, 1e-1f));
+//	mgl_assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
+//	mgl_assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
+	mgl_assert(closestPointB.Equals(closestPointB2, 1e-1f));
 	vec closestPointA2 = a.GetPoint(D2);
-	assert(closestPointA.Equals(closestPointA2, 1e-1f));
+	mgl_assert(closestPointA.Equals(closestPointA2, 1e-1f));
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-2f);
-	assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-1f));
-	assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-1f));
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-2f);
+	mgl_assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-1f));
+	mgl_assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-1f));
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.pos) + 1e-2f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.pos) + 1e-2f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.pos) + 1e-2f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.pos) + 1e-2f);
 }
 
 RANDOMIZED_TEST(LineLineSegmentClosestPoint)
@@ -207,24 +207,24 @@ RANDOMIZED_TEST(LineLineSegmentClosestPoint)
 
 	float d, d2;
 	vec closestPointA = a.ClosestPoint(b, d, d2);
-	assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
+	mgl_assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
 	vec closestPointB = b.GetPoint(d2);
 	float D, D2;
 	vec closestPointB2 = b.ClosestPoint(a, D, D2);
-//	assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
-//	assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
-	assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
+//	mgl_assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
+//	mgl_assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
+	mgl_assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
 	vec closestPointA2 = a.GetPoint(D2);
-	assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
+	mgl_assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
-	assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
-	assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
+	mgl_assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.b) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.b) + 1e-3f);
 }
 
 RANDOMIZED_TEST(RayRayClosestPoint)
@@ -237,25 +237,25 @@ RANDOMIZED_TEST(RayRayClosestPoint)
 	float d, d2;
 	vec closestPointA = a.ClosestPoint(b, d, d2);
 	vec closestPointA2 = a.GetPoint(d);
-	assert3(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA, closestPointA2, closestPointA.Distance(closestPointA2));
+	mgl_assert3(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA, closestPointA2, closestPointA.Distance(closestPointA2));
 	vec closestPointB = b.GetPoint(d2);
 	float D, D2;
 	vec closestPointB2 = b.ClosestPoint(a, D, D2);
-//	assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
-//	assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
-	assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
+//	mgl_assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
+//	mgl_assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
+	mgl_assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
 	closestPointA2 = a.GetPoint(D2);
-	assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
+	mgl_assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
-	assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
-	assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
+	mgl_assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.pos) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.pos) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.pos) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.pos) + 1e-3f);
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.pos) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.pos) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.pos) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.pos) + 1e-3f);
 }
 
 RANDOMIZED_TEST(RayLineSegmentClosestPoint)
@@ -267,27 +267,27 @@ RANDOMIZED_TEST(RayLineSegmentClosestPoint)
 
 	float d, d2;
 	vec closestPointA = a.ClosestPoint(b, d, d2);
-	assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
+	mgl_assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
 	vec closestPointB = b.GetPoint(d2);
 	float D, D2;
 	vec closestPointB2 = b.ClosestPoint(a, D, D2);
-//	assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
-//	assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
-	assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
+//	mgl_assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
+//	mgl_assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
+	mgl_assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
 	vec closestPointA2 = a.GetPoint(D2);
-	assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
+	mgl_assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
-	assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
-	assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
+	mgl_assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.b) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.b) + 1e-3f);
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.pos) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.pos) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.pos) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.pos) + 1e-3f);
 }
 
 RANDOMIZED_TEST(LineSegmentLineSegmentClosestPoint)
@@ -299,27 +299,27 @@ RANDOMIZED_TEST(LineSegmentLineSegmentClosestPoint)
 
 	float d, d2;
 	vec closestPointA = a.ClosestPoint(b, d, d2);
-	assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
+	mgl_assert3(closestPointA.Equals(a.GetPoint(d), 1e-2f), closestPointA, a.GetPoint(d), closestPointA.Distance(a.GetPoint(d)));
 	vec closestPointB = b.GetPoint(d2);
 	float D, D2;
 	vec closestPointB2 = b.ClosestPoint(a, D, D2);
-//	assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
-//	assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
-	assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
+//	mgl_assert2(EqualAbs(d, D2, 1e-2f) || EqualRel(d, D2, 1e-2f), d, D2);
+//	mgl_assert2(EqualAbs(D, d2, 1e-2f) || EqualRel(D, d2, 1e-2f), D, d2);
+	mgl_assert2(closestPointB.Equals(closestPointB2, 1e-2f), closestPointB.SerializeToCodeString(), closestPointB2.SerializeToCodeString());
 	vec closestPointA2 = a.GetPoint(D2);
-	assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
+	mgl_assert2(closestPointA.Equals(closestPointA2, 1e-2f), closestPointA.SerializeToCodeString(), closestPointA2.SerializeToCodeString());
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
-	assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
-	assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, pt.Distance(pt2) + 1e-3f);
+	mgl_assert(EqualAbs(a.Distance(b), closestPointA.Distance(closestPointB), 1e-2f));
+	mgl_assert(EqualAbs(b.Distance(a), closestPointA.Distance(closestPointB), 1e-2f));
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.b) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointA.Distance(b.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, a.Distance(b.b) + 1e-3f);
 
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.b) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.a) + 1e-3f);
-	assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, closestPointB.Distance(a.b) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.a) + 1e-3f);
+	mgl_assertcmp(closestPointA.Distance(closestPointB), <=, b.Distance(a.b) + 1e-3f);
 }

--- a/tests/MathFuncTests.cpp
+++ b/tests/MathFuncTests.cpp
@@ -45,7 +45,7 @@ UNIQUE_TEST(assertWorks)
 	EXPECT_FAIL("Testing exception throwing");
 
 	if (TrueCondition())
-		assert(false && "Testing that assert() macro fails as expected!");
+		mgl_assert(false && "Testing that assert() macro fails as expected!");
 }
 
 UNIQUE_TEST(assume1Works)
@@ -57,13 +57,13 @@ UNIQUE_TEST(assume1Works)
 		assume1(false && "Testing that assume() macro fails as expected!", val);
 }
 
-UNIQUE_TEST(assert1Works)
+UNIQUE_TEST(mgl_assert1Works)
 {
 	EXPECT_FAIL("Testing exception throwing");
 
 	int val = 5;
 	if (TrueCondition())
-		assert1(false && "Testing that assert() macro fails as expected!", val);
+		mgl_assert1(false && "Testing that assert() macro fails as expected!", val);
 }
 
 UNIQUE_TEST(assume4Works)
@@ -81,7 +81,7 @@ UNIQUE_TEST(assert4Works)
 
 	int val = 5;
 	if (TrueCondition())
-		assert4(false && "Testing that assert() macro fails as expected!", val, val, val, val);
+		mgl_assert4(false && "Testing that assert() macro fails as expected!", val, val, val, val);
 }
 
 UNIQUE_TEST(ExceptionGoesThrough)
@@ -111,7 +111,7 @@ UNIQUE_TEST(ExceptionCatchingWorks)
 	{
 		LOGE("Exception catching does not work!");
 	}
-	assert(gotException);
+	mgl_assert(gotException);
 }
 
 UNIQUE_TEST(BaseDerivedExceptionCatchingWorks)
@@ -132,7 +132,7 @@ UNIQUE_TEST(BaseDerivedExceptionCatchingWorks)
 	{
 		LOGE("Exception catching does not work!");
 	}
-	assert(gotException);
+	mgl_assert(gotException);
 }
 #endif
 
@@ -141,18 +141,18 @@ TEST(CXX11StdFinite)
 {
 	// When using MathGeoLib, users should still be able to invoke C++11 std::isfinite function.
 	// http://en.cppreference.com/w/cpp/numeric/math/isfinite
-	assert(std::isfinite(5.f));
-	assert(std::isfinite(5.0));
+	mgl_assert(std::isfinite(5.f));
+	mgl_assert(std::isfinite(5.0));
 
 	using namespace std;
 
-	assert(isfinite(5.f));
-	assert(isfinite(5.0));
+	mgl_assert(isfinite(5.f));
+	mgl_assert(isfinite(5.0));
 
 
 #ifndef __EMSCRIPTEN__ // long double is not supported.
-	assert(std::isfinite(5.0L));
-	assert(isfinite(5.0L));
+	mgl_assert(std::isfinite(5.0L));
+	mgl_assert(isfinite(5.0L));
 #endif
 
 }
@@ -172,8 +172,8 @@ struct U80
 		for(int i = 0; i < 16; ++i)
 			data[i] = 0;
 		ld = d;
-		assert(sizeof(long double) <= 16);
-		assert(sizeof(d) <= 16);
+		mgl_assert(sizeof(long double) <= 16);
+		mgl_assert(sizeof(d) <= 16);
 	}
 
 	std::string ToString() const
@@ -217,94 +217,94 @@ UNIQUE_TEST(FloatRepresentation)
 
 TEST(IsFinite)
 {
-	assert(IsFinite(5));
-	assert(IsFinite(5.f));
-	assert(IsFinite(5.0));
+	mgl_assert(IsFinite(5));
+	mgl_assert(IsFinite(5.f));
+	mgl_assert(IsFinite(5.0));
 #ifndef __EMSCRIPTEN__ // long double is not supported.
-	assert(IsFinite(5.0L));
+	mgl_assert(IsFinite(5.0L));
 #endif
 
-	assert(!IsFinite(FLOAT_NAN));
-	assert(!IsFinite(FLOAT_INF));
-	assert(IsFinite(FLT_MAX));
+	mgl_assert(!IsFinite(FLOAT_NAN));
+	mgl_assert(!IsFinite(FLOAT_INF));
+	mgl_assert(IsFinite(FLT_MAX));
 
-	assert(!IsFinite((double)FLOAT_NAN));
-	assert(!IsFinite((double)FLOAT_INF));
-	assert(IsFinite((double)FLT_MAX));
+	mgl_assert(!IsFinite((double)FLOAT_NAN));
+	mgl_assert(!IsFinite((double)FLOAT_INF));
+	mgl_assert(IsFinite((double)FLT_MAX));
 
 #ifndef __EMSCRIPTEN__ // long double is not supported.
-	assert(!IsFinite((long double)FLOAT_NAN));
-	assert(!IsFinite((long double)FLOAT_INF));
-	assert(IsFinite((long double)FLT_MAX));
+	mgl_assert(!IsFinite((long double)FLOAT_NAN));
+	mgl_assert(!IsFinite((long double)FLOAT_INF));
+	mgl_assert(IsFinite((long double)FLT_MAX));
 #endif
 }
 
 TEST(IsNan)
 {
-	assert(!IsNan(5.f));
-	assert(!IsNan(5.0));
+	mgl_assert(!IsNan(5.f));
+	mgl_assert(!IsNan(5.0));
 #ifndef __EMSCRIPTEN__ // long double is not supported.
-	assert(!IsNan(5.0L));
+	mgl_assert(!IsNan(5.0L));
 #endif
 
-	assert(IsNan(FLOAT_NAN));
-	assert(!IsNan(FLOAT_INF));
-	assert(!IsNan(FLT_MAX));
+	mgl_assert(IsNan(FLOAT_NAN));
+	mgl_assert(!IsNan(FLOAT_INF));
+	mgl_assert(!IsNan(FLT_MAX));
 
-	assert(IsNan((double)FLOAT_NAN));
-	assert(!IsNan((double)FLOAT_INF));
-	assert(!IsNan((double)FLT_MAX));
+	mgl_assert(IsNan((double)FLOAT_NAN));
+	mgl_assert(!IsNan((double)FLOAT_INF));
+	mgl_assert(!IsNan((double)FLT_MAX));
 
 #ifndef __EMSCRIPTEN__ // long double is not supported.
-	assert(IsNan((long double)FLOAT_NAN));
-	assert(!IsNan((long double)FLOAT_INF));
-	assert(!IsNan((long double)FLT_MAX));
+	mgl_assert(IsNan((long double)FLOAT_NAN));
+	mgl_assert(!IsNan((long double)FLOAT_INF));
+	mgl_assert(!IsNan((long double)FLT_MAX));
 #endif
 }
 
 TEST(IsInf)
 {
-	assert(!IsInf(5.f));
-	assert(!IsInf(5.0));
+	mgl_assert(!IsInf(5.f));
+	mgl_assert(!IsInf(5.0));
 #ifndef __EMSCRIPTEN__ // long double is not supported.
-	assert(!IsInf(5.0L));
+	mgl_assert(!IsInf(5.0L));
 #endif
 
-	assert(!IsInf(FLOAT_NAN));
-	assert(IsInf(FLOAT_INF));
-	assert(IsInf(-FLOAT_INF));
-	assert(!IsInf(FLT_MAX));
+	mgl_assert(!IsInf(FLOAT_NAN));
+	mgl_assert(IsInf(FLOAT_INF));
+	mgl_assert(IsInf(-FLOAT_INF));
+	mgl_assert(!IsInf(FLT_MAX));
 
-	assert(!IsInf((double)FLOAT_NAN));
-	assert(IsInf((double)FLOAT_INF));
-	assert(IsInf(-(double)FLOAT_INF));
-	assert(!IsInf((double)FLT_MAX));
+	mgl_assert(!IsInf((double)FLOAT_NAN));
+	mgl_assert(IsInf((double)FLOAT_INF));
+	mgl_assert(IsInf(-(double)FLOAT_INF));
+	mgl_assert(!IsInf((double)FLT_MAX));
 
 #ifndef __EMSCRIPTEN__ // long double is not supported.
-	assert(!IsInf((long double)FLOAT_NAN));
-	assert(IsInf((long double)FLOAT_INF));
-	assert(IsInf(-(long double)FLOAT_INF));
-	assert(!IsInf((long double)FLT_MAX));
+	mgl_assert(!IsInf((long double)FLOAT_NAN));
+	mgl_assert(IsInf((long double)FLOAT_INF));
+	mgl_assert(IsInf(-(long double)FLOAT_INF));
+	mgl_assert(!IsInf((long double)FLT_MAX));
 #endif
 }
 
 TEST(ReinterpretAsU32)
 {
-	assert(ReinterpretAsU32(0.0f) == 0x00000000);
-	assert(ReinterpretAsU32(1.0f) == 0x3F800000);
-	assert(ReinterpretAsU32(2.0f) == 0x40000000);
-	assert(ReinterpretAsU32(-1.0f) == 0xBF800000);
-	assert(ReinterpretAsU32(FLOAT_INF) == 0x7F800000);
+	mgl_assert(ReinterpretAsU32(0.0f) == 0x00000000);
+	mgl_assert(ReinterpretAsU32(1.0f) == 0x3F800000);
+	mgl_assert(ReinterpretAsU32(2.0f) == 0x40000000);
+	mgl_assert(ReinterpretAsU32(-1.0f) == 0xBF800000);
+	mgl_assert(ReinterpretAsU32(FLOAT_INF) == 0x7F800000);
 }
 
 TEST(ReinterpretAsFloat)
 {
-	assert(ReinterpretAsFloat(0x00000000) == 0.0f);
-	assert(ReinterpretAsFloat(0x3F800000) == 1.0f);
-	assert(ReinterpretAsFloat(0x40000000) == 2.0f);
-	assert(ReinterpretAsFloat(0xBF800000) == -1.0f);
-	assert(ReinterpretAsFloat(0x7F800000) == FLOAT_INF);
-	assert(IsNan(ReinterpretAsFloat(0x7F800001)));
+	mgl_assert(ReinterpretAsFloat(0x00000000) == 0.0f);
+	mgl_assert(ReinterpretAsFloat(0x3F800000) == 1.0f);
+	mgl_assert(ReinterpretAsFloat(0x40000000) == 2.0f);
+	mgl_assert(ReinterpretAsFloat(0xBF800000) == -1.0f);
+	mgl_assert(ReinterpretAsFloat(0x7F800000) == FLOAT_INF);
+	mgl_assert(IsNan(ReinterpretAsFloat(0x7F800001)));
 }
 
 // Idea: Since approx Sqrt is so fast, run through that and do one manual Newton-Rhapson iteration to improve.
@@ -382,9 +382,9 @@ float AnotherHackSqrt(float f)
 
 UNIQUE_TEST(SqrtVals)
 {
-	assert(Sqrt(-0.f) == 0.f);
-	assert(Sqrt(0.f) == 0.f);
-	assert(Sqrt(1.f) == 1.f);
+	mgl_assert(Sqrt(-0.f) == 0.f);
+	mgl_assert(Sqrt(0.f) == 0.f);
+	mgl_assert(Sqrt(1.f) == 1.f);
 }
 
 UNIQUE_TEST(sqrt_precision)
@@ -425,27 +425,27 @@ UNIQUE_TEST(sqrt_precision)
 		}
 
 		LOGI("Max relative error with Sqrt: %e", maxRelError[0]);
-		assert(maxRelError[0] < 1e-6f);
+		mgl_assert(maxRelError[0] < 1e-6f);
 		LOGI("Max relative error with SqrtFast: %e", maxRelError[1]);
-		assert(maxRelError[1] < 1e-3f);
+		mgl_assert(maxRelError[1] < 1e-3f);
 		LOGI("Max relative error with NewtonRhapsonSqrt: %e", maxRelError[2]);
-		assert(maxRelError[2] < 1e-6f);
+		mgl_assert(maxRelError[2] < 1e-6f);
 #ifdef MATH_SSE
 		LOGI("Max relative error with NewtonRhapsonSSESqrt: %e", maxRelError[3]);
-		assert(maxRelError[3] < 1e-6f);
+		mgl_assert(maxRelError[3] < 1e-6f);
 
 		LOGI("Max relative error with NewtonRhapsonSSESqrt2: %e", maxRelError[4]);
-		assert(maxRelError[4] < 1e-6f);
+		mgl_assert(maxRelError[4] < 1e-6f);
 
 		LOGI("Max relative error with NewtonRhapsonSSESqrt3: %e", maxRelError[5]);
-		assert(maxRelError[5] < 1e-6f);
+		mgl_assert(maxRelError[5] < 1e-6f);
 
 		LOGI("Max relative error with Sqrt_Via_Rcp_RSqrt: %e", maxRelError[6]);
-		assert(maxRelError[6] < 1e-3f);
+		mgl_assert(maxRelError[6] < 1e-3f);
 #endif
 #ifdef MATH_SIMD
 		LOGI("Max relative error with sqrt_ps: %e", maxRelError[7]);
-		assert(maxRelError[7] < 1e-6f);
+		mgl_assert(maxRelError[7] < 1e-6f);
 #endif
 
 		LOGI("Max relative error with sqrtf: %e", maxRelError[8]);
@@ -549,18 +549,18 @@ UNIQUE_TEST(sqrt_rsqrt_precision)
 			maxRelError[j] = Max(RelativeError(x, X[j]), maxRelError[j]);
 	}
 	LOGI("Max relative error with RSqrt: %e", maxRelError[0]);
-	assert(maxRelError[0] < 1e-6f);
+	mgl_assert(maxRelError[0] < 1e-6f);
 	LOGI("Max relative error with 1.f/sqrtf: %e", maxRelError[1]);
-	assert(maxRelError[1] < 1e-6f);
+	mgl_assert(maxRelError[1] < 1e-6f);
 	LOGI("Max relative error with sqrtf(1.f/x): %e", maxRelError[2]);
-	assert(maxRelError[2] < 1e-6f);
+	mgl_assert(maxRelError[2] < 1e-6f);
 	LOGI("Max relative error with Quake InvSqrt: %e", maxRelError[3]);
-	assert(maxRelError[3] < 1e-2f);
+	mgl_assert(maxRelError[3] < 1e-2f);
 	LOGI("Max relative error with RSqrtFast: %e", maxRelError[4]);
-	assert(maxRelError[4] < 5e-3f);
+	mgl_assert(maxRelError[4] < 5e-3f);
 #ifdef MATH_SIMD
 	LOGI("Max relative error with rsqrt_ps: %e", maxRelError[5]);
-	assert(maxRelError[5] < 1e-6f);
+	mgl_assert(maxRelError[5] < 1e-6f);
 #endif
 }
 
@@ -614,7 +614,7 @@ float NewtonRhapsonRecip(float x)
 
 	// Do one iteration of Newton-Rhapson:
 	simd4f e2 = _mm_mul_ss(e,e);
-	
+
 	return s4f_x(_mm_sub_ss(_mm_add_ss(e, e), _mm_mul_ss(X, e2)));
 }
 
@@ -684,24 +684,24 @@ UNIQUE_TEST(sqrt_recip_precision)
 	}
 
 	LOGI("Max relative error with Recip: %e", maxRelError[0]);
-	assert(maxRelError[0] < 1e-5f);
+	mgl_assert(maxRelError[0] < 1e-5f);
 	LOGI("Max relative error with RecipFast: %e", maxRelError[1]);
-	assert(maxRelError[1] < 5e-3f);
+	mgl_assert(maxRelError[1] < 5e-3f);
 #ifdef MATH_SSE
 	LOGI("Max relative error with NewtonRhapsonRecip: %e", maxRelError[2]);
-	assert(maxRelError[2] < 1e-5f);
+	mgl_assert(maxRelError[2] < 1e-5f);
 	LOGI("Max relative error with NewtonRhapsonRecip2: %e", maxRelError[3]);
-	assert(maxRelError[3] < 1e-5f);
+	mgl_assert(maxRelError[3] < 1e-5f);
 #endif
 	LOGI("Max relative error with 1.f/x: %e", maxRelError[4]);
-	assert(maxRelError[4] < 1e-6f);
+	mgl_assert(maxRelError[4] < 1e-6f);
 #ifdef MATH_SIMD
 	LOGI("Max relative error with rcp_ps: %e", maxRelError[5]);
-	assert(maxRelError[5] < 1e-5f);
+	mgl_assert(maxRelError[5] < 1e-5f);
 #endif
 #ifdef MATH_SSE2
 	LOGI("Max relative error with rcp_double: %e", maxRelError[6]);
-	assert(maxRelError[6] < 1e-5f);
+	mgl_assert(maxRelError[6] < 1e-5f);
 #endif
 }
 
@@ -1007,7 +1007,7 @@ RANDOMIZED_TEST(Min)
 	if (rng.Int(0,10) == 0) b = FLOAT_INF;
 	float correctMin = std::min(a,b);
 	float mglMin = Min(a, b);
-	assert(correctMin == mglMin);
+	mgl_assert(correctMin == mglMin);
 	MARK_UNUSED(correctMin);
 	MARK_UNUSED(mglMin);
 }
@@ -1026,7 +1026,7 @@ RANDOMIZED_TEST(Max)
 	if (rng.Int(0,10) == 0) b = FLOAT_INF;
 	float correctMax = std::max(a,b);
 	float mglMax = Max(a, b);
-	assert(correctMax == mglMax);
+	mgl_assert(correctMax == mglMax);
 	MARK_UNUSED(correctMax);
 	MARK_UNUSED(mglMax);
 }
@@ -1139,159 +1139,159 @@ BENCHMARK_END;
 
 UNIQUE_TEST(IsPow2)
 {
-	assert(IsPow2(0));
-	assert(IsPow2(1));
-	assert(IsPow2(2));
-	assert(!IsPow2(3));
-	assert(IsPow2(4));
-	assert(!IsPow2(6));
-	assert(IsPow2(8));
-	assert(IsPow2(65536));
-	assert(!IsPow2(3423626));
-	assert(!IsPow2((u32)-1));
-	assert(!IsPow2((u32)0xFFFFFFFFU));
-	assert(IsPow2((u32)0x40000000U));
-	assert(IsPow2((u32)0x80000000U));
+	mgl_assert(IsPow2(0));
+	mgl_assert(IsPow2(1));
+	mgl_assert(IsPow2(2));
+	mgl_assert(!IsPow2(3));
+	mgl_assert(IsPow2(4));
+	mgl_assert(!IsPow2(6));
+	mgl_assert(IsPow2(8));
+	mgl_assert(IsPow2(65536));
+	mgl_assert(!IsPow2(3423626));
+	mgl_assert(!IsPow2((u32)-1));
+	mgl_assert(!IsPow2((u32)0xFFFFFFFFU));
+	mgl_assert(IsPow2((u32)0x40000000U));
+	mgl_assert(IsPow2((u32)0x80000000U));
 }
 
 UNIQUE_TEST(IsPow2_u64)
 {
-	assert(IsPow2(0ULL));
-	assert(IsPow2(1ULL));
-	assert(IsPow2(2ULL));
-	assert(!IsPow2(3ULL));
-	assert(IsPow2(4ULL));
-	assert(!IsPow2(6ULL));
-	assert(IsPow2(8ULL));
-	assert(IsPow2(65536ULL));
-	assert(!IsPow2(3423626ULL));
-	assert(!IsPow2((u64)-1));
-	assert(!IsPow2(0xFFFFFFFFULL));
-	assert(!IsPow2(0xFFFFFFFFFFFFFFFFULL));
-	assert(IsPow2(0x40000000ULL));
-	assert(IsPow2(0x80000000ULL));
-	assert(IsPow2(0x100000000ULL));
-	assert(IsPow2(0x4000000000000000ULL));
-	assert(IsPow2(0x8000000000000000ULL));
+	mgl_assert(IsPow2(0ULL));
+	mgl_assert(IsPow2(1ULL));
+	mgl_assert(IsPow2(2ULL));
+	mgl_assert(!IsPow2(3ULL));
+	mgl_assert(IsPow2(4ULL));
+	mgl_assert(!IsPow2(6ULL));
+	mgl_assert(IsPow2(8ULL));
+	mgl_assert(IsPow2(65536ULL));
+	mgl_assert(!IsPow2(3423626ULL));
+	mgl_assert(!IsPow2((u64)-1));
+	mgl_assert(!IsPow2(0xFFFFFFFFULL));
+	mgl_assert(!IsPow2(0xFFFFFFFFFFFFFFFFULL));
+	mgl_assert(IsPow2(0x40000000ULL));
+	mgl_assert(IsPow2(0x80000000ULL));
+	mgl_assert(IsPow2(0x100000000ULL));
+	mgl_assert(IsPow2(0x4000000000000000ULL));
+	mgl_assert(IsPow2(0x8000000000000000ULL));
 }
 
 UNIQUE_TEST(RoundUpPow2)
 {
-	asserteq(RoundUpPow2(0), 0);
-	asserteq(RoundUpPow2(1), 1);
-	asserteq(RoundUpPow2(2), 2);
-	asserteq(RoundUpPow2(3), 4);
-	asserteq(RoundUpPow2(4), 4);
-	asserteq(RoundUpPow2(5), 8);
-	asserteq(RoundUpPow2(64241), 65536);
-	asserteq(RoundUpPow2((u32)0x7FFFFFFFU), 0x80000000U);
-	asserteq(RoundUpPow2((u32)0x80000000U), 0x80000000U);
-	asserteq(RoundUpPow2((u32)0x80000001U), 0);
-	asserteq(RoundUpPow2((u32)0xFE873210U), 0);
-	asserteq(RoundUpPow2((u32)0xFFFFFFFFU), 0);
+	mgl_asserteq(RoundUpPow2(0), 0);
+	mgl_asserteq(RoundUpPow2(1), 1);
+	mgl_asserteq(RoundUpPow2(2), 2);
+	mgl_asserteq(RoundUpPow2(3), 4);
+	mgl_asserteq(RoundUpPow2(4), 4);
+	mgl_asserteq(RoundUpPow2(5), 8);
+	mgl_asserteq(RoundUpPow2(64241), 65536);
+	mgl_asserteq(RoundUpPow2((u32)0x7FFFFFFFU), 0x80000000U);
+	mgl_asserteq(RoundUpPow2((u32)0x80000000U), 0x80000000U);
+	mgl_asserteq(RoundUpPow2((u32)0x80000001U), 0);
+	mgl_asserteq(RoundUpPow2((u32)0xFE873210U), 0);
+	mgl_asserteq(RoundUpPow2((u32)0xFFFFFFFFU), 0);
 }
 
 UNIQUE_TEST(RoundUpPow2_u64)
 {
-	asserteq(RoundUpPow2(0ULL), 0);
-	asserteq(RoundUpPow2(1ULL), 1);
-	asserteq(RoundUpPow2(2ULL), 2);
-	asserteq(RoundUpPow2(3ULL), 4);
-	asserteq(RoundUpPow2(4ULL), 4);
-	asserteq(RoundUpPow2(5ULL), 8);
-	asserteq(RoundUpPow2(64241ULL), 65536);
-	asserteq(RoundUpPow2(0x7FFFFFFFULL), 0x80000000U);
-	asserteq(RoundUpPow2(0x80000000ULL), 0x80000000U);
-	asserteq(RoundUpPow2(0x80000001ULL), 0x100000000ULL);
-	asserteq(RoundUpPow2(0xFE873210ULL), 0x100000000ULL);
-	asserteq(RoundUpPow2(0xFFFFFFFFULL), 0x100000000ULL);
-	asserteq(RoundUpPow2(0x7FFFFFFFFFFFFFFFULL), 0x8000000000000000ULL);
-	asserteq(RoundUpPow2(0x8000000000000000ULL), 0x8000000000000000ULL);
-	asserteq(RoundUpPow2(0x8000000000000001ULL), 0);
-	asserteq(RoundUpPow2(0xFE87321084208274ULL), 0);
-	asserteq(RoundUpPow2(0xFFFFFFFFFFFFFFFFULL), 0);
+	mgl_asserteq(RoundUpPow2(0ULL), 0);
+	mgl_asserteq(RoundUpPow2(1ULL), 1);
+	mgl_asserteq(RoundUpPow2(2ULL), 2);
+	mgl_asserteq(RoundUpPow2(3ULL), 4);
+	mgl_asserteq(RoundUpPow2(4ULL), 4);
+	mgl_asserteq(RoundUpPow2(5ULL), 8);
+	mgl_asserteq(RoundUpPow2(64241ULL), 65536);
+	mgl_asserteq(RoundUpPow2(0x7FFFFFFFULL), 0x80000000U);
+	mgl_asserteq(RoundUpPow2(0x80000000ULL), 0x80000000U);
+	mgl_asserteq(RoundUpPow2(0x80000001ULL), 0x100000000ULL);
+	mgl_asserteq(RoundUpPow2(0xFE873210ULL), 0x100000000ULL);
+	mgl_asserteq(RoundUpPow2(0xFFFFFFFFULL), 0x100000000ULL);
+	mgl_asserteq(RoundUpPow2(0x7FFFFFFFFFFFFFFFULL), 0x8000000000000000ULL);
+	mgl_asserteq(RoundUpPow2(0x8000000000000000ULL), 0x8000000000000000ULL);
+	mgl_asserteq(RoundUpPow2(0x8000000000000001ULL), 0);
+	mgl_asserteq(RoundUpPow2(0xFE87321084208274ULL), 0);
+	mgl_asserteq(RoundUpPow2(0xFFFFFFFFFFFFFFFFULL), 0);
 }
 
 UNIQUE_TEST(RoundDownPow2)
 {
-	asserteq(RoundDownPow2(0), 0);
-	asserteq(RoundDownPow2(1), 1);
-	asserteq(RoundDownPow2(2), 2);
-	asserteq(RoundDownPow2(3), 2);
-	asserteq(RoundDownPow2(4), 4);
-	asserteq(RoundDownPow2(5), 4);
-	asserteq(RoundDownPow2(64241), 32768);
-	asserteq(RoundDownPow2((u32)0x7FFFFFFFU), 0x40000000U);
-	asserteq(RoundDownPow2((u32)0x80000000U), 0x80000000U);
-	asserteq(RoundDownPow2((u32)0x80000001U), 0x80000000U);
-	asserteq(RoundDownPow2((u32)0xFE873210U), 0x80000000U);
-	asserteq(RoundDownPow2((u32)0xFFFFFFFFU), 0x80000000U);
+	mgl_asserteq(RoundDownPow2(0), 0);
+	mgl_asserteq(RoundDownPow2(1), 1);
+	mgl_asserteq(RoundDownPow2(2), 2);
+	mgl_asserteq(RoundDownPow2(3), 2);
+	mgl_asserteq(RoundDownPow2(4), 4);
+	mgl_asserteq(RoundDownPow2(5), 4);
+	mgl_asserteq(RoundDownPow2(64241), 32768);
+	mgl_asserteq(RoundDownPow2((u32)0x7FFFFFFFU), 0x40000000U);
+	mgl_asserteq(RoundDownPow2((u32)0x80000000U), 0x80000000U);
+	mgl_asserteq(RoundDownPow2((u32)0x80000001U), 0x80000000U);
+	mgl_asserteq(RoundDownPow2((u32)0xFE873210U), 0x80000000U);
+	mgl_asserteq(RoundDownPow2((u32)0xFFFFFFFFU), 0x80000000U);
 }
 
 UNIQUE_TEST(RoundDownPow2_u64)
 {
-	asserteq(RoundDownPow2(0ULL), 0);
-	asserteq(RoundDownPow2(1ULL), 1);
-	asserteq(RoundDownPow2(2ULL), 2);
-	asserteq(RoundDownPow2(3ULL), 2);
-	asserteq(RoundDownPow2(4ULL), 4);
-	asserteq(RoundDownPow2(5ULL), 4);
-	asserteq(RoundDownPow2(64241ULL), 32768);
-	asserteq(RoundDownPow2(0x7FFFFFFFULL), 0x40000000U);
-	asserteq(RoundDownPow2(0x80000000ULL), 0x80000000U);
-	asserteq(RoundDownPow2(0x80000001ULL), 0x80000000ULL);
-	asserteq(RoundDownPow2(0xFE873210ULL), 0x80000000ULL);
-	asserteq(RoundDownPow2(0xFFFFFFFFULL), 0x80000000ULL);
-	asserteq(RoundDownPow2(0x7FFFFFFFFFFFFFFFULL), 0x4000000000000000ULL);
-	asserteq(RoundDownPow2(0x8000000000000000ULL), 0x8000000000000000ULL);
-	asserteq(RoundDownPow2(0x8000000000000001ULL), 0x8000000000000000ULL);
-	asserteq(RoundDownPow2(0xFE87321084208274ULL), 0x8000000000000000ULL);
-	asserteq(RoundDownPow2(0xFFFFFFFFFFFFFFFFULL), 0x8000000000000000ULL);
+	mgl_asserteq(RoundDownPow2(0ULL), 0);
+	mgl_asserteq(RoundDownPow2(1ULL), 1);
+	mgl_asserteq(RoundDownPow2(2ULL), 2);
+	mgl_asserteq(RoundDownPow2(3ULL), 2);
+	mgl_asserteq(RoundDownPow2(4ULL), 4);
+	mgl_asserteq(RoundDownPow2(5ULL), 4);
+	mgl_asserteq(RoundDownPow2(64241ULL), 32768);
+	mgl_asserteq(RoundDownPow2(0x7FFFFFFFULL), 0x40000000U);
+	mgl_asserteq(RoundDownPow2(0x80000000ULL), 0x80000000U);
+	mgl_asserteq(RoundDownPow2(0x80000001ULL), 0x80000000ULL);
+	mgl_asserteq(RoundDownPow2(0xFE873210ULL), 0x80000000ULL);
+	mgl_asserteq(RoundDownPow2(0xFFFFFFFFULL), 0x80000000ULL);
+	mgl_asserteq(RoundDownPow2(0x7FFFFFFFFFFFFFFFULL), 0x4000000000000000ULL);
+	mgl_asserteq(RoundDownPow2(0x8000000000000000ULL), 0x8000000000000000ULL);
+	mgl_asserteq(RoundDownPow2(0x8000000000000001ULL), 0x8000000000000000ULL);
+	mgl_asserteq(RoundDownPow2(0xFE87321084208274ULL), 0x8000000000000000ULL);
+	mgl_asserteq(RoundDownPow2(0xFFFFFFFFFFFFFFFFULL), 0x8000000000000000ULL);
 }
 
 UNIQUE_TEST(LSB_U32)
 {
-	asserteq(LSB((u32)0), 0);
-	asserteq(LSB((u32)1), 1);
-	asserteq(LSB((u32)2), 3);
-	asserteq(LSB((u32)3), 7);
-	asserteq(LSB((u32)16), 0xFFFFU);
-	asserteq(LSB((u32)31), 0x7FFFFFFFU);
-	asserteq(LSB((u32)32), 0xFFFFFFFFU);
+	mgl_asserteq(LSB((u32)0), 0);
+	mgl_asserteq(LSB((u32)1), 1);
+	mgl_asserteq(LSB((u32)2), 3);
+	mgl_asserteq(LSB((u32)3), 7);
+	mgl_asserteq(LSB((u32)16), 0xFFFFU);
+	mgl_asserteq(LSB((u32)31), 0x7FFFFFFFU);
+	mgl_asserteq(LSB((u32)32), 0xFFFFFFFFU);
 }
 
 UNIQUE_TEST(LSB_U64)
 {
-	asserteq(LSB64((u64)0), 0);
-	asserteq(LSB64((u64)1), 1);
-	asserteq(LSB64((u64)2), 3);
-	asserteq(LSB64((u64)3), 7);
-	asserteq(LSB64((u64)16), 0xFFFFULL);
-	asserteq(LSB64((u64)31), 0x7FFFFFFFULL);
-	asserteq(LSB64((u64)32), 0xFFFFFFFFULL);
-	asserteq(LSB64((u64)33), 0x1FFFFFFFFULL);
-	asserteq(LSB64((u64)63), 0x7FFFFFFFFFFFFFFFULL);
-	asserteq(LSB64((u64)64), 0xFFFFFFFFFFFFFFFFULL);
+	mgl_asserteq(LSB64((u64)0), 0);
+	mgl_asserteq(LSB64((u64)1), 1);
+	mgl_asserteq(LSB64((u64)2), 3);
+	mgl_asserteq(LSB64((u64)3), 7);
+	mgl_asserteq(LSB64((u64)16), 0xFFFFULL);
+	mgl_asserteq(LSB64((u64)31), 0x7FFFFFFFULL);
+	mgl_asserteq(LSB64((u64)32), 0xFFFFFFFFULL);
+	mgl_asserteq(LSB64((u64)33), 0x1FFFFFFFFULL);
+	mgl_asserteq(LSB64((u64)63), 0x7FFFFFFFFFFFFFFFULL);
+	mgl_asserteq(LSB64((u64)64), 0xFFFFFFFFFFFFFFFFULL);
 }
 
 UNIQUE_TEST(Sin_lookuptable)
 {
-	asserteq(Sin(0.f), 0.f);
-	assert1(EqualAbs(Sin(pi), 0.f, 1e-7f), Sin(pi));
-	assert1(EqualAbs(Sin(-pi), 0.f, 1e-7f), Sin(-pi));
-	assert1(EqualAbs(Sin(-37.6991577f), 0.f, 1e-4f), Sin(-37.6991577f));
-	assert1(EqualAbs(Sin(pi/2.f), 1.f, 1e-7f), Sin(pi/2.f));
-	assert1(EqualAbs(Sin(-pi/2.f), -1.f, 1e-4f), Sin(-pi/2.f));
-	assert1(EqualAbs(Sin(pi/4.f), 1.f/Sqrt(2.f), 1e-4f), Sin(pi/4.f));
+	mgl_asserteq(Sin(0.f), 0.f);
+	mgl_assert1(EqualAbs(Sin(pi), 0.f, 1e-7f), Sin(pi));
+	mgl_assert1(EqualAbs(Sin(-pi), 0.f, 1e-7f), Sin(-pi));
+	mgl_assert1(EqualAbs(Sin(-37.6991577f), 0.f, 1e-4f), Sin(-37.6991577f));
+	mgl_assert1(EqualAbs(Sin(pi/2.f), 1.f, 1e-7f), Sin(pi/2.f));
+	mgl_assert1(EqualAbs(Sin(-pi/2.f), -1.f, 1e-4f), Sin(-pi/2.f));
+	mgl_assert1(EqualAbs(Sin(pi/4.f), 1.f/Sqrt(2.f), 1e-4f), Sin(pi/4.f));
 }
 
 UNIQUE_TEST(Cos_lookuptable)
 {
-	asserteq(Cos(0.f), 1.f);
-	assert1(EqualAbs(Cos(pi), -1.f, 1e-7f), Cos(pi));
-	assert1(EqualAbs(Cos(-pi), -1.f, 1e-7f), Cos(-pi));
-	assert1(EqualAbs(Cos(-37.6991577f), 1.f, 1e-4f), Cos(-37.6991577f));
-	assert1(EqualAbs(Cos(pi / 2.f), 0.f, 1e-7f), Cos(pi / 2.f));
-	assert1(EqualAbs(Cos(-pi / 2.f), -0.f, 1e-4f), Cos(-pi / 2.f));
-	assert1(EqualAbs(Cos(pi / 4.f), 1.f/Sqrt(2.f), 1e-4f), Cos(pi / 4.f));
+	mgl_asserteq(Cos(0.f), 1.f);
+	mgl_assert1(EqualAbs(Cos(pi), -1.f, 1e-7f), Cos(pi));
+	mgl_assert1(EqualAbs(Cos(-pi), -1.f, 1e-7f), Cos(-pi));
+	mgl_assert1(EqualAbs(Cos(-37.6991577f), 1.f, 1e-4f), Cos(-37.6991577f));
+	mgl_assert1(EqualAbs(Cos(pi / 2.f), 0.f, 1e-7f), Cos(pi / 2.f));
+	mgl_assert1(EqualAbs(Cos(-pi / 2.f), -0.f, 1e-4f), Cos(-pi / 2.f));
+	mgl_assert1(EqualAbs(Cos(pi / 4.f), 1.f/Sqrt(2.f), 1e-4f), Cos(pi / 4.f));
 }

--- a/tests/MatrixTests.cpp
+++ b/tests/MatrixTests.cpp
@@ -28,9 +28,9 @@ TEST(Float3x4ScaleRow)
 	m.ScaleRow(1, 4.f);
 	m.ScaleRow(2, 2.f);
 	m -= float3x4(8,8,8,8,8,8,8,8,8,8,8,8);
-	assert(m.IsSymmetric());
-	assert(m.IsSkewSymmetric());
-	assert((m+float3x4::identity).IsIdentity());
+	mgl_assert(m.IsSymmetric());
+	mgl_assert(m.IsSkewSymmetric());
+	mgl_assert((m+float3x4::identity).IsIdentity());
 }
 
 TEST(Float3x4SetRow)
@@ -41,7 +41,7 @@ TEST(Float3x4SetRow)
 	float v[4] = {9,10,11,12};
 	m.SetRow(2, v);
 
-	assert(m.Equals(float3x4(1,2,3,4, 5,6,7,8, 9,10,11,12)));
+	mgl_assert(m.Equals(float3x4(1,2,3,4, 5,6,7,8, 9,10,11,12)));
 }
 
 TEST(Float3x4SwapRows)
@@ -58,10 +58,10 @@ TEST(Float3x4SwapRows)
 	float3x4 v2;
 	v2.SetRotatePart(float3x3(0,0,1, 0,1,0, 1,0,0));
 	v2.SetTranslatePart(0,0,0);
-	assert(v.Equals(v2));
+	mgl_assert(v.Equals(v2));
 
 	v4 = v2;
-	assert(v3.Equals(v4));
+	mgl_assert(v3.Equals(v4));
 }
 
 Line RandomLineContainingPoint(const vec &pt);
@@ -70,37 +70,37 @@ RANDOMIZED_TEST(Float3x4TransformFloat4)
 {
 	Line l = RandomLineContainingPoint(POINT_VEC_SCALAR(0.f));
 	l.pos = POINT_VEC(float3::zero);
-	assert(l.dir.IsNormalized());
+	mgl_assert(l.dir.IsNormalized());
 	float4 pt = POINT_TO_FLOAT4(l.GetPoint(rng.Float(-3.f, 3.f)));
 	float3x4 rot = Quat::RandomRotation(rng).ToFloat3x4();
 	float4 newDir = rot.Transform(DIR_TO_FLOAT4(l.dir));
-	assert(newDir.w == 0.f);
+	mgl_assert(newDir.w == 0.f);
 	l.dir = FLOAT4_TO_DIR(newDir);
-	assert(l.dir.IsNormalized(1e-1f));
+	mgl_assert(l.dir.IsNormalized(1e-1f));
 	l.dir.Normalize();
 	pt = rot.Transform(pt);
-	assert(pt.w == 1.f);
+	mgl_assert(pt.w == 1.f);
 	float d = l.Distance(FLOAT4_TO_POINT(pt));
 	MARK_UNUSED(d);
-	assert(EqualAbs(d, 0.f));
-	assert(l.Contains(FLOAT4_TO_POINT(pt)));
+	mgl_assert(EqualAbs(d, 0.f));
+	mgl_assert(l.Contains(FLOAT4_TO_POINT(pt)));
 }
 
 RANDOMIZED_TEST(Float3x4TransformPosDir)
 {
 	Line l = RandomLineContainingPoint(POINT_VEC_SCALAR(0.f));
 	l.pos = POINT_VEC(float3::zero);
-	assert(l.dir.IsNormalized());
+	mgl_assert(l.dir.IsNormalized());
 	vec pt = l.GetPoint(rng.Float(-3.f, 3.f));
 	float3x4 rot = Quat::RandomRotation(rng).ToFloat3x4();
 	l.dir = rot.TransformDir(l.dir);
-	assert(l.dir.IsNormalized(1e-1f));
+	mgl_assert(l.dir.IsNormalized(1e-1f));
 	l.dir.Normalize();
 	pt = POINT_VEC(rot.TransformPos(POINT_TO_FLOAT3(pt)));
 	float d = l.Distance(pt);
 	MARK_UNUSED(d);
-	assert(EqualAbs(d, 0.f));
-	assert(l.Contains(pt));
+	mgl_assert(EqualAbs(d, 0.f));
+	mgl_assert(l.Contains(pt));
 }
 
 RANDOMIZED_TEST(Float3x4MulFloat3x4)
@@ -116,7 +116,7 @@ RANDOMIZED_TEST(Float3x4MulFloat3x4)
 		v = m * v;
 		m4.SetCol(i, v.xyz());
 	}
-	assert(m3.Equals(m4));
+	mgl_assert(m3.Equals(m4));
 }
 
 RANDOMIZED_TEST(Float3x4MulScalar)
@@ -130,8 +130,8 @@ RANDOMIZED_TEST(Float3x4MulScalar)
 	for(int i = 0; i < 12; ++i)
 		m4.ptr()[i] = m.ptr()[i] * scalar;
 
-	assert(m2.Equals(m4));
-	assert(m3.Equals(m4));
+	mgl_assert(m2.Equals(m4));
+	mgl_assert(m3.Equals(m4));
 }
 
 
@@ -146,8 +146,8 @@ RANDOMIZED_TEST(Float3x4DivScalar)
 	for(int i = 0; i < 12; ++i)
 		m4.ptr()[i] = m.ptr()[i] / scalar;
 
-	assert(m2.Equals(m4));
-	assert(m3.Equals(m4));
+	mgl_assert(m2.Equals(m4));
+	mgl_assert(m3.Equals(m4));
 }
 
 RANDOMIZED_TEST(Float3x4AddFloat3x4)
@@ -162,29 +162,29 @@ RANDOMIZED_TEST(Float3x4AddFloat3x4)
 		for(int x = 0; x < 4; ++x)
 			m4.At(y,x) = m.At(y,x) + m2.At(y,x);
 
-	assert(m3.Equals(m4));
-	assert(m5.Equals(m4));
+	mgl_assert(m3.Equals(m4));
+	mgl_assert(m5.Equals(m4));
 }
 
 TEST(Float3x3AddUnary)
 {
 	float3x3 m(1,2,3, 4,5,6, 7,8,9);
 	float3x3 m2 = +m;
-	assert(m.Equals(m2));
+	mgl_assert(m.Equals(m2));
 }
 
 TEST(Float3x4AddUnary)
 {
 	float3x4 m(1,2,3,4, 5,6,7,8, 9,10,11,12);
 	float3x4 m2 = +m;
-	assert(m.Equals(m2));
+	mgl_assert(m.Equals(m2));
 }
 
 TEST(Float4x4AddUnary)
 {
 	float4x4 m(1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16);
 	float4x4 m2 = +m;
-	assert(m.Equals(m2));
+	mgl_assert(m.Equals(m2));
 }
 
 ///\todo Create and move to QuatTests.cpp
@@ -192,7 +192,7 @@ TEST(QuatAddUnary)
 {
 	Quat q(1,2,3,4);
 	Quat q2 = +q;
-	assert(q.Equals(q2));
+	mgl_assert(q.Equals(q2));
 }
 
 RANDOMIZED_TEST(Float3x4SubFloat3x4)
@@ -207,8 +207,8 @@ RANDOMIZED_TEST(Float3x4SubFloat3x4)
 		for(int x = 0; x < 4; ++x)
 			m4.At(y,x) = m.At(y,x) - m2.At(y,x);
 
-	assert(m3.Equals(m4));
-	assert(m5.Equals(m4));
+	mgl_assert(m3.Equals(m4));
+	mgl_assert(m5.Equals(m4));
 }
 
 RANDOMIZED_TEST(Float3x4Neg)
@@ -220,7 +220,7 @@ RANDOMIZED_TEST(Float3x4Neg)
 		for(int x = 0; x < 4; ++x)
 			m3.At(y,x) = -m.At(y,x);
 
-	assert(m2.Equals(m3));
+	mgl_assert(m2.Equals(m3));
 }
 
 RANDOMIZED_TEST(Float3x3SolveAxb)
@@ -232,13 +232,13 @@ RANDOMIZED_TEST(Float3x3SolveAxb)
 
 	float3 x;
 	bool success = A.SolveAxb(b, x);
-	assert(success || mayFail);
+	mgl_assert(success || mayFail);
 	MARK_UNUSED(success);
 	MARK_UNUSED(mayFail);
 	if (success)
 	{
 		float3 b2 = A*x;
-		assert(b2.Equals(b, 1e-1f));
+		mgl_assert(b2.Equals(b, 1e-1f));
 	}
 }
 
@@ -246,7 +246,7 @@ UNIQUE_TEST(Float3x3InverseCase)
 {
 	float3x3 m(-8.75243664f,6.71196938f,-5.95816374f,6.81996822f,-6.85106039f,2.38949537f,-0.856015682f,3.45762491f,3.311584f);
 	bool success = m.Inverse();
-	assert(success);
+	mgl_assert(success);
 	MARK_UNUSED(success);
 }
 
@@ -257,15 +257,15 @@ RANDOMIZED_TEST(Float3x3Inverse)
 
 	float3x3 A2 = A;
 	bool success = A2.Inverse();
-	assert(success || mayFail);
+	mgl_assert(success || mayFail);
 	MARK_UNUSED(success);
 	MARK_UNUSED(mayFail);
 	if (success)
 	{
 		float3x3 id = A * A2;
 		float3x3 id2 = A2 * A;
-		assert(id.Equals(float3x3::identity, 0.3f));
-		assert(id2.Equals(float3x3::identity, 0.3f));
+		mgl_assert(id.Equals(float3x3::identity, 0.3f));
+		mgl_assert(id2.Equals(float3x3::identity, 0.3f));
 	}
 }
 
@@ -276,15 +276,15 @@ RANDOMIZED_TEST(Float3x4Inverse)
 
 	float3x4 A2 = A;
 	bool success = A2.Inverse();
-	assert(success || mayFail);
+	mgl_assert(success || mayFail);
 	MARK_UNUSED(success);
 	MARK_UNUSED(mayFail);
 	if (success)
 	{
 		float3x4 id = A * A2;
 		float3x4 id2 = A2 * A;
-		assert(id.Equals(float3x4::identity, 0.3f));
-		assert(id2.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id2.Equals(float3x4::identity, 0.3f));
 	}
 }
 
@@ -294,14 +294,14 @@ RANDOMIZED_TEST(Float3x4InverseOrthogonalUniformScale)
 
 	float3x4 A2 = A;
 	bool success = A2.InverseOrthogonalUniformScale();
-	assert(success);
+	mgl_assert(success);
 	MARK_UNUSED(success);
 	if (success)
 	{
 		float3x4 id = A * A2;
 		float3x4 id2 = A2 * A;
-		assert(id.Equals(float3x4::identity, 0.3f));
-		assert(id2.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id2.Equals(float3x4::identity, 0.3f));
 	}
 }
 
@@ -314,14 +314,14 @@ RANDOMIZED_TEST(Float3x4InverseInverseColOrthogonal)
 
 	float3x4 A2 = A;
 	bool success = A2.InverseColOrthogonal();
-	assert(success);
+	mgl_assert(success);
 	MARK_UNUSED(success);
 	if (success)
 	{
 		float3x4 id = A * A2;
 		float3x4 id2 = A2 * A;
-		assert(id.Equals(float3x4::identity, 0.3f));
-		assert(id2.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id2.Equals(float3x4::identity, 0.3f));
 	}
 }
 
@@ -332,15 +332,15 @@ RANDOMIZED_TEST(Float4x4Inverse)
 
 	float4x4 A2 = A;
 	bool success = A2.Inverse();
-	assert(success || mayFail);
+	mgl_assert(success || mayFail);
 	MARK_UNUSED(success);
 	MARK_UNUSED(mayFail);
 	if (success)
 	{
 		float4x4 id = A * A2;
 		float4x4 id2 = A2 * A;
-		assert(id.Equals(float3x4::identity, 0.3f));
-		assert(id2.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id.Equals(float3x4::identity, 0.3f));
+		mgl_assert(id2.Equals(float3x4::identity, 0.3f));
 	}
 }
 
@@ -351,15 +351,15 @@ RANDOMIZED_TEST(Float3x3InverseFast)
 
 	float3x3 A2 = A;
 	bool success = A2.InverseFast();
-	assert(success || mayFail);
+	mgl_assert(success || mayFail);
 	MARK_UNUSED(success);
 	MARK_UNUSED(mayFail);
 	if (success)
 	{
 		float3x3 id = A * A2;
 		float3x3 id2 = A2 * A;
-		assert(id.Equals(float3x3::identity, 0.3f));
-		assert(id2.Equals(float3x3::identity, 0.3f));
+		mgl_assert(id.Equals(float3x3::identity, 0.3f));
+		mgl_assert(id2.Equals(float3x3::identity, 0.3f));
 	}
 }
 
@@ -369,25 +369,25 @@ RANDOMIZED_TEST(Float4x4Ctor)
 	float4x4 m2(m);
 	for(int y = 0; y < 3; ++y)
 		for(int x = 0; x < 3; ++x)
-			assert2(EqualAbs(m.At(y,x), m2.At(y,x)), m.At(y,x), m2.At(y,x));
-	assert(EqualAbs(m2[0][3], 0.f));
-	assert(EqualAbs(m2[1][3], 0.f));
-	assert(EqualAbs(m2[2][3], 0.f));
+			mgl_assert2(EqualAbs(m.At(y,x), m2.At(y,x)), m.At(y,x), m2.At(y,x));
+	mgl_assert(EqualAbs(m2[0][3], 0.f));
+	mgl_assert(EqualAbs(m2[1][3], 0.f));
+	mgl_assert(EqualAbs(m2[2][3], 0.f));
 
-	assert(EqualAbs(m2[3][0], 0.f));
-	assert(EqualAbs(m2[3][1], 0.f));
-	assert(EqualAbs(m2[3][2], 0.f));
-	assert(EqualAbs(m2[3][3], 1.f));
+	mgl_assert(EqualAbs(m2[3][0], 0.f));
+	mgl_assert(EqualAbs(m2[3][1], 0.f));
+	mgl_assert(EqualAbs(m2[3][2], 0.f));
+	mgl_assert(EqualAbs(m2[3][3], 1.f));
 
 	float3x4 m3 = float3x4::RandomGeneral(rng, -10.f, 10.f);
 	m2 = float4x4(m3);
 	for(int y = 0; y < 3; ++y)
 		for(int x = 0; x < 4; ++x)
-			assert(EqualAbs(m3.At(y,x), m2.At(y,x)));
-	assert(EqualAbs(m2[3][0], 0.f));
-	assert(EqualAbs(m2[3][1], 0.f));
-	assert(EqualAbs(m2[3][2], 0.f));
-	assert(EqualAbs(m2[3][3], 1.f));
+			mgl_assert(EqualAbs(m3.At(y,x), m2.At(y,x)));
+	mgl_assert(EqualAbs(m2[3][0], 0.f));
+	mgl_assert(EqualAbs(m2[3][1], 0.f));
+	mgl_assert(EqualAbs(m2[3][2], 0.f));
+	mgl_assert(EqualAbs(m2[3][3], 1.f));
 }
 
 TEST(Float4x4SetRow)
@@ -401,8 +401,8 @@ TEST(Float4x4SetRow)
 	float4x4 m3(1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16);
 	float4x4 m2;
 	m2.Set(1,2,3,4, 5,6,7,8, 9,10,11,12, 13,14,15,16);
-	assert(m.Equals(m2));
-	assert(m.Equals(m3));
+	mgl_assert(m.Equals(m2));
+	mgl_assert(m.Equals(m3));
 }
 
 RANDOMIZED_TEST(Float4x4Set3x4Part)
@@ -411,17 +411,17 @@ RANDOMIZED_TEST(Float4x4Set3x4Part)
 	float4x4 m2 = m;
 	float4x4 m4;
 	m4 = m2;
-	assert(m4.Equals(m2));
+	mgl_assert(m4.Equals(m2));
 	float3x4 m3 = float3x4::RandomGeneral(rng, -10.f, 10.f);
 	m2.Set3x4Part(m3);
 	for(int y = 0; y < 3; ++y)
 		for(int x = 0; x < 4; ++x)
-			assert(EqualAbs(m2[y][x], m3.At(y,x)));
+			mgl_assert(EqualAbs(m2[y][x], m3.At(y,x)));
 
-	assert(EqualAbs(m2[3][0], m[3][0]));
-	assert(EqualAbs(m2[3][1], m[3][1]));
-	assert(EqualAbs(m2[3][2], m[3][2]));
-	assert(EqualAbs(m2[3][3], m[3][3]));
+	mgl_assert(EqualAbs(m2[3][0], m[3][0]));
+	mgl_assert(EqualAbs(m2[3][1], m[3][1]));
+	mgl_assert(EqualAbs(m2[3][2], m[3][2]));
+	mgl_assert(EqualAbs(m2[3][3], m[3][3]));
 }
 
 TEST(Float4x4SwapRows)
@@ -430,7 +430,7 @@ TEST(Float4x4SwapRows)
 	float4x4 m2(13,14,15,16, 9,10,11,12, 5,6,7,8, 1,2,3,4);
 	m.SwapRows(0,3);
 	m.SwapRows(1,2);
-	assert(m.Equals(m2));
+	mgl_assert(m.Equals(m2));
 }
 
 RANDOMIZED_TEST(Float4x4AssignFloat3x4)
@@ -442,12 +442,12 @@ RANDOMIZED_TEST(Float4x4AssignFloat3x4)
 
 	for(int y = 0; y < 3; ++y)
 		for(int x = 0; x < 4; ++x)
-			assert(EqualAbs(m[y][x], m2.At(y,x)));
+			mgl_assert(EqualAbs(m[y][x], m2.At(y,x)));
 
-	assert(EqualAbs(m[3][0], 0.f));
-	assert(EqualAbs(m[3][1], 0.f));
-	assert(EqualAbs(m[3][2], 0.f));
-	assert(EqualAbs(m[3][3], 1.f));
+	mgl_assert(EqualAbs(m[3][0], 0.f));
+	mgl_assert(EqualAbs(m[3][1], 0.f));
+	mgl_assert(EqualAbs(m[3][2], 0.f));
+	mgl_assert(EqualAbs(m[3][3], 1.f));
 
 }
 
@@ -455,7 +455,7 @@ TEST(Float4x4CtorCols)
 {
 	float4x4 m(float4(1,2,3,4), float4(5,6,7,8), float4(9,10,11,12), float4(13,14,15,16));
 	float4x4 m2(1,5,9,13, 2,6,10,14, 3,7,11,15, 4,8,12,16);
-	assert(m.Equals(m2));
+	mgl_assert(m.Equals(m2));
 }
 
 RANDOMIZED_TEST(Float4x4CtorFromQuat)
@@ -466,7 +466,7 @@ RANDOMIZED_TEST(Float4x4CtorFromQuat)
 	float3 v = float3(-1, 5, 20.f);
 	float3 v1 = q * v;
 	float3 v2 = m.TransformPos(v);
-	assert(v1.Equals(v2));
+	mgl_assert(v1.Equals(v2));
 }
 
 RANDOMIZED_TEST(Float4x4CtorFromQuatTrans)
@@ -478,7 +478,7 @@ RANDOMIZED_TEST(Float4x4CtorFromQuatTrans)
 	float3 v = float3(-1, 5, 20.f);
 	float3 v1 = q * v + t;
 	float3 v2 = m.TransformPos(v);
-	assert(v1.Equals(v2));
+	mgl_assert(v1.Equals(v2));
 }
 
 RANDOMIZED_TEST(Float4x4Translate)
@@ -491,15 +491,15 @@ RANDOMIZED_TEST(Float4x4Translate)
 	float3 v = t + t2;
 	float3 v1 = m.TransformPos(t2);
 	float3 v2 = m2.TransformPos(t2);
-	assert(v1.Equals(v2));
-	assert(v.Equals(v1));
+	mgl_assert(v1.Equals(v2));
+	mgl_assert(v.Equals(v1));
 }
 
 TEST(Float4x4Scale)
 {
 	float4x4 m = float4x4::Scale(2,4,6);
 	float4x4 m2(2,0,0,0, 0,4,0,0, 0,0,6,0, 0,0,0,1);
-	assert(m.Equals(m2));
+	mgl_assert(m.Equals(m2));
 }
 
 BENCHMARK(Float3x4Inverse, "float3x4::Inverse")
@@ -551,7 +551,7 @@ RANDOMIZED_TEST(mat_inverse_orthonormal_correctness)
 	float4x4 m3 = m;
 	m2.InverseOrthonormal();
 	mat3x4_inverse_orthonormal(m3.row, m3.row);
-	assert(m2.Equals(m3));
+	mgl_assert(m2.Equals(m3));
 }
 
 BENCHMARK(mat3x4_inverse_orthonormal, "test against float3x4_InverseOrthonormal")
@@ -683,10 +683,10 @@ BENCHMARK_END;
 UNIQUE_TEST(float4x4_Determinant_Correctness)
 {
 	float4x4 m(1,0,0,0, 2,2,0,0, 3,3,3,0, 4,4,4,4);
-	asserteq(m.Determinant3(), 6.f);
-	asserteq(m.Determinant4(), 24.f);
-	asserteq(m.Float3x3Part().Determinant(), 6.f);
-	asserteq(m.Float3x4Part().Determinant(), 6.f);
+	mgl_asserteq(m.Determinant3(), 6.f);
+	mgl_asserteq(m.Determinant4(), 24.f);
+	mgl_asserteq(m.Float3x3Part().Determinant(), 6.f);
+	mgl_asserteq(m.Float3x4Part().Determinant(), 6.f);
 }
 
 RANDOMIZED_TEST(Float3x3MulFloat4x4)
@@ -697,7 +697,7 @@ RANDOMIZED_TEST(Float3x3MulFloat4x4)
 
 	float4x4 test = m * m2;
 	float4x4 correct = m_ * m2;
-	assert(test.Equals(correct));
+	mgl_assert(test.Equals(correct));
 }
 
 RANDOMIZED_TEST(Float4x4MulFloat3x3)
@@ -708,7 +708,7 @@ RANDOMIZED_TEST(Float4x4MulFloat3x3)
 
 	float4x4 test = m2 * m;
 	float4x4 correct = m2 * m_;
-	assert(test.Equals(correct));
+	mgl_assert(test.Equals(correct));
 }
 
 RANDOMIZED_TEST(Float3x4MulFloat4x4)
@@ -719,7 +719,7 @@ RANDOMIZED_TEST(Float3x4MulFloat4x4)
 
 	float4x4 test = m * m2;
 	float4x4 correct = m_ * m2;
-	assert(test.Equals(correct));
+	mgl_assert(test.Equals(correct));
 }
 
 RANDOMIZED_TEST(Float4x4MulFloat3x4)
@@ -730,17 +730,17 @@ RANDOMIZED_TEST(Float4x4MulFloat3x4)
 
 	float4x4 test = m2 * m;
 	float4x4 correct = m2 * m_;
-	assert(test.Equals(correct));
+	mgl_assert(test.Equals(correct));
 }
 
 #define EULER_TEST(from, to, cmp) \
 	float3 v = float3::RandomBox(rng, -20.f, 20.f); \
 	float3x3 m = float3x3::from(v.x, v.y, v.z); \
 	float3x3 m2 = cmp; \
-	assert2(m.Equals(m2), m, m2); \
+	mgl_assert2(m.Equals(m2), m, m2); \
 	float3 w = m.to(); \
 	float3x3 m3 = float3x3::from(w.x, w.y, w.z); \
-	assert2(m.Equals(m3), m, m3);
+	mgl_assert2(m.Equals(m3), m, m3);
 
 RANDOMIZED_TEST(Float3x3EulerXYX)
 {
@@ -749,11 +749,11 @@ RANDOMIZED_TEST(Float3x3EulerXYX)
 	float3 v = float3::RandomBox(rng, -20.f, 20.f);
 	float3x3 m = float3x3::FromEulerXYX(v.x, v.y, v.z);
 	float3x3 m2 = float3x3::RotateX(v.x) * float3x3::RotateY(v.y) * float3x3::RotateX(v.z);
-	assert2(m.Equals(m2), m, m2);
+	mgl_assert2(m.Equals(m2), m, m2);
 
 	float3 w = m.ToEulerXYX();
 	float3x3 m3 = float3x3::FromEulerXYX(w.x, w.y, w.z);
-	assert2(m.Equals(m3), m, m3);
+	mgl_assert2(m.Equals(m3), m, m3);
 	 */
 }
 
@@ -855,7 +855,7 @@ RANDOMIZED_TEST(mat4x4_mul_mat4x4)
 
 	mat4x4_mul_mat4x4(m3.row, m.row, m2.row);
 	float4x4 correct = m*m2;
-	assert(m3.Equals(correct));
+	mgl_assert(m3.Equals(correct));
 }
 
 #ifdef ANDROID
@@ -867,7 +867,7 @@ RANDOMIZED_TEST(mat4x4_mul_mat4x4_asm)
 
 	mat4x4_mul_mat4x4_asm(m3.row, m.row, m2.row);
 	float4x4 correct = m*m2;
-	assert(m3.Equals(correct));
+	mgl_assert(m3.Equals(correct));
 }
 #endif
 
@@ -893,8 +893,8 @@ RANDOMIZED_TEST(mat4x4_transpose)
 	float4x4 m2;
 	mat4x4_transpose(m2.row, m.row);
 	mat4x4_transpose(m.row, m.row);
-	assert(m.Equals(correct));
-	assert(m2.Equals(correct));
+	mgl_assert(m.Equals(correct));
+	mgl_assert(m2.Equals(correct));
 }
 #endif
 
@@ -931,7 +931,7 @@ RANDOMIZED_TEST(mat4x4_mul_vec4)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 correct = m*v;
 	float4 v2 = mat4x4_mul_vec4(m.row, v.v);
-	assert(v2.Equals(correct));
+	mgl_assert(v2.Equals(correct));
 }
 #endif
 
@@ -941,7 +941,7 @@ RANDOMIZED_TEST(vec4_mul_mat4x4)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 correct = v*m;
 	float4 v2 = vec4_mul_mat4x4(v.v, m.row);
-	assert(v2.Equals(correct));
+	mgl_assert(v2.Equals(correct));
 }
 #endif
 

--- a/tests/NEONTests.cpp
+++ b/tests/NEONTests.cpp
@@ -44,10 +44,10 @@ UNIQUE_TEST(set_ps_const)
 	simd4f constant = set_ps_const(4.f, 3.f, 2.f, 1.f);
 	float arr[4];
 	memcpy(arr, &constant, sizeof(arr));
-	asserteq(arr[0], 1.f);
-	asserteq(arr[1], 2.f);
-	asserteq(arr[2], 3.f);
-	asserteq(arr[3], 4.f);
+	mgl_asserteq(arr[0], 1.f);
+	mgl_asserteq(arr[1], 2.f);
+	mgl_asserteq(arr[2], 3.f);
+	mgl_asserteq(arr[3], 4.f);
 }
 
 UNIQUE_TEST(set_ps_const_hex)
@@ -55,10 +55,10 @@ UNIQUE_TEST(set_ps_const_hex)
 	simd4f constant = set_ps_hex_const(0x80000000u, 0x3F800000u /*1.0f*/, 0x42C80000u /*100.0f*/, 0);
 	float arr[4];
 	memcpy(arr, &constant, sizeof(arr));
-	asserteq(arr[0], 0.f);
-	asserteq(arr[1], 100.f);
-	asserteq(arr[2], 1.0f);
-	asserteq(arr[3], -0.0f);
+	mgl_asserteq(arr[0], 0.f);
+	mgl_asserteq(arr[1], 100.f);
+	mgl_asserteq(arr[2], 1.0f);
+	mgl_asserteq(arr[3], -0.0f);
 }
 
 #ifdef ANDROID
@@ -89,7 +89,7 @@ UNIQUE_TEST(inline_asm_add)
 	float4 v3;
 	inline_asm_add(v.ptr(), v2.ptr(), v3.ptr());
 	float4 correct = v + v2;
-	assert(v3.Equals(correct));
+	mgl_assert(v3.Equals(correct));
 }
 
 simd4f inline_asm_add_2(simd4f v1, simd4f v2)
@@ -109,7 +109,7 @@ UNIQUE_TEST(inline_asm_add_2)
 	float4 v3;
 	v3 = inline_asm_add_2(v, v2);
 	float4 correct = v + v2;
-	assert(v3.Equals(correct));
+	mgl_assert(v3.Equals(correct));
 }
 
 simd4f inline_asm_add_3(simd4f v1, simd4f v2)
@@ -133,7 +133,7 @@ UNIQUE_TEST(inline_asm_add_3)
 	float4 v3;
 	v3 = inline_asm_add_3(v, v2);
 	float4 correct = v + v2;
-	assert(v3.Equals(correct));
+	mgl_assert(v3.Equals(correct));
 }
 
 BENCHMARK(float4_add_neon_intrinsics_once, "test against float4_op_add")
@@ -246,7 +246,7 @@ UNIQUE_TEST(vec4_length_sq_float_asm)
 {
 	float4 f(1,2,3,4);
 	float len = vec4_length_sq_float_asm(&f.v);
-	asserteq(len, 30.f);
+	mgl_asserteq(len, 30.f);
 }
 
 BENCHMARK(vec4_length_sq_float_asm, "neon")
@@ -261,10 +261,10 @@ UNIQUE_TEST(vec4_length_sq_ps_asm)
 	float4 lensq;
 	vec4_length_sq_ps_asm(&f.v, &lensq.v);
 	LOGI("%s", lensq.ToString().c_str());
-	asserteq(lensq.x, 30.f);
-	asserteq(lensq.y, 30.f);
-	asserteq(lensq.z, 30.f);
-	asserteq(lensq.w, 30.f);
+	mgl_asserteq(lensq.x, 30.f);
+	mgl_asserteq(lensq.y, 30.f);
+	mgl_asserteq(lensq.z, 30.f);
+	mgl_asserteq(lensq.w, 30.f);
 }
 
 BENCHMARK(vec4_length_sq_ps_asm, "neon")

--- a/tests/NegativeTests.cpp
+++ b/tests/NegativeTests.cpp
@@ -24,13 +24,13 @@ AABB RandomAABBInHalfspace(const Plane &plane, float maxSideLength)
 	float distance = plane.Distance(aabbExtremePoint);
 	a.Translate((distance + GUARDBAND) * plane.normal);
 
-	assert(!a.IsDegenerate());
-	assert(a.IsFinite());
-	assert(!a.Intersects(plane));
-//	assert(a.SignedDistance(plane) > 0.f);
+	mgl_assert(!a.IsDegenerate());
+	mgl_assert(a.IsFinite());
+	mgl_assert(!a.Intersects(plane));
+//	mgl_assert(a.SignedDistance(plane) > 0.f);
 	aabbExtremePoint = a.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(aabbExtremePoint) > 0.f);
-	assert(plane.SignedDistance(a) > 0.f);
+	mgl_assert(plane.SignedDistance(aabbExtremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(a) > 0.f);
 	return a;
 }
 
@@ -45,13 +45,13 @@ OBB RandomOBBInHalfspace(const Plane &plane, float maxSideLength)
 	float distance = plane.Distance(obbExtremePoint);
 	o.Translate((distance + GUARDBAND) * plane.normal);
 
-	assert1(!o.IsDegenerate(), o);
-	assert(o.IsFinite());
-	assert(!o.Intersects(plane));
-//	assert(o.SignedDistance(plane) > 0.f);
+	mgl_assert1(!o.IsDegenerate(), o);
+	mgl_assert(o.IsFinite());
+	mgl_assert(!o.Intersects(plane));
+//	mgl_assert(o.SignedDistance(plane) > 0.f);
 	obbExtremePoint = o.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(obbExtremePoint) > 0.f);
-	assert(plane.SignedDistance(o) > 0.f);
+	mgl_assert(plane.SignedDistance(obbExtremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(o) > 0.f);
 
 	return o;
 }
@@ -65,13 +65,13 @@ Sphere RandomSphereInHalfspace(const Plane &plane, float maxRadius)
 	float distance = plane.Distance(extremePoint);
 	s.Translate((distance + GUARDBAND) * plane.normal);
 
-	assert(s.IsFinite());
-	assert(!s.IsDegenerate());
-	assert(!s.Intersects(plane));
-//	assert(s.SignedDistance(plane) > 0.f);
+	mgl_assert(s.IsFinite());
+	mgl_assert(!s.IsDegenerate());
+	mgl_assert(!s.Intersects(plane));
+//	mgl_assert(s.SignedDistance(plane) > 0.f);
 	extremePoint = s.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(extremePoint) > 0.f);
-	assert(plane.SignedDistance(s) > 0.f);
+	mgl_assert(plane.SignedDistance(extremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(s) > 0.f);
 	return s;
 }
 
@@ -98,19 +98,19 @@ Frustum RandomFrustumInHalfspace(const Plane &plane)
 
 	f.SetKind((rng.Int(0, 1) == 1) ? FrustumSpaceD3D : FrustumSpaceGL, (rng.Int(0, 1) == 1) ? FrustumRightHanded : FrustumLeftHanded);
 
-//	assert(!f.IsDegenerate());
+//	mgl_assert(!f.IsDegenerate());
 
 	vec extremePoint = f.ExtremePoint(-plane.normal);
 	float distance = plane.Distance(extremePoint);
 	f.Translate((distance + GUARDBAND) * plane.normal);
 
-	assert(f.IsFinite());
-//	assert(!f.IsDegenerate());
-	assert(!f.Intersects(plane));
-//	assert(s.SignedDistance(plane) > 0.f);
+	mgl_assert(f.IsFinite());
+//	mgl_assert(!f.IsDegenerate());
+	mgl_assert(!f.Intersects(plane));
+//	mgl_assert(s.SignedDistance(plane) > 0.f);
 	extremePoint = f.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(extremePoint) > 0.f);
-	assert(plane.SignedDistance(f) > 0.f);
+	mgl_assert(plane.SignedDistance(extremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(f) > 0.f);
 
 	return f;
 }
@@ -121,13 +121,13 @@ Line RandomLineInHalfspace(const Plane &plane)
 	if (plane.SignedDistance(linePos) < 0.f)
 		linePos = plane.Mirror(linePos);
 	linePos += plane.normal * 1e-2f;
-	assert(plane.SignedDistance(linePos) >= 1e-3f);
+	mgl_assert(plane.SignedDistance(linePos) >= 1e-3f);
 
 	vec dir = plane.normal.RandomPerpendicular(rng);
 	Line l(linePos, dir);
-	assert(l.IsFinite());
-	assert2(!plane.Intersects(l), plane.SerializeToCodeString(), l.SerializeToCodeString());
-	assert1(plane.SignedDistance(l) > 0.f, plane.SignedDistance(l));
+	mgl_assert(l.IsFinite());
+	mgl_assert2(!plane.Intersects(l), plane.SerializeToCodeString(), l.SerializeToCodeString());
+	mgl_assert1(plane.SignedDistance(l) > 0.f, plane.SignedDistance(l));
 	return l;
 }
 
@@ -140,16 +140,16 @@ Ray RandomRayInHalfspace(const Plane &plane)
 	if (plane.SignedDistance(rayPos) < 0.f)
 		rayPos = plane.Mirror(rayPos);
 	rayPos += plane.normal * 1e-2f;
-	assert(plane.SignedDistance(rayPos) >= 1e-3f);
+	mgl_assert(plane.SignedDistance(rayPos) >= 1e-3f);
 
 	vec dir = vec::RandomDir(rng);
 	if (dir.Dot(plane.normal) < 0.f)
 		dir = -dir;
 	Ray r(rayPos, dir);
-	assert(r.IsFinite());
-	assert(plane.SignedDistance(r.GetPoint(SCALE*10.f)) > 0.f);
-	assert(!plane.Intersects(r));
-	assert(plane.SignedDistance(r) > 0.f);
+	mgl_assert(r.IsFinite());
+	mgl_assert(plane.SignedDistance(r.GetPoint(SCALE*10.f)) > 0.f);
+	mgl_assert(!plane.Intersects(r));
+	mgl_assert(plane.SignedDistance(r) > 0.f);
 	return r;
 }
 
@@ -157,8 +157,8 @@ LineSegment RandomLineSegmentInHalfspace(const Plane &plane)
 {
 	float f = rng.Float(0.f, SCALE);
 	LineSegment ls = RandomRayInHalfspace(plane).ToLineSegment(0.f, f);
-	assert(ls.IsFinite());
-	assert(plane.SignedDistance(ls) > 0.f);
+	mgl_assert(ls.IsFinite());
+	mgl_assert(plane.SignedDistance(ls) > 0.f);
 
 	return ls;
 }
@@ -171,19 +171,19 @@ Capsule RandomCapsuleInHalfspace(const Plane &plane)
 	float b = rng.Float(0, SCALE);
 	float r = rng.Float(0.001f, SCALE);
 	Capsule c(pt + a*dir, pt - b*dir, r);
-	assert(c.IsFinite());
+	mgl_assert(c.IsFinite());
 
 	vec extremePoint = c.ExtremePoint(-plane.normal);
 	float distance = plane.Distance(extremePoint);
 	c.Translate((distance + GUARDBAND) * plane.normal);
 
-	assert(c.IsFinite());
-//	assert(!c.IsDegenerate());
-	assert(!c.Intersects(plane));
-//	assert(c.SignedDistance(plane) > 0.f);
+	mgl_assert(c.IsFinite());
+//	mgl_assert(!c.IsDegenerate());
+	mgl_assert(!c.Intersects(plane));
+//	mgl_assert(c.SignedDistance(plane) > 0.f);
 	extremePoint = c.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(extremePoint) > 0.f);
-	assert(plane.SignedDistance(c) > 0.f);
+	mgl_assert(plane.SignedDistance(extremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(c) > 0.f);
 
 	return c;
 }
@@ -193,7 +193,7 @@ Plane RandomPlaneInHalfspace(Plane &plane)
 	Plane p2;
 	p2.normal = plane.normal;
 	p2.d = rng.Float(plane.d + 1e-2f, plane.d + 1e-2f + SCALE);
-	assert(!p2.IsDegenerate());
+	mgl_assert(!p2.IsDegenerate());
 	return p2;
 }
 
@@ -204,20 +204,20 @@ Triangle RandomTriangleInHalfspace(const Plane &plane)
 	vec c = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle t(a,b,c);
 
-	assert1(t.IsFinite(), t);
-	assert1(!t.IsDegenerate(), t);
+	mgl_assert1(t.IsFinite(), t);
+	mgl_assert1(!t.IsDegenerate(), t);
 
 	vec extremePoint = t.ExtremePoint(-plane.normal);
 	float distance = plane.Distance(extremePoint);
 	t.Translate((distance + GUARDBAND) * plane.normal);
 
-	assert1(t.IsFinite(), t);
-	assert1(!t.IsDegenerate(), t);
-	assert2(!t.Intersects(plane), t, plane);
-//	assert(t.SignedDistance(plane) > 0.f);
+	mgl_assert1(t.IsFinite(), t);
+	mgl_assert1(!t.IsDegenerate(), t);
+	mgl_assert2(!t.Intersects(plane), t, plane);
+//	mgl_assert(t.SignedDistance(plane) > 0.f);
 	extremePoint = t.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(extremePoint) > 0.f);
-	assert(plane.SignedDistance(t) > 0.f);
+	mgl_assert(plane.SignedDistance(extremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(t) > 0.f);
 
 	return t;
 }
@@ -239,21 +239,21 @@ Polyhedron RandomPolyhedronInHalfspace(const Plane &plane)
 	default: p = Polyhedron::Dodecahedron(pt, SCALE); break;
 	}
 
-//	assert(p.IsFinite());
-//	assert(!p.IsDegenerate());
+//	mgl_assert(p.IsFinite());
+//	mgl_assert(!p.IsDegenerate());
 
 	vec extremePoint = p.ExtremePoint(-plane.normal);
 	float distance = plane.Distance(extremePoint);
 	p.Translate((distance + GUARDBAND) * plane.normal);
 
-//	assert(p.IsFinite());
-//	assert(!p.IsDegenerate());
-	assert(!p.Intersects(plane));
-//	assert(p.SignedDistance(plane) > 0.f);
+//	mgl_assert(p.IsFinite());
+//	mgl_assert(!p.IsDegenerate());
+	mgl_assert(!p.Intersects(plane));
+//	mgl_assert(p.SignedDistance(plane) > 0.f);
 	extremePoint = p.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(extremePoint) > 0.f);
-	assert(plane.SignedDistance(p) > 0.f);
-	
+	mgl_assert(plane.SignedDistance(extremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(p) > 0.f);
+
 	return p;
 }
 
@@ -262,14 +262,14 @@ Polygon RandomPolygonInHalfspace(const Plane &plane)
 	Polyhedron p = RandomPolyhedronInHalfspace(plane);
 	Polygon poly = p.FacePolygon(rng.Int(0, p.NumFaces()-1));
 
-	assert1(!poly.IsDegenerate(), poly);
-	assert1(!poly.IsNull(), poly);
-	assert1(poly.IsPlanar(), poly);
-	assert1(poly.IsFinite(), poly);
-	assert2(!poly.Intersects(plane), poly, plane);
+	mgl_assert1(!poly.IsDegenerate(), poly);
+	mgl_assert1(!poly.IsNull(), poly);
+	mgl_assert1(poly.IsPlanar(), poly);
+	mgl_assert1(poly.IsFinite(), poly);
+	mgl_assert2(!poly.Intersects(plane), poly, plane);
 	vec extremePoint = poly.ExtremePoint(-plane.normal);
-	assert(plane.SignedDistance(extremePoint) > 0.f);
-	assert(plane.SignedDistance(poly) > 0.f);
+	mgl_assert(plane.SignedDistance(extremePoint) > 0.f);
+	mgl_assert(plane.SignedDistance(poly) > 0.f);
 
 	return poly;
 }
@@ -281,18 +281,18 @@ RANDOMIZED_TEST(AABBAABBNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	AABB b = RandomAABBInHalfspace(p, 10.f);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBOBBNoIntersect)
@@ -301,23 +301,23 @@ RANDOMIZED_TEST(AABBOBBNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	OBB b = RandomOBBInHalfspace(p, 10.f);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(!SATIntersect(a, b));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(AABBLineNoIntersectCase)
 {
 	Plane p(DIR_VEC(-0.72379446f,0.652315021f,-0.224959269f),27.2405319f);
 	Line l(POINT_VEC(-16.0996895f,22.3687477f,-5.59284782f),DIR_VEC(-0.616314948f,-0.757768512f,-0.214342773f));
-	assert(!p.Intersects(l));
+	mgl_assert(!p.Intersects(l));
 }
 
 RANDOMIZED_TEST(AABBLineNoIntersect)
@@ -331,14 +331,14 @@ RANDOMIZED_TEST(AABBLineNoIntersect)
 		LOGI("AABB: %s", a.ToString().c_str());
 		LOGI("Line: %s", b.ToString().c_str());
 	}
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBRayNoIntersect)
@@ -347,14 +347,14 @@ RANDOMIZED_TEST(AABBRayNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBLineSegmentNoIntersect)
@@ -363,16 +363,16 @@ RANDOMIZED_TEST(AABBLineSegmentNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBPlaneNoIntersect)
@@ -381,14 +381,14 @@ RANDOMIZED_TEST(AABBPlaneNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBSphereNoIntersect)
@@ -397,16 +397,16 @@ RANDOMIZED_TEST(AABBSphereNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Sphere b = RandomSphereInHalfspace(p, SCALE);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBCapsuleNoIntersect)
@@ -415,16 +415,16 @@ RANDOMIZED_TEST(AABBCapsuleNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBTriangleNoIntersect)
@@ -433,18 +433,18 @@ RANDOMIZED_TEST(AABBTriangleNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBFrustumNoIntersect)
@@ -453,18 +453,18 @@ RANDOMIZED_TEST(AABBFrustumNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBPolyhedronNoIntersect)
@@ -473,14 +473,14 @@ RANDOMIZED_TEST(AABBPolyhedronNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Polyhedron b = RandomPolyhedronInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(AABBPolygonNoIntersectCase)
@@ -492,7 +492,7 @@ UNIQUE_TEST(AABBPolygonNoIntersectCase)
 	b.p.push_back(POINT_VEC(24.5866089f,-58.1762543f,114.95137f));
 	b.p.push_back(POINT_VEC(36.3900108f,-89.0779572f,134.049667f));
 	b.p.push_back(POINT_VEC(24.5866089f,-119.97966f,114.95137f));
-	assert(!a.Intersects(b));
+	mgl_assert(!a.Intersects(b));
 }
 
 RANDOMIZED_TEST(AABBPolygonNoIntersect)
@@ -501,14 +501,14 @@ RANDOMIZED_TEST(AABBPolygonNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Polygon b = RandomPolygonInHalfspace(p);
-	assert2(!a.Intersects(b), a.SerializeToCodeString(), b.SerializeToString());
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a.SerializeToCodeString(), b.SerializeToString());
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -520,18 +520,18 @@ RANDOMIZED_TEST(OBBOBBNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	OBB b = RandomOBBInHalfspace(p, 10.f);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 extern int xxxxx;
@@ -581,14 +581,14 @@ RANDOMIZED_TEST(OBBLineNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBRayNoIntersect)
@@ -597,14 +597,14 @@ RANDOMIZED_TEST(OBBRayNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBLineSegmentNoIntersect)
@@ -613,16 +613,16 @@ RANDOMIZED_TEST(OBBLineSegmentNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBPlaneNoIntersect)
@@ -631,14 +631,14 @@ RANDOMIZED_TEST(OBBPlaneNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBSphereNoIntersect)
@@ -647,16 +647,16 @@ RANDOMIZED_TEST(OBBSphereNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Sphere b = RandomSphereInHalfspace(p, SCALE);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-////	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+////	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBCapsuleNoIntersect)
@@ -665,16 +665,16 @@ RANDOMIZED_TEST(OBBCapsuleNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBTriangleNoIntersect)
@@ -683,18 +683,18 @@ RANDOMIZED_TEST(OBBTriangleNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBFrustumNoIntersect)
@@ -703,18 +703,18 @@ RANDOMIZED_TEST(OBBFrustumNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBPolyhedronNoIntersect)
@@ -723,14 +723,14 @@ RANDOMIZED_TEST(OBBPolyhedronNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Polyhedron b = RandomPolyhedronInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBPolygonNoIntersect)
@@ -739,14 +739,14 @@ RANDOMIZED_TEST(OBBPolygonNoIntersect)
 	OBB a = RandomOBBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Polygon b = RandomPolygonInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-///	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+///	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -759,16 +759,16 @@ RANDOMIZED_TEST(SphereSphereNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Sphere b = RandomSphereInHalfspace(p, 10.f);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereLineNoIntersect)
@@ -777,14 +777,14 @@ RANDOMIZED_TEST(SphereLineNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereRayNoIntersect)
@@ -793,14 +793,14 @@ RANDOMIZED_TEST(SphereRayNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereLineSegmentNoIntersect)
@@ -809,16 +809,16 @@ RANDOMIZED_TEST(SphereLineSegmentNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SpherePlaneNoIntersect)
@@ -827,14 +827,14 @@ RANDOMIZED_TEST(SpherePlaneNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereCapsuleNoIntersect)
@@ -843,16 +843,16 @@ RANDOMIZED_TEST(SphereCapsuleNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereTriangleNoIntersect)
@@ -861,16 +861,16 @@ RANDOMIZED_TEST(SphereTriangleNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereFrustumNoIntersect)
@@ -879,16 +879,16 @@ RANDOMIZED_TEST(SphereFrustumNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SpherePolyhedronNoIntersect)
@@ -897,14 +897,14 @@ RANDOMIZED_TEST(SpherePolyhedronNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Polyhedron b = RandomPolyhedronInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SpherePolygonNoIntersect)
@@ -913,14 +913,14 @@ RANDOMIZED_TEST(SpherePolygonNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Polygon b = RandomPolygonInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -932,14 +932,14 @@ RANDOMIZED_TEST(FrustumLineNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumRayNoIntersect)
@@ -948,14 +948,14 @@ RANDOMIZED_TEST(FrustumRayNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumLineSegmentNoIntersect)
@@ -964,16 +964,16 @@ RANDOMIZED_TEST(FrustumLineSegmentNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumPlaneNoIntersect)
@@ -982,14 +982,14 @@ RANDOMIZED_TEST(FrustumPlaneNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumCapsuleNoIntersect)
@@ -998,16 +998,16 @@ RANDOMIZED_TEST(FrustumCapsuleNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumTriangleNoIntersect)
@@ -1016,18 +1016,18 @@ RANDOMIZED_TEST(FrustumTriangleNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumFrustumNoIntersect)
@@ -1036,18 +1036,18 @@ RANDOMIZED_TEST(FrustumFrustumNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 extern int xxxxx;
@@ -1118,14 +1118,14 @@ RANDOMIZED_TEST(FrustumPolyhedronNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Polyhedron b = RandomPolyhedronInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumPolygonNoIntersect)
@@ -1134,14 +1134,14 @@ RANDOMIZED_TEST(FrustumPolygonNoIntersect)
 	Frustum a = RandomFrustumInHalfspace(p);
 	p.ReverseNormal();
 	Polygon b = RandomPolygonInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1149,14 +1149,14 @@ UNIQUE_TEST(PlaneLineNoIntersectCase)
 {
 	Plane p(DIR_VEC(-0.746312618f,0.586626351f,-0.31446299f),-35.7190437f);
 	Line l(POINT_VEC(45.1519928f,46.7459641f,92.9752197f),DIR_VEC(0.631202042f,0.773685277f,-0.0547275133f));
-	assert(!p.Intersects(l));
+	mgl_assert(!p.Intersects(l));
 }
 
 UNIQUE_TEST(PlaneLineNoIntersectCase2)
 {
 	Plane p(DIR_VEC(0.344275832f,-0.882686555f,0.31990397f),-56.7400818f);
 	Line l(POINT_VEC(36.2179184f,88.9618607f,29.178812f),DIR_VEC(0.775070965f,0.459497392f,0.433736295f));
-	assert(!p.Intersects(l));
+	mgl_assert(!p.Intersects(l));
 }
 
 RANDOMIZED_TEST(CapsuleLineNoIntersect)
@@ -1165,14 +1165,14 @@ RANDOMIZED_TEST(CapsuleLineNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleRayNoIntersect)
@@ -1181,14 +1181,14 @@ RANDOMIZED_TEST(CapsuleRayNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleLineSegmentNoIntersect)
@@ -1197,16 +1197,16 @@ RANDOMIZED_TEST(CapsuleLineSegmentNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsulePlaneNoIntersect)
@@ -1215,14 +1215,14 @@ RANDOMIZED_TEST(CapsulePlaneNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleCapsuleNoIntersect)
@@ -1231,16 +1231,16 @@ RANDOMIZED_TEST(CapsuleCapsuleNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Capsule b = RandomCapsuleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleTriangleNoIntersect)
@@ -1249,16 +1249,16 @@ RANDOMIZED_TEST(CapsuleTriangleNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-///	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+///	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsulePolyhedronNoIntersect)
@@ -1267,14 +1267,14 @@ RANDOMIZED_TEST(CapsulePolyhedronNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Polyhedron b = RandomPolyhedronInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-///	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+///	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsulePolygonNoIntersect)
@@ -1283,14 +1283,14 @@ RANDOMIZED_TEST(CapsulePolygonNoIntersect)
 	Capsule a = RandomCapsuleInHalfspace(p);
 	p.ReverseNormal();
 	Polygon b = RandomPolygonInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1303,14 +1303,14 @@ RANDOMIZED_TEST(PolyhedronLineNoIntersect)
 	Polyhedron a = RandomPolyhedronInHalfspace(p);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronRayNoIntersect)
@@ -1319,14 +1319,14 @@ RANDOMIZED_TEST(PolyhedronRayNoIntersect)
 	Polyhedron a = RandomPolyhedronInHalfspace(p);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronLineSegmentNoIntersect)
@@ -1335,17 +1335,17 @@ RANDOMIZED_TEST(PolyhedronLineSegmentNoIntersect)
 	Polyhedron a = RandomPolyhedronInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-	assert4(a.Distance(a.ClosestPoint(b)) < 1e-3f, a, b, a.ClosestPoint(b), a.Distance(a.ClosestPoint(b)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+	mgl_assert4(a.Distance(a.ClosestPoint(b)) < 1e-3f, a, b, a.ClosestPoint(b), a.Distance(a.ClosestPoint(b)));
 //	TODO: The following is problematic due to numerical
 //	stability issues at the surface of the Polyhedron.
-//	assert(a.Contains(a.ClosestPoint(b)));
-	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronPlaneNoIntersect)
@@ -1354,14 +1354,14 @@ RANDOMIZED_TEST(PolyhedronPlaneNoIntersect)
 	Polyhedron a = RandomPolyhedronInHalfspace(p);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronTriangleNoIntersect)
@@ -1370,14 +1370,14 @@ RANDOMIZED_TEST(PolyhedronTriangleNoIntersect)
 	Polyhedron a = RandomPolyhedronInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronPolyhedronNoIntersect)
@@ -1386,14 +1386,14 @@ RANDOMIZED_TEST(PolyhedronPolyhedronNoIntersect)
 	Polyhedron a = RandomPolyhedronInHalfspace(p);
 	p.ReverseNormal();
 	Polyhedron b = RandomPolyhedronInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 #ifndef _DEBUG
@@ -1418,14 +1418,14 @@ RANDOMIZED_TEST(PolyhedronPolygonNoIntersect)
 	Polyhedron a = RandomPolyhedronInHalfspace(p);
 	p.ReverseNormal();
 	Polygon b = RandomPolygonInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1436,14 +1436,14 @@ RANDOMIZED_TEST(PolygonLineNoIntersect)
 	Polygon a = RandomPolygonInHalfspace(p);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonRayNoIntersect)
@@ -1452,14 +1452,14 @@ RANDOMIZED_TEST(PolygonRayNoIntersect)
 	Polygon a = RandomPolygonInHalfspace(p);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonLineSegmentNoIntersect)
@@ -1468,17 +1468,17 @@ RANDOMIZED_TEST(PolygonLineSegmentNoIntersect)
 	Polygon a = RandomPolygonInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-	assert4(a.Distance(a.ClosestPoint(b)) < 1e-3f, a, b, a.ClosestPoint(b), a.Distance(a.ClosestPoint(b)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+	mgl_assert4(a.Distance(a.ClosestPoint(b)) < 1e-3f, a, b, a.ClosestPoint(b), a.Distance(a.ClosestPoint(b)));
 //	TODO: The following is problematic due to numerical
 //	stability issues at the surface of the Polygon.
-//	assert(a.Contains(a.ClosestPoint(b)));
-	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonPlaneNoIntersect)
@@ -1487,14 +1487,14 @@ RANDOMIZED_TEST(PolygonPlaneNoIntersect)
 	Polygon a = RandomPolygonInHalfspace(p);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonTriangleNoIntersect)
@@ -1503,14 +1503,14 @@ RANDOMIZED_TEST(PolygonTriangleNoIntersect)
 	Polygon a = RandomPolygonInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonPolygonNoIntersect)
@@ -1519,14 +1519,14 @@ RANDOMIZED_TEST(PolygonPolygonNoIntersect)
 	Polygon a = RandomPolygonInHalfspace(p);
 	p.ReverseNormal();
 	Polygon b = RandomPolygonInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-///	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+///	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1537,14 +1537,14 @@ RANDOMIZED_TEST(TriangleLineNoIntersect)
 	Triangle a = RandomTriangleInHalfspace(p);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-//	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+//	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(TriangleRayNoIntersect)
@@ -1553,14 +1553,14 @@ RANDOMIZED_TEST(TriangleRayNoIntersect)
 	Triangle a = RandomTriangleInHalfspace(p);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(TriangleLineSegmentNoIntersect)
@@ -1569,16 +1569,16 @@ RANDOMIZED_TEST(TriangleLineSegmentNoIntersect)
 	Triangle a = RandomTriangleInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-//	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+//	mgl_assert(!b.Intersects(a));
 
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(TrianglePlaneNoIntersect)
@@ -1587,14 +1587,14 @@ RANDOMIZED_TEST(TrianglePlaneNoIntersect)
 	Triangle a = RandomTriangleInHalfspace(p);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(TrickyTriangleTriangleSATNoIntersect)
@@ -1606,11 +1606,11 @@ UNIQUE_TEST(TrickyTriangleTriangleSATNoIntersect)
 	b.a = POINT_VEC(-23.087940f, 13.051629f, -21.682280f);
 	b.b = POINT_VEC(-90.890396f, -61.371635f, -44.296501f);
 	b.c = POINT_VEC(85.991585f, 38.734276f, 29.707987f);
-	assert(!a.Intersects(b));
-	assert(!b.Intersects(a));
+	mgl_assert(!a.Intersects(b));
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
 }
 
@@ -1620,18 +1620,18 @@ RANDOMIZED_TEST(TriangleTriangleNoIntersect)
 	Triangle a = RandomTriangleInHalfspace(p);
 	p.ReverseNormal();
 	Triangle b = RandomTriangleInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 
-	assert(!SATIntersect(a, b));
+	mgl_assert(!SATIntersect(a, b));
 
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(!b.Contains(a.ClosestPoint(b)));
-	assert(!a.Contains(b.ClosestPoint(a)));
-	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1643,14 +1643,14 @@ RANDOMIZED_TEST(PlaneLineNoIntersect)
 	Plane a = RandomPlaneInHalfspace(p);
 	p.ReverseNormal();
 	Line b = RandomLineInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-///	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+///	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(TrickyPlaneRayClosestPoint)
@@ -1658,7 +1658,7 @@ UNIQUE_TEST(TrickyPlaneRayClosestPoint)
 	Plane p(DIR_VEC(0.50561136f,-0.753886223f,0.419538707f),83.6198273f);
 	Ray r(POINT_VEC(-34.2622185f,97.5630875f,14.6553354f),DIR_VEC(-0.433765054f,-0.636341155f,-0.637901187f));
 	vec cp = p.ClosestPoint(r);
-	assert(p.Contains(cp));
+	mgl_assert(p.Contains(cp));
 }
 
 RANDOMIZED_TEST(PlaneRayNoIntersect)
@@ -1667,14 +1667,14 @@ RANDOMIZED_TEST(PlaneRayNoIntersect)
 	Plane a = RandomPlaneInHalfspace(p);
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-	assert3(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString());
-	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+	mgl_assert3(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString());
+	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PlaneLineSegmentNoIntersect)
@@ -1683,14 +1683,14 @@ RANDOMIZED_TEST(PlaneLineSegmentNoIntersect)
 	Plane a = RandomPlaneInHalfspace(p);
 	p.ReverseNormal();
 	LineSegment b = RandomLineSegmentInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-	assert(a.Distance(b) > 0.f);
-	assert(b.Distance(a) > 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+	mgl_assert(a.Distance(b) > 0.f);
+	mgl_assert(b.Distance(a) > 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PlanePlaneNoIntersect)
@@ -1699,14 +1699,14 @@ RANDOMIZED_TEST(PlanePlaneNoIntersect)
 	Plane a = RandomPlaneInHalfspace(p);
 	p.ReverseNormal();
 	Plane b = RandomPlaneInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
-//	assert(a.Distance(b) > 0.f);
-//	assert(b.Distance(a) > 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(!b.Contains(a.ClosestPoint(b)));
-//	assert(!a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
+//	mgl_assert(a.Distance(b) > 0.f);
+//	mgl_assert(b.Distance(a) > 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(!a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(RayTriangleMeshNoIntersect)
@@ -1718,7 +1718,7 @@ RANDOMIZED_TEST(RayTriangleMeshNoIntersect)
 	p.ReverseNormal();
 	Ray b = RandomRayInHalfspace(p);
 	float d = tm.IntersectRay(b);
-	assert(d == FLOAT_INF);
+	mgl_assert(d == FLOAT_INF);
 	MARK_UNUSED(d);
 }
 
@@ -1735,10 +1735,10 @@ RANDOMIZED_TEST(RayKdTreeNoIntersect)
 	Ray b = RandomRayInHalfspace(p);
 	TriangleKdTreeRayQueryNearestHitVisitor result;
 	t.RayQuery(b, result);
-	assert(result.rayT == FLOAT_INF);
-	assert(result.triangleIndex == KdTree<Triangle>::BUCKET_SENTINEL);
-	assert(!result.pos.IsFinite());
-	assert(!result.barycentricUV.IsFinite());
+	mgl_assert(result.rayT == FLOAT_INF);
+	mgl_assert(result.triangleIndex == KdTree<Triangle>::BUCKET_SENTINEL);
+	mgl_assert(!result.pos.IsFinite());
+	mgl_assert(!result.barycentricUV.IsFinite());
 }
 
 // https://github.com/juj/MathGeoLib/issues/55
@@ -1747,13 +1747,13 @@ UNIQUE_TEST(AABB_Capsule_NoIntersect_Case)
 	vec minPoint = POINT_VEC(438.420929f, 805.586670f, 493.709167f);
 	vec maxPoint = POINT_VEC(443.420929f, 810.586670f, 498.709167f);
 	AABB aabb(minPoint, maxPoint);
-	
+
 	vec a = POINT_VEC(479.665222f,  -30.f, 509.737244f);
 	vec b = POINT_VEC(479.665222f, 1530.f, 509.737244f);
-	
+
 	Capsule cylinder(a, b, 37.6882935f);
-	
-	assert(!cylinder.Intersects(aabb));
+
+	mgl_assert(!cylinder.Intersects(aabb));
 }
 
 // https://github.com/juj/MathGeoLib/issues/55
@@ -1763,13 +1763,13 @@ UNIQUE_TEST(AABB_Capsule_NoIntersect_Case_2)
 	vec minPoint = POINT_VEC(438.f,        0.f, 493.f);
 	vec maxPoint = POINT_VEC(443.420929f, 10.f, 499.f);
 	AABB aabb(minPoint, maxPoint);
-	
+
 	vec a = POINT_VEC(479.665222f,  0.f, 509.737244f);
 	vec b = POINT_VEC(479.665222f, 10.f, 509.737244f);
-	
+
 	Capsule cylinder(a, b, 37.6882935f);
-	
-	assert(!cylinder.Intersects(aabb));
+
+	mgl_assert(!cylinder.Intersects(aabb));
 }
 
 // https://github.com/juj/MathGeoLib/issues/56
@@ -1786,5 +1786,5 @@ UNIQUE_TEST(AABB_Capsule_NoIntersect_Case_3)
 
 	// TODO: The Cylinder and AABB should not intersect, but the GJK algorithm
 	// does not produce the right result.
-	assert(!cylinder.Intersects(aabb));
+	mgl_assert(!cylinder.Intersects(aabb));
 }

--- a/tests/OBBTests.cpp
+++ b/tests/OBBTests.cpp
@@ -18,10 +18,10 @@ UNIQUE_TEST(OBB_ClosestPoint_Point)
 {
 	vec pt = POINT_VEC_SCALAR(0.f);
 	OBB o(pt, DIR_VEC(1.f, 1.f, 1.f), vec::unitX, vec::unitY, vec::unitZ);
-	assert(o.ClosestPoint(pt).Equals(pt));
-	assert(o.ClosestPoint(POINT_VEC(5.f, 0.f, 0.f)).Equals(POINT_VEC(1.f, 0.f, 0.f)));
-	assert(o.ClosestPoint(POINT_VEC(5.f, 5.f, 5.f)).Equals(POINT_VEC(1.f, 1.f, 1.f)));
-	assert(o.ClosestPoint(POINT_VEC(-5.f, -5.f, -5.f)).Equals(POINT_VEC(-1.f, -1.f, -1.f)));
+	mgl_assert(o.ClosestPoint(pt).Equals(pt));
+	mgl_assert(o.ClosestPoint(POINT_VEC(5.f, 0.f, 0.f)).Equals(POINT_VEC(1.f, 0.f, 0.f)));
+	mgl_assert(o.ClosestPoint(POINT_VEC(5.f, 5.f, 5.f)).Equals(POINT_VEC(1.f, 1.f, 1.f)));
+	mgl_assert(o.ClosestPoint(POINT_VEC(-5.f, -5.f, -5.f)).Equals(POINT_VEC(-1.f, -1.f, -1.f)));
 }
 
 // Programmatically found test case of two OBBs which by construction should be disjoint.
@@ -42,7 +42,7 @@ UNIQUE_TEST(OBB_NoIntersect_OBB_Case1)
 	b.axis[1] = DIR_VEC(0.44f, -0.23f, -0.87f);
 	b.axis[2] = DIR_VEC(-0.80f, -0.54f, -0.26f);
 
-	assert(!a.Intersects(b));
+	mgl_assert(!a.Intersects(b));
 }
 
 BENCHMARK(OBBIntersectsOBB_Random, "OBB::Intersects(OBB) Random")
@@ -113,16 +113,16 @@ RANDOMIZED_TEST(OBB_OptimalEnclosingOBB)
 	OBB o = OBB::OptimalEnclosingOBB(points, n);
 
 #ifdef MATH_VEC_IS_FLOAT4
-	assert(EqualAbs(o.pos.w, 1.f));
-	assert(EqualAbs(o.axis[0].w, 0.f));
-	assert(EqualAbs(o.axis[1].w, 0.f));
-	assert(EqualAbs(o.axis[2].w, 0.f));
-	assert(EqualAbs(o.r.w, 0.f));
+	mgl_assert(EqualAbs(o.pos.w, 1.f));
+	mgl_assert(EqualAbs(o.axis[0].w, 0.f));
+	mgl_assert(EqualAbs(o.axis[1].w, 0.f));
+	mgl_assert(EqualAbs(o.axis[2].w, 0.f));
+	mgl_assert(EqualAbs(o.r.w, 0.f));
 #endif
 	// Test that it does actually enclose the given points.
 	for(int i = 0; i < n; ++i)
-		assert1(o.Distance(points[i]) < 1e-3f, o.Distance(points[i]));
-		//assert2(o.Contains(points[i]), points[i], o.Distance(points[i]));
+		mgl_assert1(o.Distance(points[i]) < 1e-3f, o.Distance(points[i]));
+		//mgl_assert2(o.Contains(points[i]), points[i], o.Distance(points[i]));
 }
 
 // Tests that OBB::OptimalEnclosingOBB() works even if all points in the input set lie in a plane (degenerating into a 2D convex hull computation)
@@ -149,40 +149,40 @@ RANDOMIZED_TEST(OBB_OptimalEnclosingOBB_Degenerate2D)
 
 	// Compute the minimal OBB that encloses those points.
 	OBB optimalObb = OBB::OptimalEnclosingOBB(points, n);
-	assert(!optimalObb.IsDegenerate());
-	assert(optimalObb.LocalToWorld().IsOrthonormal());
+	mgl_assert(!optimalObb.IsDegenerate());
+	mgl_assert(optimalObb.LocalToWorld().IsOrthonormal());
 
 #ifdef MATH_VEC_IS_FLOAT4
-	assert(EqualAbs(optimalObb.pos.w, 1.f));
-	assert(EqualAbs(optimalObb.axis[0].w, 0.f));
-	assert(EqualAbs(optimalObb.axis[1].w, 0.f));
-	assert(EqualAbs(optimalObb.axis[2].w, 0.f));
-	assert(EqualAbs(optimalObb.r.w, 0.f));
+	mgl_assert(EqualAbs(optimalObb.pos.w, 1.f));
+	mgl_assert(EqualAbs(optimalObb.axis[0].w, 0.f));
+	mgl_assert(EqualAbs(optimalObb.axis[1].w, 0.f));
+	mgl_assert(EqualAbs(optimalObb.axis[2].w, 0.f));
+	mgl_assert(EqualAbs(optimalObb.r.w, 0.f));
 #endif
 
 	// Brute force compute a bounding box
 	OBB bruteObb = OBB::BruteEnclosingOBB(points, n);
-	assert(!bruteObb.IsDegenerate());
-	assert(bruteObb.LocalToWorld().IsOrthonormal());
+	mgl_assert(!bruteObb.IsDegenerate());
+	mgl_assert(bruteObb.LocalToWorld().IsOrthonormal());
 
 	// Test that both boxes actually enclose the given points.
 	for(int i = 0; i < n; ++i)
 	{
-		assert1(optimalObb.Distance(points[i]) < 1e-3f, optimalObb.Distance(points[i]));
-		assert1(bruteObb.Distance(points[i]) < 1e-3f, bruteObb.Distance(points[i]));
+		mgl_assert1(optimalObb.Distance(points[i]) < 1e-3f, optimalObb.Distance(points[i]));
+		mgl_assert1(bruteObb.Distance(points[i]) < 1e-3f, bruteObb.Distance(points[i]));
 	}
-		//assert2(o.Contains(points[i]), points[i], o.Distance(points[i]));
+		//mgl_assert2(o.Contains(points[i]), points[i], o.Distance(points[i]));
 
 	// Would like to assert that optimal OBB has smaller volume than brute-force computed OBB volume, but since
 	// the point sets are planar, the generated OBB should be practically flat, and volume should be zero. Therefore
 	// instead of asserting volume, assert that the surface area of the optimal box is smaller than that of the brute
 	// force OBB.
-//	assert4(optimalObb.Volume() <= bruteObb.Volume(), optimalObb, bruteObb, optimalObb.Volume(), bruteObb.Volume());
+//	mgl_assert4(optimalObb.Volume() <= bruteObb.Volume(), optimalObb, bruteObb, optimalObb.Volume(), bruteObb.Volume());
 
 #define MAX_SURFACE_AREA(v) Max(v.x*v.y, v.x*v.z, v.y*v.z)
 	float optimalSurfaceArea = MAX_SURFACE_AREA(optimalObb.r);
 	float bruteSurfaceArea = MAX_SURFACE_AREA(bruteObb.r);
-	assert4(optimalSurfaceArea <= bruteSurfaceArea + 1e-5f, optimalObb, bruteObb, optimalSurfaceArea, bruteSurfaceArea);
+	mgl_assert4(optimalSurfaceArea <= bruteSurfaceArea + 1e-5f, optimalObb, bruteObb, optimalSurfaceArea, bruteSurfaceArea);
 }
 
 UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case)
@@ -212,7 +212,7 @@ UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case)
 	OBB fastOBB = OBB::BruteEnclosingOBB(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert1(knownTightOBB.Distance(points[i]) < 1e-5f, knownTightOBB.Distance(points[i]));
+		mgl_assert1(knownTightOBB.Distance(points[i]) < 1e-5f, knownTightOBB.Distance(points[i]));
 	LOGI("Tight OBB Volume: %.9g", knownTightOBB.Volume());
 	for(int i = 0; i < 6; i += 2)
 		LOGI("Tight OBB normal: %s", knownTightOBB.FacePlane(i).normal.ToString().c_str());
@@ -224,9 +224,9 @@ UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case)
 	LOGI("Difference in angle: %.9g (%.9g degrees)", q.AngleBetween(q2), RadToDeg(q.AngleBetween(q2)));
 //	LOGI("%s", fastOBB.SerializeToCodeString().c_str());
 
-	assert(minOBB.Volume() <= knownTightOBB.Volume());
-	assert(fastOBB.Volume() <= knownTightOBB.Volume()*1.005 /* fastOBB is only an approximation, so allow small 0.5% wiggle room. */);
-	assert(minOBB.Volume() <= fastOBB.Volume());
+	mgl_assert(minOBB.Volume() <= knownTightOBB.Volume());
+	mgl_assert(fastOBB.Volume() <= knownTightOBB.Volume()*1.005 /* fastOBB is only an approximation, so allow small 0.5% wiggle room. */);
+	mgl_assert(minOBB.Volume() <= fastOBB.Volume());
 }
 
 UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case2)
@@ -250,7 +250,7 @@ UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case2)
 	OBB fastOBB = OBB::BruteEnclosingOBB(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert1(knownTightOBB.Distance(points[i]) < 1e-4f, knownTightOBB.Distance(points[i]));
+		mgl_assert1(knownTightOBB.Distance(points[i]) < 1e-4f, knownTightOBB.Distance(points[i]));
 	LOGI("Tight OBB Volume: %.9g", knownTightOBB.Volume());
 	for(int i = 0; i < 6; i += 2)
 		LOGI("Tight OBB normal: %s", knownTightOBB.FacePlane(i).normal.ToString().c_str());
@@ -262,8 +262,8 @@ UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case2)
 	LOGI("Difference in angle: %.9g (%.9g degrees)", q.AngleBetween(q2), RadToDeg(q.AngleBetween(q2)));
 //	LOGI("%s", fastOBB.SerializeToCodeString().c_str());
 
-	assert(minOBB.Volume() <= knownTightOBB.Volume());
-	assert(minOBB.Volume() <= fastOBB.Volume());
+	mgl_assert(minOBB.Volume() <= knownTightOBB.Volume());
+	mgl_assert(minOBB.Volume() <= fastOBB.Volume());
 }
 
 UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case3)
@@ -287,7 +287,7 @@ UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case3)
 	OBB fastOBB = OBB::BruteEnclosingOBB(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert1(knownTightOBB.Distance(points[i]) < 1e-4f, knownTightOBB.Distance(points[i]));
+		mgl_assert1(knownTightOBB.Distance(points[i]) < 1e-4f, knownTightOBB.Distance(points[i]));
 	LOGI("Tight OBB Volume: %.9g", knownTightOBB.Volume());
 	for(int i = 0; i < 6; i += 2)
 		LOGI("Tight OBB normal: %s", knownTightOBB.FacePlane(i).normal.ToString().c_str());
@@ -299,8 +299,8 @@ UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case3)
 	LOGI("Difference in angle: %.9g (%.9g degrees)", q.AngleBetween(q2), RadToDeg(q.AngleBetween(q2)));
 //	LOGI("%s", fastOBB.SerializeToCodeString().c_str());
 
-	assert(minOBB.Volume() <= knownTightOBB.Volume());
-//	assert(minOBB.Volume() <= fastOBB.Volume()); // TODO: Due to numerical imprecision, brute-forcing seems to jiggle itself to a tiny fraction better result than the minimally computed one
+	mgl_assert(minOBB.Volume() <= knownTightOBB.Volume());
+//	mgl_assert(minOBB.Volume() <= fastOBB.Volume()); // TODO: Due to numerical imprecision, brute-forcing seems to jiggle itself to a tiny fraction better result than the minimally computed one
 }
 
 UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case4)
@@ -316,18 +316,18 @@ UNIQUE_TEST(OBB_OptimalEnclosingOBB_Case4)
 
 	Polyhedron convexHull = Polyhedron::ConvexHull(points, n);
 	for(int i = 0; i < n; ++i)
-		assert3(convexHull.ContainsConvex(points[i]) || convexHull.Distance(points[i]) < 1e-4f, convexHull, points[i], convexHull.Distance(points[i]));
+		mgl_assert3(convexHull.ContainsConvex(points[i]) || convexHull.Distance(points[i]) < 1e-4f, convexHull, points[i], convexHull.Distance(points[i]));
 
 	OBB minOBB = OBB::OptimalEnclosingOBB(points, n);
 	OBB fastOBB = OBB::BruteEnclosingOBB(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert2(fastOBB.Distance(points[i]) < 1e-4f, i, fastOBB.Distance(points[i]));
+		mgl_assert2(fastOBB.Distance(points[i]) < 1e-4f, i, fastOBB.Distance(points[i]));
 
 	LOGI("Min OBB volume: %.9g", minOBB.Volume());
 	LOGI("fast OBB volume: %.9g", fastOBB.Volume());
 
-//	assert(minOBB.Volume() <= fastOBB.Volume()); // TODO: Due to numerical imprecision, brute-forcing seems to jiggle itself to a tiny fraction better result than the minimally computed one
+//	mgl_assert(minOBB.Volume() <= fastOBB.Volume()); // TODO: Due to numerical imprecision, brute-forcing seems to jiggle itself to a tiny fraction better result than the minimally computed one
 }
 
 

--- a/tests/PBVolumeTests.cpp
+++ b/tests/PBVolumeTests.cpp
@@ -14,20 +14,20 @@ RANDOMIZED_TEST(AABBPBVolumeIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 	bool contained = b.Contains(a);
 
-	assert(b.Contains(b.CenterPoint()));
+	mgl_assert(b.Contains(b.CenterPoint()));
 
 	PBVolume<6> pbVolume = b.ToPBVolume();
-	assert(pbVolume.Contains(b.CenterPoint()));
+	mgl_assert(pbVolume.Contains(b.CenterPoint()));
 	CullTestResult r = pbVolume.InsideOrIntersects(a);
-	assert(r == TestInside || r == TestNotContained);
+	mgl_assert(r == TestInside || r == TestNotContained);
 	MARK_UNUSED(r);
 	if (contained)
-		assert(r == TestInside);
+		mgl_assert(r == TestInside);
 }
 
 RANDOMIZED_TEST(AABBPBVolumeNoIntersect)
@@ -36,14 +36,14 @@ RANDOMIZED_TEST(AABBPBVolumeNoIntersect)
 	AABB a = RandomAABBInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 	PBVolume<6> pbVolume = b.ToPBVolume();
-	assert(pbVolume.Contains(b.CenterPoint()));
+	mgl_assert(pbVolume.Contains(b.CenterPoint()));
 	CullTestResult r = pbVolume.InsideOrIntersects(a);
 	MARK_UNUSED(r);
-	assert(r == TestOutside || r == TestNotContained);
+	mgl_assert(r == TestOutside || r == TestNotContained);
 }
 
 RANDOMIZED_TEST(SpherePBVolumeIntersect)
@@ -51,20 +51,20 @@ RANDOMIZED_TEST(SpherePBVolumeIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 //	bool contained = b.Contains(a);
 
-	assert(b.Contains(b.CenterPoint()));
+	mgl_assert(b.Contains(b.CenterPoint()));
 
 	PBVolume<6> pbVolume = b.ToPBVolume();
-	assert(pbVolume.Contains(b.CenterPoint()));
+	mgl_assert(pbVolume.Contains(b.CenterPoint()));
 	CullTestResult r = pbVolume.InsideOrIntersects(a);
 	MARK_UNUSED(r);
-	assert(r == TestInside || r == TestNotContained);
+	mgl_assert(r == TestInside || r == TestNotContained);
 //	if (contained)
-//		assert(r == TestInside);
+//		mgl_assert(r == TestInside);
 }
 
 RANDOMIZED_TEST(SpherePBVolumeNoIntersect)
@@ -73,12 +73,12 @@ RANDOMIZED_TEST(SpherePBVolumeNoIntersect)
 	Sphere a = RandomSphereInHalfspace(p, 10.f);
 	p.ReverseNormal();
 	Frustum b = RandomFrustumInHalfspace(p);
-	assert2(!a.Intersects(b), a, b);
-	assert(!b.Intersects(a));
+	mgl_assert2(!a.Intersects(b), a, b);
+	mgl_assert(!b.Intersects(a));
 
 	PBVolume<6> pbVolume = b.ToPBVolume();
-	assert(pbVolume.Contains(b.CenterPoint()));
+	mgl_assert(pbVolume.Contains(b.CenterPoint()));
 	CullTestResult r = pbVolume.InsideOrIntersects(a);
 	MARK_UNUSED(r);
-	assert(r == TestOutside || r == TestNotContained);
+	mgl_assert(r == TestOutside || r == TestNotContained);
 }

--- a/tests/PolygonTests.cpp
+++ b/tests/PolygonTests.cpp
@@ -16,17 +16,17 @@ UNIQUE_TEST(Polygon_collinear_points_Plane)
 	poly.p.push_back(POINT_VEC(4820, 8600, 12835));
 	poly.p.push_back(POINT_VEC(4980, 8600, 12835));
 
-	assert1(!poly.IsDegenerate(), poly);
-	assert1(!poly.IsNull(), poly);
-	assert1(poly.IsPlanar(), poly);
-	assert1(poly.IsFinite(), poly);
+	mgl_assert1(!poly.IsDegenerate(), poly);
+	mgl_assert1(!poly.IsNull(), poly);
+	mgl_assert1(poly.IsPlanar(), poly);
+	mgl_assert1(poly.IsFinite(), poly);
 
 	math::Plane plane = poly.PlaneCCW();
 
-	assert1(!plane.IsDegenerate(), plane);
+	mgl_assert1(!plane.IsDegenerate(), plane);
 
 	for(size_t i = 0; i < poly.p.size(); ++i)
-		assert(plane.Contains(poly.p[i]));
+		mgl_assert(plane.Contains(poly.p[i]));
 }
 
 UNIQUE_TEST(Polygon_IsPlanarCase)
@@ -36,7 +36,7 @@ UNIQUE_TEST(Polygon_IsPlanarCase)
 	p.p.push_back(POINT_VEC(0.f,       0.f, 0.f));
 	p.p.push_back(POINT_VEC(0.f,       0.f, 1.f));
 	p.p.push_back(POINT_VEC(0.001175f, 0.f, 1.f));
-	assert(p.IsPlanar());
+	mgl_assert(p.IsPlanar());
 }
 
 UNIQUE_TEST(Polygon_IsPlanarCase2)
@@ -46,7 +46,7 @@ UNIQUE_TEST(Polygon_IsPlanarCase2)
 	p.p.push_back(POINT_VEC(36.0442657f,147.617859f,13.1296129f));
 	p.p.push_back(POINT_VEC(185.938354f,-49.2594376f,24.0656204f));
 	p.p.push_back(POINT_VEC(-38.1764603f,96.0109634f,244.697083f));
-	assert(p.IsPlanar());
+	mgl_assert(p.IsPlanar());
 }
 
 UNIQUE_TEST(Polygon_IsPlanarCase3)
@@ -56,7 +56,7 @@ UNIQUE_TEST(Polygon_IsPlanarCase3)
 	p.p.push_back(POINT_VEC(-134.202698f,-27.2182236f,6.43854856f));
 	p.p.push_back(POINT_VEC(-23.2372704f,4.65003967f,204.453552f));
 	p.p.push_back(POINT_VEC(-130.144333f,161.677658f,-124.184113f));
-	assert(p.IsPlanar());
+	mgl_assert(p.IsPlanar());
 }
 
 UNIQUE_TEST(Triangle_ContainsPoint)
@@ -67,7 +67,7 @@ UNIQUE_TEST(Triangle_ContainsPoint)
 
 	vec pt = POINT_VEC(96.5959015f,-95.449379f,-80.2810669f);
 
-	assert(t.Contains(pt));
+	mgl_assert(t.Contains(pt));
 }
 
 UNIQUE_TEST(Polygon_Intersects_LineSegment_2D)
@@ -77,27 +77,27 @@ UNIQUE_TEST(Polygon_Intersects_LineSegment_2D)
 	p.p.push_back(POINT_VEC(1, 0, 0));
 	p.p.push_back(POINT_VEC(1, 1, 0));
 	p.p.push_back(POINT_VEC(0, 1, 0));
-	assert(p.IsPlanar());
+	mgl_assert(p.IsPlanar());
 
 	LineSegment contained(POINT_VEC(0.5f, 0.5f, 0), POINT_VEC(0.5f, 0.75f, 0));
 	LineSegment intersecting(POINT_VEC(0.5f, 0.5f, 0), POINT_VEC(0.5f, 1.5f, 0));
 	LineSegment intersecting2(POINT_VEC(-0.5f, 0.5f, 0), POINT_VEC(1.5f, 0.5f, 0));
 	LineSegment noncontained(POINT_VEC(1.5f, 1.5f, 0), POINT_VEC(1.5f, 2.5f, 0));
 
-	assert(p.Intersects(contained));
-	assert(p.Intersects(intersecting));
-	assert(p.Intersects(intersecting2));
-	assert(!p.Intersects(noncontained));
+	mgl_assert(p.Intersects(contained));
+	mgl_assert(p.Intersects(intersecting));
+	mgl_assert(p.Intersects(intersecting2));
+	mgl_assert(!p.Intersects(noncontained));
 
-	assert(p.Contains(contained));
-	assert(!p.Contains(intersecting));
-	assert(!p.Contains(intersecting2));
-	assert(!p.Contains(noncontained));
+	mgl_assert(p.Contains(contained));
+	mgl_assert(!p.Contains(intersecting));
+	mgl_assert(!p.Contains(intersecting2));
+	mgl_assert(!p.Contains(noncontained));
 
-	assert(p.Contains2D(contained));
-	assert(!p.Contains2D(intersecting));
-	assert(!p.Contains2D(intersecting2));
-	assert(!p.Contains2D(noncontained));
+	mgl_assert(p.Contains2D(contained));
+	mgl_assert(!p.Contains2D(intersecting));
+	mgl_assert(!p.Contains2D(intersecting2));
+	mgl_assert(!p.Contains2D(noncontained));
 }
 
 UNIQUE_TEST(Polygon_Intersects_Polygon_2D)
@@ -106,22 +106,22 @@ UNIQUE_TEST(Polygon_Intersects_Polygon_2D)
 	p.p.push_back(POINT_VEC(156.644623f, -3.16135454f, 0));
 	p.p.push_back(POINT_VEC(160.721878f, 18.5124626f, 0));
 	p.p.push_back(POINT_VEC(169.520157f, -3.80513144f, 0));
-	assert(p.IsPlanar());
-	assert(p.IsSimple());
+	mgl_assert(p.IsPlanar());
+	mgl_assert(p.IsSimple());
 
 	Polygon p2;
 	p2.p.push_back(POINT_VEC(30.0000019f, 0, 0));
 	p2.p.push_back(POINT_VEC(30.2276134f, 4.43845034f, 0));
 	p2.p.push_back(POINT_VEC(225.f, -10.f, 0));
 	p2.p.push_back(POINT_VEC(225.2276f, -5.56155014f, 0));
-	assert(p2.IsPlanar());
-	assert(!p2.IsSimple());
+	mgl_assert(p2.IsPlanar());
+	mgl_assert(!p2.IsSimple());
 
 	// p2 is a self-intersecting polygon. The convex hull of that Polygon would intersect p, but p2 itself does not intersect p.
-	assert(!p.Intersects(p2));
-	assert(!p2.Intersects(p));
-	assert(!p.Contains(p2));
-	assert(!p2.Contains(p));
+	mgl_assert(!p.Intersects(p2));
+	mgl_assert(!p2.Intersects(p));
+	mgl_assert(!p.Contains(p2));
+	mgl_assert(!p2.Contains(p));
 
 	// Test that the rewinded version of p2 which has its vertices so that it does not self-intersect, does correctly return
 	// intersection with p.
@@ -130,11 +130,11 @@ UNIQUE_TEST(Polygon_Intersects_Polygon_2D)
 	p3.p.push_back(POINT_VEC(30.2276134f, 4.43845034f, 0));
 	p3.p.push_back(POINT_VEC(225.2276f, -5.56155014f, 0));
 	p3.p.push_back(POINT_VEC(225.f, -10.f, 0));
-	assert(p3.IsPlanar());
-	assert(p3.IsSimple());
+	mgl_assert(p3.IsPlanar());
+	mgl_assert(p3.IsSimple());
 
-	assert(p3.Intersects(p));
-	assert(p.Intersects(p3));
-	assert(!p3.Contains(p));
-	assert(!p.Contains(p3));
+	mgl_assert(p3.Intersects(p));
+	mgl_assert(p.Intersects(p3));
+	mgl_assert(!p3.Contains(p));
+	mgl_assert(!p.Contains(p3));
 }

--- a/tests/PolyhedronTests.cpp
+++ b/tests/PolyhedronTests.cpp
@@ -17,10 +17,10 @@ RANDOMIZED_TEST(PolyhedronConvexCentroid)
 	Polyhedron p = RandomPolyhedronContainingPoint(pt);
 
 	vec convexCentroid = p.ConvexCentroid();
-	assert2(p.Contains(convexCentroid), p, convexCentroid);
+	mgl_assert2(p.Contains(convexCentroid), p, convexCentroid);
 
 	vec approximateConvexCentroid = p.ApproximateConvexCentroid();
-	assert2(p.Contains(approximateConvexCentroid), p, approximateConvexCentroid);
+	mgl_assert2(p.Contains(approximateConvexCentroid), p, approximateConvexCentroid);
 }
 
 // Skipped due to numerical stability reasons.
@@ -41,9 +41,9 @@ UNIQUE_TEST(PolyhedronConvexCentroidCase)
 	PBVolume<12> intersection = Source.ToPBVolume().SetIntersection(Target.ToPBVolume());
 	Polyhedron Volume = intersection.ToPolyhedron();
 	vec c = Volume.ConvexCentroid();
-	assert(Volume.Contains(c));
-	assert(Source.Contains(c));
-	assert(Target.Contains(c));
+	mgl_assert(Volume.Contains(c));
+	mgl_assert(Source.Contains(c));
+	mgl_assert(Target.Contains(c));
 }
 */
 
@@ -55,7 +55,7 @@ RANDOMIZED_TEST(Polyhedron_intersects_itself)
 	else
 		pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron p = RandomPolyhedronContainingPoint(pt);
-	assert(p.Intersects(p));
+	mgl_assert(p.Intersects(p));
 }
 
 UNIQUE_TEST(Platonic_solids_contain_zero)
@@ -72,7 +72,7 @@ UNIQUE_TEST(Platonic_solids_contain_zero)
 		case 3: p = Polyhedron::Icosahedron(pt, SCALE); break;
 		default: p = Polyhedron::Dodecahedron(pt, SCALE); break;
 		}
-		assert(p.Contains(pt));
+		mgl_assert(p.Contains(pt));
 	}
 }
 
@@ -87,7 +87,7 @@ UNIQUE_TEST(PolyhedronContainsPointCase)
 	p.v.push_back(POINT_VEC(-16.392548f, -65.362495f, -39.771103f));
 	p.v.push_back(POINT_VEC(-16.392548f, -18.697929f, -102.40900f));
 	p.v.push_back(POINT_VEC(-16.392548f, -18.697929f, -39.771103f));
-	
+
 	int i0[4] = {0,1,3,2};
 	int i1[4] = {4,6,7,5};
 	int i2[4] = {0,4,5,1};
@@ -104,7 +104,7 @@ UNIQUE_TEST(PolyhedronContainsPointCase)
 	AABB a(POINT_VEC(-115.40511f, -65.362495f, -102.40900f),
 		POINT_VEC(-16.392548f,-18.697929f, -39.771103f));
 
-	assert(p.Contains(a.CenterPoint()));
+	mgl_assert(p.Contains(a.CenterPoint()));
 }
 
 RANDOMIZED_TEST(Polyhedron_ConvexHull)
@@ -117,7 +117,7 @@ RANDOMIZED_TEST(Polyhedron_ConvexHull)
 	Polyhedron convexHull = Polyhedron::ConvexHull(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
+		mgl_assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
 }
 
 UNIQUE_TEST(Polyhedron_ConvexHull_case)
@@ -133,7 +133,7 @@ UNIQUE_TEST(Polyhedron_ConvexHull_case)
 	Polyhedron convexHull = Polyhedron::ConvexHull(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
+		mgl_assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
 }
 
 UNIQUE_TEST(Polyhedron_ConvexHull_case2)
@@ -150,7 +150,7 @@ UNIQUE_TEST(Polyhedron_ConvexHull_case2)
 	Polyhedron convexHull = Polyhedron::ConvexHull(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
+		mgl_assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
 }
 
 UNIQUE_TEST(Polyhedron_ConvexHull_case3)
@@ -167,5 +167,5 @@ UNIQUE_TEST(Polyhedron_ConvexHull_case3)
 	Polyhedron convexHull = Polyhedron::ConvexHull(points, n);
 
 	for(int i = 0; i < n; ++i)
-		assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
+		mgl_assert1(convexHull.ContainsConvex(points[i]), convexHull.Distance(points[i]));
 }

--- a/tests/PositiveTests.cpp
+++ b/tests/PositiveTests.cpp
@@ -20,12 +20,12 @@ AABB RandomAABBContainingPoint(const vec &pt, float maxSideLength)
 	h = rng.Float(1e-3f, h-1e-3f);
 	d = rng.Float(1e-3f, d-1e-3f);
 	a.Translate(pt - POINT_VEC(w, h, d));
-	assert(!a.IsDegenerate());
-	assert(a.IsFinite());
-	assert(a.Contains(pt));
+	mgl_assert(!a.IsDegenerate());
+	mgl_assert(a.IsFinite());
+	mgl_assert(a.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(a.minPoint.w, 1.f);
-	asserteq(a.maxPoint.w, 1.f);
+	mgl_asserteq(a.minPoint.w, 1.f);
+	mgl_asserteq(a.maxPoint.w, 1.f);
 #endif
 	return a;
 }
@@ -41,25 +41,25 @@ OBB RandomOBBContainingPoint(const vec &pt, float maxSideLength)
 	o.axis[0] = DIR_VEC(rot.Col(0));
 	o.axis[1] = DIR_VEC(rot.Col(1));
 	o.axis[2] = DIR_VEC(rot.Col(2));
-	assume2(o.axis[0].IsNormalized(), o.axis[0], o.axis[0].LengthSq());
-	assume2(o.axis[1].IsNormalized(), o.axis[1], o.axis[1].LengthSq());
-	assume2(o.axis[2].IsNormalized(), o.axis[2], o.axis[2].LengthSq());
-	assume(vec::AreOrthogonal(o.axis[0], o.axis[1], o.axis[2]));
+	mgl_assume2(o.axis[0].IsNormalized(), o.axis[0], o.axis[0].LengthSq());
+	mgl_assume2(o.axis[1].IsNormalized(), o.axis[1], o.axis[1].LengthSq());
+	mgl_assume2(o.axis[2].IsNormalized(), o.axis[2], o.axis[2].LengthSq());
+	mgl_assume(vec::AreOrthogonal(o.axis[0], o.axis[1], o.axis[2]));
 //	assume(vec::AreOrthonormal(o.axis[0], o.axis[1], o.axis[2]));
 	o.r = DIR_VEC(w, h, d);
 	const float epsilon = 1e-4f;
 	o.pos += rng.Float(-w+epsilon, w-epsilon) * o.axis[0];
 	o.pos += rng.Float(-h+epsilon, h-epsilon) * o.axis[1];
 	o.pos += rng.Float(-d+epsilon, d-epsilon) * o.axis[2];
-	assert1(!o.IsDegenerate(), o);
-	assert(o.IsFinite());
-	assert(o.Contains(pt));
+	mgl_assert1(!o.IsDegenerate(), o);
+	mgl_assert(o.IsFinite());
+	mgl_assert(o.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(o.pos.w, 1.f);
-	asserteq(o.r.w, 0.f);
-	asserteq(o.axis[0].w, 0.f);
-	asserteq(o.axis[1].w, 0.f);
-	asserteq(o.axis[2].w, 0.f);
+	mgl_asserteq(o.pos.w, 1.f);
+	mgl_asserteq(o.r.w, 0.f);
+	mgl_asserteq(o.axis[0].w, 0.f);
+	mgl_asserteq(o.axis[1].w, 0.f);
+	mgl_asserteq(o.axis[2].w, 0.f);
 #endif
 	return o;
 }
@@ -68,11 +68,11 @@ Sphere RandomSphereContainingPoint(const vec &pt, float maxRadius)
 {
 	Sphere s(pt, rng.Float(1.f, maxRadius));
 	s.pos += vec::RandomDir(rng, Max(0.f, s.r - 1e-2f));
-	assert(s.IsFinite());
-	assert(!s.IsDegenerate());
-	assert(s.Contains(pt));
+	mgl_assert(s.IsFinite());
+	mgl_assert(!s.IsDegenerate());
+	mgl_assert(s.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(s.pos.w, 1.f);
+	mgl_asserteq(s.pos.w, 1.f);
 #endif
 	return s;
 }
@@ -88,9 +88,9 @@ Circle2D RandomCircle2DContainingPoint(LCG &lcg, const float2 &pt, float maxRadi
     if (!c.Contains(pt))
         return RandomCircle2DContainingPoint(pt, maxRadius);
 #endif
-	assert(c.IsFinite());
-	assert(!c.IsDegenerate());
-	assert(c.Contains(pt));
+	mgl_assert(c.IsFinite());
+	mgl_assert(!c.IsDegenerate());
+	mgl_assert(c.Contains(pt));
 	return c;
 }
 
@@ -120,13 +120,13 @@ Frustum RandomFrustumContainingPoint(LCG &lcg, const vec &pt)
 	vec pt2 = f.UniformRandomPointInside(lcg);
 	f.SetPos(f.Pos() + pt - pt2);
 
-	assert(f.IsFinite());
-//	assert(!f.IsDegenerate());
-	assert(f.Contains(pt));
+	mgl_assert(f.IsFinite());
+//	mgl_assert(!f.IsDegenerate());
+	mgl_assert(f.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(f.Pos().w, 1.f);
-	asserteq(f.Front().w, 0.f);
-	asserteq(f.Up().w, 0.f);
+	mgl_asserteq(f.Pos().w, 1.f);
+	mgl_asserteq(f.Front().w, 0.f);
+	mgl_asserteq(f.Up().w, 0.f);
 #endif
 	return f;
 }
@@ -136,11 +136,11 @@ Line RandomLineContainingPoint(const vec &pt)
 	vec dir = vec::RandomDir(rng);
 	Line l(pt, dir);
 	l.pos = l.GetPoint(rng.Float(-SCALE, SCALE));
-	assert(l.IsFinite());
-	assert(l.Contains(pt));
+	mgl_assert(l.IsFinite());
+	mgl_assert(l.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(l.pos.w, 1.f);
-	asserteq(l.dir.w, 0.f);
+	mgl_asserteq(l.pos.w, 1.f);
+	mgl_asserteq(l.dir.w, 0.f);
 #endif
 	return l;
 }
@@ -150,11 +150,11 @@ Ray RandomRayContainingPoint(const vec &pt)
 	vec dir = vec::RandomDir(rng);
 	Ray l(pt, dir);
 	l.pos = l.GetPoint(rng.Float(-SCALE, 0));
-	assert(l.IsFinite());
-	assert(l.Contains(pt));
+	mgl_assert(l.IsFinite());
+	mgl_assert(l.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(l.pos.w, 1.f);
-	asserteq(l.dir.w, 0.f);
+	mgl_asserteq(l.pos.w, 1.f);
+	mgl_asserteq(l.dir.w, 0.f);
 #endif
 	return l;
 }
@@ -165,11 +165,11 @@ LineSegment RandomLineSegmentContainingPoint(const vec &pt)
 	float a = rng.Float(0, SCALE);
 	float b = rng.Float(0, SCALE);
 	LineSegment l(pt + a*dir, pt - b*dir);
-	assert(l.IsFinite());
-	assert(l.Contains(pt));
+	mgl_assert(l.IsFinite());
+	mgl_assert(l.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(l.a.w, 1.f);
-	asserteq(l.b.w, 1.f);
+	mgl_asserteq(l.a.w, 1.f);
+	mgl_asserteq(l.b.w, 1.f);
 #endif
 	return l;
 }
@@ -184,11 +184,11 @@ Capsule RandomCapsuleContainingPoint(const vec &pt)
 	vec d = vec::RandomSphere(rng, vec::zero, c.r);
 	c.l.a += d;
 	c.l.b += d;
-	assert(c.IsFinite());
-	assert(c.Contains(pt));
+	mgl_assert(c.IsFinite());
+	mgl_assert(c.Contains(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(c.l.a.w, 1.f);
-	asserteq(c.l.b.w, 1.f);
+	mgl_asserteq(c.l.a.w, 1.f);
+	mgl_asserteq(c.l.b.w, 1.f);
 #endif
 
 	return c;
@@ -197,11 +197,11 @@ Capsule RandomCapsuleContainingPoint(const vec &pt)
 Plane RandomPlaneContainingPoint(const vec &pt)
 {
 	vec dir = vec::RandomDir(rng);
-	assume2(dir.IsNormalized(), dir.SerializeToCodeString(), dir.Length());
+	mgl_assume2(dir.IsNormalized(), dir.SerializeToCodeString(), dir.Length());
 	Plane p(pt, dir);
-	assert(!p.IsDegenerate());
+	mgl_assert(!p.IsDegenerate());
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(p.normal.w, 0.f);
+	mgl_asserteq(p.normal.w, 0.f);
 #endif
 	return p;
 }
@@ -220,13 +220,13 @@ Triangle RandomTriangleContainingPoint(const vec &pt)
 	t.b += pt;
 	t.c += pt;
 
-	assert1(t.IsFinite(), t);
-	assert1(!t.IsDegenerate(), t);
-	assert3(t.Contains(pt), t.SerializeToCodeString(), pt.SerializeToCodeString(), t.Distance(pt));
+	mgl_assert1(t.IsFinite(), t);
+	mgl_assert1(!t.IsDegenerate(), t);
+	mgl_assert3(t.Contains(pt), t.SerializeToCodeString(), pt.SerializeToCodeString(), t.Distance(pt));
 #ifdef MATH_AUTOMATIC_SSE
-	asserteq(t.a.w, 1.f);
-	asserteq(t.b.w, 1.f);
-	asserteq(t.c.w, 1.f);
+	mgl_asserteq(t.a.w, 1.f);
+	mgl_asserteq(t.b.w, 1.f);
+	mgl_asserteq(t.c.w, 1.f);
 #endif
 	return t;
 }
@@ -247,12 +247,12 @@ Polyhedron RandomPolyhedronContainingPoint(const vec &pt)
 	}
 #ifdef MATH_AUTOMATIC_SSE
 	for (int i = 0; i < p.NumVertices(); ++i)
-		asserteq(p.Vertex(i).w, 1.f);
+		mgl_asserteq(p.Vertex(i).w, 1.f);
 #endif
 	return p;
-//	assert1(t.IsFinite(), t);
-//	assert1(!t.IsDegenerate(), t);
-//	assert3(t.Contains(pt), t.SerializeToCodeString(), pt.SerializeToCodeString(), t.Distance(pt));
+//	mgl_assert1(t.IsFinite(), t);
+//	mgl_assert1(!t.IsDegenerate(), t);
+//	mgl_assert3(t.Contains(pt), t.SerializeToCodeString(), pt.SerializeToCodeString(), t.Distance(pt));
 }
 
 UNIQUE_TEST(Polygon_Contains_PointCase)
@@ -265,7 +265,7 @@ UNIQUE_TEST(Polygon_Contains_PointCase)
 	p.p.push_back(POINT_VEC(0.f, 0.f, 1.f));
 	vec pt = POINT_VEC(0.5f, 0.f, 0.0007f);
 
-	assert(p.Contains(pt));
+	mgl_assert(p.Contains(pt));
 }
 
 Polygon RandomPolygonContainingPoint(const vec &pt)
@@ -274,17 +274,17 @@ Polygon RandomPolygonContainingPoint(const vec &pt)
 	Polygon poly = p.FacePolygon(rng.Int(0, p.NumFaces()-1));
 
 	vec pt2 = poly.FastRandomPointInside(rng);
-	assert3(poly.Contains(pt2), poly.SerializeToString(), pt2.SerializeToString(), poly.Distance(pt2));
+	mgl_assert3(poly.Contains(pt2), poly.SerializeToString(), pt2.SerializeToString(), poly.Distance(pt2));
 	poly.Translate(pt - pt2);
 
-	assert1(!poly.IsDegenerate(), poly);
-	assert1(!poly.IsNull(), poly);
-	assert1(poly.IsPlanar(), poly);
-	assert1(poly.IsFinite(), poly);
-	assert3(poly.Contains(pt), poly, pt, poly.Distance(pt));
+	mgl_assert1(!poly.IsDegenerate(), poly);
+	mgl_assert1(!poly.IsNull(), poly);
+	mgl_assert1(poly.IsPlanar(), poly);
+	mgl_assert1(poly.IsFinite(), poly);
+	mgl_assert3(poly.Contains(pt), poly, pt, poly.Distance(pt));
 #ifdef MATH_AUTOMATIC_SSE
 	for (int i = 0; i < poly.NumVertices(); ++i)
-		asserteq(poly.Vertex(i).w, 1.f);
+		mgl_asserteq(poly.Vertex(i).w, 1.f);
 #endif
 
 	return poly;
@@ -295,18 +295,18 @@ RANDOMIZED_TEST(AABBAABBIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	AABB b = RandomAABBContainingPoint(pt, 10.f);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBOBBIntersect)
@@ -314,18 +314,18 @@ RANDOMIZED_TEST(AABBOBBIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	OBB b = RandomOBBContainingPoint(pt, 10.f);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBLineIntersect)
@@ -333,14 +333,14 @@ RANDOMIZED_TEST(AABBLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Line b = RandomLineContainingPoint(pt);
-	assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
-	assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToCodeString());
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
+	mgl_assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToCodeString());
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBRayIntersect)
@@ -348,14 +348,14 @@ RANDOMIZED_TEST(AABBRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(TrickyAABBLineSegmentIntersectGJK)
@@ -366,8 +366,8 @@ UNIQUE_TEST(TrickyAABBLineSegmentIntersectGJK)
 	LineSegment b;
 	b.a = POINT_VEC(-61.331539f, 16.955204f, -18.561975f);
 	b.b = POINT_VEC(-53.097103f, 40.628937f, 30.422394f);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
 }
@@ -377,16 +377,16 @@ RANDOMIZED_TEST(AABBLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBPlaneIntersect)
@@ -394,14 +394,14 @@ RANDOMIZED_TEST(AABBPlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBSphereIntersect)
@@ -409,16 +409,16 @@ RANDOMIZED_TEST(AABBSphereIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Sphere b = RandomSphereContainingPoint(pt, SCALE);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
 
 
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBCapsuleIntersect)
@@ -426,14 +426,14 @@ RANDOMIZED_TEST(AABBCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBTriangleIntersect)
@@ -441,18 +441,18 @@ RANDOMIZED_TEST(AABBTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBFrustumIntersect)
@@ -460,18 +460,18 @@ RANDOMIZED_TEST(AABBFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(AABBPolyhedronIntersect)
@@ -479,14 +479,14 @@ RANDOMIZED_TEST(AABBPolyhedronIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Polyhedron b = RandomPolyhedronContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(AABBPolygonIntersectCase)
@@ -498,7 +498,7 @@ UNIQUE_TEST(AABBPolygonIntersectCase)
 	b.p.push_back(POINT_VEC(56.3732452f,-19.4667053f,-35.8499298f));
 	b.p.push_back(POINT_VEC(56.3732452f,-119.466698f,-35.8499298f));
 	b.p.push_back(POINT_VEC(-43.6267548f,-119.466698f,-35.8499298f));
-	assert(a.Intersects(b));
+	mgl_assert(a.Intersects(b));
 }
 
 UNIQUE_TEST(AABBPolygonIntersectCase2)
@@ -509,7 +509,7 @@ UNIQUE_TEST(AABBPolygonIntersectCase2)
 	b.p.push_back(POINT_VEC(74.7439194f,-20.989212f,181.39743f));
 	b.p.push_back(POINT_VEC(-25.2560806f,-20.989212f,81.3974304f));
 	b.p.push_back(POINT_VEC(74.7439194f,-120.989212f,81.3974304f));
-	assert(a.Intersects(b));
+	mgl_assert(a.Intersects(b));
 }
 
 RANDOMIZED_TEST(AABBPolygonIntersect)
@@ -517,14 +517,14 @@ RANDOMIZED_TEST(AABBPolygonIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	AABB a = RandomAABBContainingPoint(pt, 10.f);
 	Polygon b = RandomPolygonContainingPoint(pt);
-	assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToString());
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToString());
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -535,18 +535,18 @@ RANDOMIZED_TEST(OBBOBBIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	OBB b = RandomOBBContainingPoint(pt, 10.f);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 int xxxxx = 0;
@@ -610,14 +610,14 @@ RANDOMIZED_TEST(OBBLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Line b = RandomLineContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBRayIntersect)
@@ -625,14 +625,14 @@ RANDOMIZED_TEST(OBBRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBLineSegmentIntersect)
@@ -640,16 +640,16 @@ RANDOMIZED_TEST(OBBLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBPlaneIntersect)
@@ -657,14 +657,14 @@ RANDOMIZED_TEST(OBBPlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBSphereIntersect)
@@ -672,16 +672,16 @@ RANDOMIZED_TEST(OBBSphereIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Sphere b = RandomSphereContainingPoint(pt, SCALE);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-////	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+////	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBCapsuleIntersect)
@@ -689,16 +689,16 @@ RANDOMIZED_TEST(OBBCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBTriangleIntersect)
@@ -706,18 +706,18 @@ RANDOMIZED_TEST(OBBTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBFrustumIntersect)
@@ -725,18 +725,18 @@ RANDOMIZED_TEST(OBBFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBPolyhedronIntersect)
@@ -744,14 +744,14 @@ RANDOMIZED_TEST(OBBPolyhedronIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Polyhedron b = RandomPolyhedronContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(OBBPolygonIntersect)
@@ -759,14 +759,14 @@ RANDOMIZED_TEST(OBBPolygonIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	OBB a = RandomOBBContainingPoint(pt, 10.f);
 	Polygon b = RandomPolygonContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-///	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+///	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -778,16 +778,16 @@ RANDOMIZED_TEST(SphereSphereIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Sphere b = RandomSphereContainingPoint(pt, 10.f);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereLineIntersect)
@@ -795,14 +795,14 @@ RANDOMIZED_TEST(SphereLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Line b = RandomLineContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereRayIntersect)
@@ -810,14 +810,14 @@ RANDOMIZED_TEST(SphereRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereLineSegmentIntersect)
@@ -825,16 +825,16 @@ RANDOMIZED_TEST(SphereLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SpherePlaneIntersect)
@@ -842,14 +842,14 @@ RANDOMIZED_TEST(SpherePlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereCapsuleIntersect)
@@ -857,16 +857,16 @@ RANDOMIZED_TEST(SphereCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereTriangleIntersect)
@@ -874,16 +874,16 @@ RANDOMIZED_TEST(SphereTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SphereFrustumIntersect)
@@ -891,16 +891,16 @@ RANDOMIZED_TEST(SphereFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SpherePolyhedronIntersect)
@@ -908,14 +908,14 @@ RANDOMIZED_TEST(SpherePolyhedronIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Polyhedron b = RandomPolyhedronContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(SpherePolygonIntersect)
@@ -923,14 +923,14 @@ RANDOMIZED_TEST(SpherePolygonIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Sphere a = RandomSphereContainingPoint(pt, 10.f);
 	Polygon b = RandomPolygonContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -941,14 +941,14 @@ RANDOMIZED_TEST(FrustumLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Line b = RandomLineContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumRayIntersect)
@@ -956,14 +956,14 @@ RANDOMIZED_TEST(FrustumRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumLineSegmentIntersect)
@@ -971,16 +971,16 @@ RANDOMIZED_TEST(FrustumLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumPlaneIntersect)
@@ -988,14 +988,14 @@ RANDOMIZED_TEST(FrustumPlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumCapsuleIntersect)
@@ -1003,16 +1003,16 @@ RANDOMIZED_TEST(FrustumCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumTriangleIntersect)
@@ -1020,18 +1020,18 @@ RANDOMIZED_TEST(FrustumTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumFrustumIntersect)
@@ -1039,18 +1039,18 @@ RANDOMIZED_TEST(FrustumFrustumIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Frustum b = RandomFrustumContainingPoint(rng, pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 BENCHMARK(BM_FrustumFrustumIntersect, "Frustum-Frustum Intersects")
@@ -1112,14 +1112,14 @@ RANDOMIZED_TEST(FrustumPolyhedronIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Polyhedron b = RandomPolyhedronContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(FrustumPolygonIntersect)
@@ -1127,14 +1127,14 @@ RANDOMIZED_TEST(FrustumPolygonIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Frustum a = RandomFrustumContainingPoint(rng, pt);
 	Polygon b = RandomPolygonContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1145,14 +1145,14 @@ RANDOMIZED_TEST(CapsuleLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Line b = RandomLineContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleRayIntersect)
@@ -1160,14 +1160,14 @@ RANDOMIZED_TEST(CapsuleRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleLineSegmentIntersect)
@@ -1175,16 +1175,16 @@ RANDOMIZED_TEST(CapsuleLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsulePlaneIntersect)
@@ -1192,14 +1192,14 @@ RANDOMIZED_TEST(CapsulePlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleCapsuleIntersect)
@@ -1207,16 +1207,16 @@ RANDOMIZED_TEST(CapsuleCapsuleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Capsule b = RandomCapsuleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsuleTriangleIntersect)
@@ -1224,16 +1224,16 @@ RANDOMIZED_TEST(CapsuleTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-///	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+///	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsulePolyhedronIntersect)
@@ -1241,14 +1241,14 @@ RANDOMIZED_TEST(CapsulePolyhedronIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Polyhedron b = RandomPolyhedronContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-///	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+///	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(CapsulePolygonIntersect)
@@ -1256,14 +1256,14 @@ RANDOMIZED_TEST(CapsulePolygonIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Capsule a = RandomCapsuleContainingPoint(pt);
 	Polygon b = RandomPolygonContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1275,14 +1275,14 @@ RANDOMIZED_TEST(PolyhedronLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron a = RandomPolyhedronContainingPoint(pt);
 	Line b = RandomLineContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronRayIntersect)
@@ -1290,14 +1290,14 @@ RANDOMIZED_TEST(PolyhedronRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron a = RandomPolyhedronContainingPoint(pt);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronLineSegmentIntersect)
@@ -1305,17 +1305,17 @@ RANDOMIZED_TEST(PolyhedronLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron a = RandomPolyhedronContainingPoint(pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-	assert4(a.Distance(a.ClosestPoint(b)) < 1e-3f, a, b, a.ClosestPoint(b), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+	mgl_assert4(a.Distance(a.ClosestPoint(b)) < 1e-3f, a, b, a.ClosestPoint(b), a.Distance(a.ClosestPoint(b)));
 //	TODO: The following is problematic due to numerical
 //	stability issues at the surface of the Polyhedron.
-//	assert(a.Contains(a.ClosestPoint(b)));
-	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronPlaneIntersect)
@@ -1323,14 +1323,14 @@ RANDOMIZED_TEST(PolyhedronPlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron a = RandomPolyhedronContainingPoint(pt);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronTriangleIntersect)
@@ -1338,14 +1338,14 @@ RANDOMIZED_TEST(PolyhedronTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron a = RandomPolyhedronContainingPoint(pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronPolyhedronIntersect)
@@ -1353,14 +1353,14 @@ RANDOMIZED_TEST(PolyhedronPolyhedronIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron a = RandomPolyhedronContainingPoint(pt);
 	Polyhedron b = RandomPolyhedronContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolyhedronPolygonIntersect)
@@ -1368,14 +1368,14 @@ RANDOMIZED_TEST(PolyhedronPolygonIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polyhedron a = RandomPolyhedronContainingPoint(pt);
 	Polygon b = RandomPolygonContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(PolygonLineIntersectCase)
@@ -1389,7 +1389,7 @@ UNIQUE_TEST(PolygonLineIntersectCase)
 
 	Line l(POINT_VEC(-51.2448387f,66.6799698f,-31.887619f),DIR_VEC(-0.494226635f,-0.341286302f,-0.799539685f));
 
-	assert(p.Intersects(l));
+	mgl_assert(p.Intersects(l));
 }
 
 RANDOMIZED_TEST(PolygonLineIntersect)
@@ -1397,14 +1397,14 @@ RANDOMIZED_TEST(PolygonLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polygon a = RandomPolygonContainingPoint(pt);
 	Line b = RandomLineContainingPoint(pt);
-	assert2(a.Intersects(b), a.SerializeToString(), b.SerializeToCodeString());
-	assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToString());
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToString(), b.SerializeToCodeString());
+	mgl_assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToString());
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonRayIntersect)
@@ -1412,14 +1412,14 @@ RANDOMIZED_TEST(PolygonRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polygon a = RandomPolygonContainingPoint(pt);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonLineSegmentIntersect)
@@ -1427,14 +1427,14 @@ RANDOMIZED_TEST(PolygonLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polygon a = RandomPolygonContainingPoint(pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a, b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert3(b.Contains(a.ClosestPoint(b)), b.SerializeToCodeString(), a.SerializeToString(), b.Distance(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a, b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert3(b.Contains(a.ClosestPoint(b)), b.SerializeToCodeString(), a.SerializeToString(), b.Distance(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonPlaneIntersect)
@@ -1442,14 +1442,14 @@ RANDOMIZED_TEST(PolygonPlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polygon a = RandomPolygonContainingPoint(pt);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PolygonTriangleIntersect)
@@ -1457,14 +1457,14 @@ RANDOMIZED_TEST(PolygonTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polygon a = RandomPolygonContainingPoint(pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(PolygonPolygonIntersectCase)
@@ -1493,15 +1493,15 @@ UNIQUE_TEST(PolygonPolygonIntersectCase)
 			break;
 		}
 
-		assert(t1.Intersects(t1));
-		assert(t2.Intersects(t2));
-		assert(t1.Intersects(t2));
+		mgl_assert(t1.Intersects(t1));
+		mgl_assert(t2.Intersects(t2));
+		mgl_assert(t1.Intersects(t2));
 
 		Polygon a = t1.ToPolygon();
-		assert(a.Intersects(a));
+		mgl_assert(a.Intersects(a));
 		Polygon b = t2.ToPolygon();
 
-		assert(a.Intersects(b));
+		mgl_assert(a.Intersects(b));
 	}
 }
 
@@ -1519,7 +1519,7 @@ UNIQUE_TEST(PolygonPolygonIntersectCase2)
 	b.p.push_back(POINT_VEC(-29.0814209f,53.0219727f, 0.f));
 	b.p.push_back(POINT_VEC(-29.0814209f,-46.9780273f, 0.f));
 
-	assert(a.Intersects(b));
+	mgl_assert(a.Intersects(b));
 }
 
 UNIQUE_TEST(PolygonContainsPointCase)
@@ -1529,9 +1529,9 @@ UNIQUE_TEST(PolygonContainsPointCase)
 	a.p.push_back(POINT_VEC(15.0997639f,-67.2276688f,12.971736f));
 	a.p.push_back(POINT_VEC(15.062994f,-67.2823105f,12.9826784f));
 	a.p.push_back(POINT_VEC(-27.6450062f,-17.8819065f,116.161354f));
-	
+
 	vec pt = POINT_VEC(12.1201611f,-63.8624725f,20.105011f);
-	assert(a.Contains(pt, 1e-2f));
+	mgl_assert(a.Contains(pt, 1e-2f));
 }
 
 RANDOMIZED_TEST(PolygonPolygonIntersect)
@@ -1539,14 +1539,14 @@ RANDOMIZED_TEST(PolygonPolygonIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Polygon a = RandomPolygonContainingPoint(pt);
 	Polygon b = RandomPolygonContainingPoint(pt);
-	assert2(a.Intersects(b), a.SerializeToString(), b.SerializeToString());
-	assert2(b.Intersects(a), b.SerializeToString(), a.SerializeToString());
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-///	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToString(), b.SerializeToString());
+	mgl_assert2(b.Intersects(a), b.SerializeToString(), a.SerializeToString());
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+///	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1556,14 +1556,14 @@ RANDOMIZED_TEST(TriangleLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle a = RandomTriangleContainingPoint(pt);
 	Line b = RandomLineContainingPoint(pt);
-	assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
-//	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(b.Contains(a.ClosestPoint(b)));
-	assert(a.Contains(b.ClosestPoint(a)));
-	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
+//	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(b.Contains(a.ClosestPoint(b)));
+	mgl_assert(a.Contains(b.ClosestPoint(a)));
+	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(TriangleRayIntersect)
@@ -1571,14 +1571,14 @@ RANDOMIZED_TEST(TriangleRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle a = RandomTriangleContainingPoint(pt);
 	Ray b = RandomRayContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(TriangleLineSegmentIntersectCase)
@@ -1586,10 +1586,10 @@ UNIQUE_TEST(TriangleLineSegmentIntersectCase)
 	Triangle a(POINT_VEC(-45.7166939f,-104.675713f,17.1150723f),POINT_VEC(-20.9888325f,-89.1524963f,-31.5042286f),POINT_VEC(-1.45244789f,-76.914505f,-69.9231262f));
 	LineSegment b(POINT_VEC(-19.0950012f,-134.222748f,-33.7456589f),POINT_VEC(-52.5003471f,-49.3652039f,28.5405655f));
 
-	assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
+	mgl_assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
 	vec cp = a.ClosestPoint(b);
-	assert(a.Contains(cp));
-//	assert(b.Contains(cp));
+	mgl_assert(a.Contains(cp));
+//	mgl_assert(b.Contains(cp));
 }
 
 RANDOMIZED_TEST(TriangleLineSegmentIntersect)
@@ -1597,16 +1597,16 @@ RANDOMIZED_TEST(TriangleLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle a = RandomTriangleContainingPoint(pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert(a.Intersects(b));
-//	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+//	mgl_assert(b.Intersects(a));
 
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(TrianglePlaneIntersect)
@@ -1614,14 +1614,14 @@ RANDOMIZED_TEST(TrianglePlaneIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle a = RandomTriangleContainingPoint(pt);
 	Plane b = RandomPlaneContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(TriangleTriangleIntersect)
@@ -1629,18 +1629,18 @@ RANDOMIZED_TEST(TriangleTriangleIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Triangle a = RandomTriangleContainingPoint(pt);
 	Triangle b = RandomTriangleContainingPoint(pt);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 
 
-	assert(SATIntersect(a, b));
+	mgl_assert(SATIntersect(a, b));
 
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(b.Contains(a.ClosestPoint(b)));
-	assert(a.Contains(b.ClosestPoint(a)));
-	assert(b.Contains(b.ClosestPoint(a)));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(b.Contains(a.ClosestPoint(b)));
+	mgl_assert(a.Contains(b.ClosestPoint(a)));
+	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 
@@ -1651,21 +1651,21 @@ RANDOMIZED_TEST(PlaneLineIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Plane a = RandomPlaneContainingPoint(pt);
 	Line b = RandomLineContainingPoint(pt);
-	assert(a.Intersects(b));
-///	assert(b.Intersects(a));
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert(a.Intersects(b));
+///	mgl_assert(b.Intersects(a));
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(PlaneRayIntersectCase)
 {
 	Plane p(DIR_VEC(-0.25385046f,-0.518036366f,-0.816822112f),91.5489655f);
 	Ray r(POINT_VEC(-70.5785141f,-19.6609783f,-77.6785507f),DIR_VEC(0.916250288f,0.141897082f,-0.374634057f));
-	assert(p.Intersects(r));
+	mgl_assert(p.Intersects(r));
 }
 
 RANDOMIZED_TEST(PlaneRayIntersect)
@@ -1673,14 +1673,14 @@ RANDOMIZED_TEST(PlaneRayIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Plane a = RandomPlaneContainingPoint(pt);
 	Ray b = RandomRayContainingPoint(pt);
-	assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
-	assert2(b.Intersects(a), a.SerializeToCodeString(), b.SerializeToCodeString());
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-	assert2(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString());
-	assert2(b.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString());
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
+	mgl_assert2(b.Intersects(a), a.SerializeToCodeString(), b.SerializeToCodeString());
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+	mgl_assert2(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString());
+	mgl_assert2(b.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString());
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(PlaneLineSegmentIntersect)
@@ -1688,22 +1688,22 @@ RANDOMIZED_TEST(PlaneLineSegmentIntersect)
 	vec pt = vec::RandomBox(rng, POINT_VEC_SCALAR(-SCALE), POINT_VEC_SCALAR(SCALE));
 	Plane a = RandomPlaneContainingPoint(pt);
 	LineSegment b = RandomLineSegmentContainingPoint(pt);
-	assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
-	assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToCodeString());
-	assert(a.Distance(b) == 0.f);
-	assert(b.Distance(a) == 0.f);
-	assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
-	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
+	mgl_assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToCodeString());
+	mgl_assert(a.Distance(b) == 0.f);
+	mgl_assert(b.Distance(a) == 0.f);
+	mgl_assert4(a.Contains(a.ClosestPoint(b)), a.SerializeToCodeString(), b.SerializeToCodeString(), a.ClosestPoint(b).SerializeToCodeString(), a.Distance(a.ClosestPoint(b)));
+	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 UNIQUE_TEST(PlanePlaneIntersectCase)
 {
 	Plane a(DIR_VEC(-9.31284958e-005f,0.896122217f,-0.44380734f).Normalized(),-63.5531387f);
 	Plane b(DIR_VEC(0.0797545761f,-0.9964259f,0.0185146127f).Normalized(),45.0416794f);
-	assert(a.Intersects(b));
-	assert(b.Intersects(a));
+	mgl_assert(a.Intersects(b));
+	mgl_assert(b.Intersects(a));
 }
 
 RANDOMIZED_TEST(PlanePlaneIntersect)
@@ -1715,14 +1715,14 @@ RANDOMIZED_TEST(PlanePlaneIntersect)
 		a.d = b.d; // Avoid floating-point imprecision issues in the test: if plane normals are equal, make sure the planes are parallel.
 	if (a.normal.Equals(-b.normal))
 		a.d = -b.d;
-	assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
-	assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToCodeString());
-//	assert(a.Distance(b) == 0.f);
-//	assert(b.Distance(a) == 0.f);
-//	assert(a.Contains(a.ClosestPoint(b)));
-//	assert(b.Contains(a.ClosestPoint(b)));
-//	assert(a.Contains(b.ClosestPoint(a)));
-//	assert(b.Contains(b.ClosestPoint(a)));
+	mgl_assert2(a.Intersects(b), a.SerializeToCodeString(), b.SerializeToCodeString());
+	mgl_assert2(b.Intersects(a), b.SerializeToCodeString(), a.SerializeToCodeString());
+//	mgl_assert(a.Distance(b) == 0.f);
+//	mgl_assert(b.Distance(a) == 0.f);
+//	mgl_assert(a.Contains(a.ClosestPoint(b)));
+//	mgl_assert(b.Contains(a.ClosestPoint(b)));
+//	mgl_assert(a.Contains(b.ClosestPoint(a)));
+//	mgl_assert(b.Contains(b.ClosestPoint(a)));
 }
 
 RANDOMIZED_TEST(RayTriangleMeshIntersect)
@@ -1734,8 +1734,8 @@ RANDOMIZED_TEST(RayTriangleMeshIntersect)
 	Ray b = RandomRayContainingPoint(pt);
 	float d = tm.IntersectRay(b);
 	MARK_UNUSED(d);
-	assert(d >= 0.f);
-	assert(IsFinite(d));
+	mgl_assert(d >= 0.f);
+	mgl_assert(IsFinite(d));
 }
 
 RANDOMIZED_TEST(RayKdTreeIntersect)
@@ -1750,11 +1750,11 @@ RANDOMIZED_TEST(RayKdTreeIntersect)
 	Ray b = RandomRayContainingPoint(pt);
 	TriangleKdTreeRayQueryNearestHitVisitor result;
 	t.RayQuery(b, result);
-	assert(result.rayT >= 0.f);
-	assert(result.rayT < FLOAT_INF);
-	assert(result.triangleIndex != KdTree<Triangle_storage>::BUCKET_SENTINEL);
-	assert(result.pos.IsFinite());
-	assert(result.barycentricUV.IsFinite());
+	mgl_assert(result.rayT >= 0.f);
+	mgl_assert(result.rayT < FLOAT_INF);
+	mgl_assert(result.triangleIndex != KdTree<Triangle_storage>::BUCKET_SENTINEL);
+	mgl_assert(result.pos.IsFinite());
+	mgl_assert(result.barycentricUV.IsFinite());
 }
 
 TEST(PolygonContains2D)
@@ -1768,7 +1768,7 @@ TEST(PolygonContains2D)
 	pol.p.push_back(POINT_VEC(xmax, ymax, z));
 	pol.p.push_back(POINT_VEC(xmin, ymax, z));
 
-	assert(pol.Contains(point));
+	mgl_assert(pol.Contains(point));
 }
 
 #if 0
@@ -1782,6 +1782,6 @@ UNIQUE_TEST(PolygonContainsPointCase2)
 
 	vec pt = POINT_VEC(1.f,0.0645294f,0);
 
-	assert(p.Contains(pt));
+	mgl_assert(p.Contains(pt));
 }
 #endif

--- a/tests/QuatTests.cpp
+++ b/tests/QuatTests.cpp
@@ -164,7 +164,7 @@ RANDOMIZED_TEST(Quat_SetFromAxisAngle)
 	Quat q, q2;
 	q.SetFromAxisAngle(axis, f);
 	q2.SetFromAxisAngle(axis4, f);
-	assert2(q.Equals(q2), q, q2);
+	mgl_assert2(q.Equals(q2), q, q2);
 }
 
 RANDOMIZED_TEST(Quat_Transform)
@@ -175,34 +175,34 @@ RANDOMIZED_TEST(Quat_Transform)
 	float3 mv = m*v;
 	float3 qv = q*v;
 	float3 qv2 = q.Transform(v);
-	assert(mv.Equals(qv));
-	assert(qv.Equals(qv2));
+	mgl_assert(mv.Equals(qv));
+	mgl_assert(qv.Equals(qv2));
 
 	float4 V(v, (float)rng.Int(0, 1));
 	float4x4 M = float4x4(q);
 	float4 MV = M*V;
 	float4 qV = q*V;
 	float4 qV2 = q.Transform(V);
-	assert(MV.Equals(qV));
-	assert(MV.Equals(qV2));
+	mgl_assert(MV.Equals(qV));
+	mgl_assert(MV.Equals(qV2));
 }
 
 RANDOMIZED_TEST(Quat_float4x4_conv)
 {
 	Quat q = Quat::RandomRotation(rng);
 	float4x4 m = q.ToFloat4x4();
-	assert(m.TranslatePart().Equals(0,0,0));
-	assert(!m.ContainsProjection());
+	mgl_assert(m.TranslatePart().Equals(0,0,0));
+	mgl_assert(!m.ContainsProjection());
 	Quat q2 = m.Float3x3Part().ToQuat();
-	assert(q.Equals(q2) || q.Equals(q2.Neg()));
+	mgl_assert(q.Equals(q2) || q.Equals(q2.Neg()));
 
 	float4 v = float4::RandomGeneral(rng, -1000.f, 1000.f);
 	v.w = (float)rng.Int(0,1);
 	m = q.ToFloat4x4(v);
-	assert(m.TranslatePart().Equals(v.xyz()));
-	assert(!m.ContainsProjection());
+	mgl_assert(m.TranslatePart().Equals(v.xyz()));
+	mgl_assert(!m.ContainsProjection());
 	q2 = m.Float3x3Part().ToQuat();
-	assert(q.Equals(q2) || q.Equals(q2.Neg()));
+	mgl_assert(q.Equals(q2) || q.Equals(q2.Neg()));
 }
 
 BENCHMARK(Quat_op_mul_Quat, "Quat * Quat")
@@ -255,8 +255,8 @@ RANDOMIZED_TEST(Quat_Mul_Quat)
 	float3x3 m = q.ToFloat3x3();
 	float3x3 m2 = q2.ToFloat3x3();
 	float4 v4 = m2*m*v;
-	assert(v2.Equals(v3));
-	assert(v2.Equals(v4));
+	mgl_assert(v2.Equals(v3));
+	mgl_assert(v2.Equals(v4));
 }
 
 RANDOMIZED_TEST(quat_mul_quat)
@@ -265,7 +265,7 @@ RANDOMIZED_TEST(quat_mul_quat)
 	Quat q2 = Quat::RandomRotation(rng);
 	Quat correct = Quat(q.ToFloat3x3() * q2.ToFloat3x3());
 	Quat q3 = quat_mul_quat(q.q, q2.q);
-	assert(q3.Equals(correct) || q3.Equals(correct.Neg()));
+	mgl_assert(q3.Equals(correct) || q3.Equals(correct.Neg()));
 }
 
 RANDOMIZED_TEST(Quat_ToAxisAngle_float3)
@@ -276,7 +276,7 @@ RANDOMIZED_TEST(Quat_ToAxisAngle_float3)
 	q.ToAxisAngle(axis, angle);
 	Quat q2;
 	q2.SetFromAxisAngle(axis, angle);
-	assert(q.Equals(q2));
+	mgl_assert(q.Equals(q2));
 }
 
 RANDOMIZED_TEST(Quat_ToAxisAngle_float4)
@@ -287,10 +287,10 @@ RANDOMIZED_TEST(Quat_ToAxisAngle_float4)
 	q.ToAxisAngle(axis, angle);
 
 	vec axis2 = q.Axis();
-	assert(axis2.xyz().Equals(axis.xyz()));
+	mgl_assert(axis2.xyz().Equals(axis.xyz()));
 	Quat q2;
 	q2.SetFromAxisAngle(axis, angle);
-	assert(q.Equals(q2));
+	mgl_assert(q.Equals(q2));
 }
 
 RANDOMIZED_TEST(Quat_RotateFromTo_float3)
@@ -299,7 +299,7 @@ RANDOMIZED_TEST(Quat_RotateFromTo_float3)
 	float3 v2 = float3::RandomDir(rng);
 	Quat rot = Quat::RotateFromTo(v, v2);
 	float3 v2_ = rot * v;
-	assert2(v2.Equals(v2_), v2, v2_);
+	mgl_assert2(v2.Equals(v2_), v2, v2_);
 }
 
 RANDOMIZED_TEST(Quat_RotateFromTo_float4)
@@ -308,7 +308,7 @@ RANDOMIZED_TEST(Quat_RotateFromTo_float4)
 	float4 v2 = float4::RandomDir(rng);
 	Quat rot = Quat::RotateFromTo(v, v2);
 	float4 v2_ = rot * v;
-	assert2(v2.Equals(v2_), v2, v2_);
+	mgl_assert2(v2.Equals(v2_), v2, v2_);
 }
 
 TEST(QuatNormalize)
@@ -316,30 +316,30 @@ TEST(QuatNormalize)
 	Quat q(-1.f, 2.f, 3.f, 4.f);
 	float oldLength = q.Normalize();
 	MARK_UNUSED(oldLength);
-	assertcmp(oldLength, >, 0);
-	assert(EqualAbs(q.x, -1.f / Sqrt(30.f)));
-	assert(EqualAbs(q.y, 2.f / Sqrt(30.f)));
-	assert(EqualAbs(q.z, 3.f / Sqrt(30.f)));
-	assert(EqualAbs(q.w, 4.f / Sqrt(30.f)));
+	mgl_assertcmp(oldLength, >, 0);
+	mgl_assert(EqualAbs(q.x, -1.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(q.y, 2.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(q.z, 3.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(q.w, 4.f / Sqrt(30.f)));
 
 	Quat q2(0,0,0, 0.f);
 	oldLength = q2.Normalize();
 	MARK_UNUSED(oldLength);
-	assert(oldLength == 0.f);
-	assert(q2.x == 1.f);
-	assert(q2.y == 0.f);
-	assert(q2.z == 0.f);
-	assert(q2.w == 0.f);
+	mgl_assert(oldLength == 0.f);
+	mgl_assert(q2.x == 1.f);
+	mgl_assert(q2.y == 0.f);
+	mgl_assert(q2.z == 0.f);
+	mgl_assert(q2.w == 0.f);
 }
 
 TEST(QuatNormalized)
 {
 	Quat q(-1.f, 2.f, 3.f, -4.f);
 	Quat q2 = q.Normalized();
-	assert(EqualAbs(q2.x, -1.f / Sqrt(30.f)));
-	assert(EqualAbs(q2.y, 2.f / Sqrt(30.f)));
-	assert(EqualAbs(q2.z, 3.f / Sqrt(30.f)));
-	assert(EqualAbs(q2.w, -4.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(q2.x, -1.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(q2.y, 2.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(q2.z, 3.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(q2.w, -4.f / Sqrt(30.f)));
 }
 
 #ifdef ANDROID
@@ -350,7 +350,7 @@ RANDOMIZED_TEST(quat_mul_quat_asm)
 	Quat correct = q * q2;
 	Quat q3;
 	quat_mul_quat_asm(q.ptr(), q2.ptr(), q3.ptr());
-	assert(q3.Equals(correct));
+	mgl_assert(q3.Equals(correct));
 }
 #endif
 
@@ -367,7 +367,7 @@ RANDOMIZED_TEST(quat_div_quat)
 	Quat q2 = Quat::RandomRotation(rng);
 	Quat correct = q / q2;
 	Quat q3 = quat_div_quat(q.q, q2.q);
-	assert(q3.Equals(correct));
+	mgl_assert(q3.Equals(correct));
 }
 #endif
 BENCHMARK(quat_lerp_simd, "test against Quat_Lerp")
@@ -384,7 +384,7 @@ RANDOMIZED_TEST(quat_lerp)
 	float t = rng.Float();
 	Quat correct = q.Lerp(q2, t);
 	Quat q3 = vec4_lerp(q.q, q2.q, t);
-	assert2(q3.Equals(correct), q3, correct);
+	mgl_assert2(q3.Equals(correct), q3, correct);
 }
 */
 

--- a/tests/SAT2DTests.cpp
+++ b/tests/SAT2DTests.cpp
@@ -37,7 +37,7 @@ RANDOMIZED_TEST(Poly2D_Poly2D_Intersect)
 {
 	std::vector<float2> p1 = GenerateRandomPolygonContainingPt(rng, rng.Int(3, 10), float2::zero, 10.f);
 	std::vector<float2> p2 = GenerateRandomPolygonContainingPt(rng, rng.Int(3, 10), float2::zero, 10.f);
-	assert(SATCollide2D(&p1[0], (int)p1.size(), &p2[0], (int)p2.size()));
+	mgl_assert(SATCollide2D(&p1[0], (int)p1.size(), &p2[0], (int)p2.size()));
 }
 
 BENCHMARK(Poly2D_Poly2D_Intersect, "Poly2D-Poly2D SAT positive collision")
@@ -51,7 +51,7 @@ RANDOMIZED_TEST(Poly2D_Poly2D_NoIntersect)
 {
 	std::vector<float2> p1 = GenerateRandomPolygonContainingPt(rng, rng.Int(3, 10), float2::zero, 10.f);
 	std::vector<float2> p2 = GenerateRandomPolygonContainingPt(rng, rng.Int(3, 10), float2::RandomDir(rng) * 50.f, 10.f);
-	assert(!SATCollide2D(&p1[0], (int)p1.size(), &p2[0], (int)p2.size()));
+	mgl_assert(!SATCollide2D(&p1[0], (int)p1.size(), &p2[0], (int)p2.size()));
 }
 
 BENCHMARK(Poly2D_Poly2D_NoIntersect, "Poly2D-Poly2D SAT no collision")

--- a/tests/SSEMathTests.cpp
+++ b/tests/SSEMathTests.cpp
@@ -386,7 +386,7 @@ RANDOMIZED_TEST(mat4x4_mul_avx)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = mat4x4_mul_avx((__m256*)&m, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 BENCHMARK(mat4x4_mul_avx_2, "test against float4x4_mul_float4")
@@ -401,7 +401,7 @@ RANDOMIZED_TEST(mat4x4_mul_avx_2)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = mat4x4_mul_avx_2((__m256*)&m, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 #endif // ~AVX
@@ -434,7 +434,7 @@ RANDOMIZED_TEST(mat4x4_mul_sse41)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = mat4x4_mul_sse41(m.row, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 #endif
@@ -453,7 +453,7 @@ RANDOMIZED_TEST(mat4x4_mul_sse3)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = mat4x4_mul_sse3(m.row, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 #endif
@@ -472,7 +472,7 @@ RANDOMIZED_TEST(mat4x4_mul_sse1)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = mat4x4_mul_sse1(m.row, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 BENCHMARK(colmajor_mat4x4_mul_sse1, "test against float4x4_mul_float4")
@@ -488,7 +488,7 @@ RANDOMIZED_TEST(colmajor_mat4x4_mul_sse1)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = colmajor_mat4x4_mul_sse1(tpm.row, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 #ifdef MATH_AVX
@@ -506,7 +506,7 @@ RANDOMIZED_TEST(colmajor_mat4x4_mul_avx)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = colmajor_mat4x4_mul_avx(tpm.row2, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 BENCHMARK(colmajor_mat4x4_mul_avx_2, "test against float4x4_mul_float4")
@@ -522,7 +522,7 @@ RANDOMIZED_TEST(colmajor_mat4x4_mul_avx_2)
 	float4 v = float4::RandomGeneral(rng, -10.f, 10.f);
 	float4 res = colmajor_mat4x4_mul_avx_2(tpm.row2, v);
 	float4 res2 = m*v;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 #endif
@@ -540,7 +540,7 @@ RANDOMIZED_TEST(mat4x4_mul_dpps)
 	float4x4 res;
 	mat4x4_mul_dpps(res.row, m.row, m2.row);
 	float4x4 res2 = m*m2;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 BENCHMARK(mat4x4_mul_dpps_2, "test against float4x4_op_mul")
@@ -556,7 +556,7 @@ RANDOMIZED_TEST(mat4x4_mul_dpps_2)
 	float4x4 res;
 	mat4x4_mul_dpps_2(res.row, m.row, m2.row);
 	float4x4 res2 = m*m2;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 BENCHMARK(mat4x4_mul_dpps_3, "test against float4x4_op_mul")
@@ -572,7 +572,7 @@ RANDOMIZED_TEST(mat4x4_mul_dpps_3)
 	float4x4 res;
 	mat4x4_mul_dpps_3(res.row, m.row, m2.row);
 	float4x4 res2 = m*m2;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 #ifdef MATH_FMA
@@ -631,7 +631,7 @@ RANDOMIZED_TEST(mat4x4_mul_fma)
 	float4x4 res;
 	mat4x4_mul_fma(res.row, m.row, m2.row);
 	float4x4 res2 = m*m2;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 #endif
 
@@ -648,7 +648,7 @@ RANDOMIZED_TEST(mat4x4_mul_sse)
 	float4x4 res;
 	mat4x4_mul_sse(res.row, m.row, m2.row);
 	float4x4 res2 = m*m2;
-	assert(res.Equals(res2));
+	mgl_assert(res.Equals(res2));
 }
 
 #endif

--- a/tests/SerializationTests.cpp
+++ b/tests/SerializationTests.cpp
@@ -31,10 +31,10 @@ UNIQUE_TEST(StartupLocale)
 		LOGI("This locale setup is appropriate for string serialization.");
 	else
 		LOGI("This locale setup is NOT appropriate for string serialization!");
-	assert(isGoodLocale);
+	mgl_assert(isGoodLocale);
 }
 
-#define assertveq(a,b) if (!(a).Equals((b))) { LOGE("%s != %s (%s != %s)", #a, #b, (a).ToString().c_str(), (b).ToString().c_str()); } assert((a).Equals(b));
+#define assertveq(a,b) if (!(a).Equals((b))) { LOGE("%s != %s (%s != %s)", #a, #b, (a).ToString().c_str(), (b).ToString().c_str()); } mgl_assert((a).Equals(b));
 
 TEST(Float2FromString)
 {
@@ -150,7 +150,7 @@ RANDOMIZED_TEST(SerializeFloat)
 	SerializeFloat(f, str);
 	float f2 = DeserializeFloat(str);
 	u32 u2 = ReinterpretAsU32(f2);
-	assert4(u == u2, u, u2, f, f2);
+	mgl_assert4(u == u2, u, u2, f, f2);
 }
 
 #define LARGESCALE 1e8f
@@ -161,17 +161,17 @@ RANDOMIZED_TEST(float2_Serialize)
 
 	std::string s = o.SerializeToString();
 	float2 o2 = float2::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.SerializeToCodeString();
 	o2 = float2::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.ToString();
 	o2 = float2::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(float3_Serialize)
@@ -180,17 +180,17 @@ RANDOMIZED_TEST(float3_Serialize)
 
 	std::string s = o.SerializeToString();
 	float3 o2 = float3::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.SerializeToCodeString();
 	o2 = float3::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.ToString();
 	o2 = float3::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(float4_Serialize)
@@ -199,17 +199,17 @@ RANDOMIZED_TEST(float4_Serialize)
 
 	std::string s = o.SerializeToString();
 	float4 o2 = float4::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.SerializeToCodeString();
 	o2 = float4::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.ToString();
 	o2 = float4::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Quat_Serialize)
@@ -219,17 +219,17 @@ RANDOMIZED_TEST(Quat_Serialize)
 
 	std::string s = o.SerializeToString();
 	Quat o2 = Quat::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.SerializeToCodeString();
 	o2 = Quat::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.ToString();
 	o2 = Quat::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(AABB_Serialize)
@@ -238,17 +238,17 @@ RANDOMIZED_TEST(AABB_Serialize)
 	AABB o = RandomAABBContainingPoint(pt, LARGESCALE);
 	std::string s = o.SerializeToString();
 	AABB o2 = AABB::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.SerializeToCodeString();
 	o2 = AABB::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.ToString();
 	o2 = AABB::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(OBB_Serialize)
@@ -257,17 +257,17 @@ RANDOMIZED_TEST(OBB_Serialize)
 	OBB o = RandomOBBContainingPoint(pt, LARGESCALE);
 	std::string s = o.SerializeToString();
 	OBB o2 = OBB::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.SerializeToCodeString();
 	o2 = OBB::FromString(s);
-	assert(o.Equals(o2));
-	assert(o.BitEquals(o2));
+	mgl_assert(o.Equals(o2));
+	mgl_assert(o.BitEquals(o2));
 
 	s = o.ToString();
 	o2 = OBB::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Sphere_Serialize)
@@ -276,17 +276,17 @@ RANDOMIZED_TEST(Sphere_Serialize)
 	Sphere o = RandomSphereContainingPoint(pt, SCALE);
 	std::string s = o.SerializeToString();
 	Sphere o2 = Sphere::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.SerializeToCodeString();
 	o2 = Sphere::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = Sphere::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Plane_Serialize)
@@ -295,17 +295,17 @@ RANDOMIZED_TEST(Plane_Serialize)
 	Plane o = RandomPlaneContainingPoint(pt);
 	std::string s = o.SerializeToString();
 	Plane o2 = Plane::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.SerializeToCodeString();
 	o2 = Plane::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = Plane::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Triangle_Serialize)
@@ -314,17 +314,17 @@ RANDOMIZED_TEST(Triangle_Serialize)
 	Triangle o = RandomTriangleContainingPoint(pt);
 	std::string s = o.SerializeToString();
 	Triangle o2 = Triangle::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.SerializeToCodeString();
 	o2 = Triangle::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = Triangle::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Ray_Serialize)
@@ -333,17 +333,17 @@ RANDOMIZED_TEST(Ray_Serialize)
 	Ray o = RandomRayContainingPoint(pt);
 	std::string s = o.SerializeToString();
 	Ray o2 = Ray::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.SerializeToCodeString();
 	o2 = Ray::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = Ray::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(LineSegment_Serialize)
@@ -352,17 +352,17 @@ RANDOMIZED_TEST(LineSegment_Serialize)
 	LineSegment o = RandomLineSegmentContainingPoint(pt);
 	std::string s = o.SerializeToString();
 	LineSegment o2 = LineSegment::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.SerializeToCodeString();
 	o2 = LineSegment::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = LineSegment::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Line_Serialize)
@@ -371,18 +371,18 @@ RANDOMIZED_TEST(Line_Serialize)
 	Line o = RandomLineContainingPoint(pt);
 	std::string s = o.SerializeToString();
 	Line o2 = Line::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.SerializeToCodeString();
 	o2 = Line::FromString(s);
-	assert(o.Equals(o2));
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert(o.Equals(o2));
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = Line::FromString(s);
 	o2.dir.Normalize();
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Capsule_Serialize)
@@ -391,17 +391,17 @@ RANDOMIZED_TEST(Capsule_Serialize)
 	Capsule o = RandomCapsuleContainingPoint(pt);
 	std::string s = o.SerializeToString();
 	Capsule o2 = Capsule::FromString(s);
-	assert2(o.Equals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert2(o.Equals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.SerializeToCodeString();
 	o2 = Capsule::FromString(s);
-	assert2(o.Equals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert2(o.Equals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = Capsule::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 }
 
 RANDOMIZED_TEST(Polygon_Serialize)
@@ -410,17 +410,17 @@ RANDOMIZED_TEST(Polygon_Serialize)
 	Polygon o = RandomPolygonContainingPoint(pt);
 	std::string s = o.SerializeToString();
 	Polygon o2 = Polygon::FromString(s);
-	assert2(o.Equals(o2), o.SerializeToString(), o2.SerializeToString());
-	assert2(o.BitEquals(o2), o.SerializeToString(), o2.SerializeToString());
+	mgl_assert2(o.Equals(o2), o.SerializeToString(), o2.SerializeToString());
+	mgl_assert2(o.BitEquals(o2), o.SerializeToString(), o2.SerializeToString());
 /*
 	s = o.SerializeToCodeString();
 	o2 = Polygon::FromString(s);
-	assert2(o.Equals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
-	assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert2(o.Equals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
+	mgl_assert2(o.BitEquals(o2), o.SerializeToCodeString(), o2.SerializeToCodeString());
 
 	s = o.ToString();
 	o2 = Polygon::FromString(s);
-	assert(o.Equals(o2, 0.1f));
+	mgl_assert(o.Equals(o2, 0.1f));
 */
 }
 
@@ -448,12 +448,12 @@ void test_double_to_string(double d, const char *d_in_src)
 #endif
 		LOGE("%.17g to str -> %s does not match:\nOriginal: %.17g (0x%s)\nExpected: %.17g (0x%s)\n   %d ulps difference!", d, s.c_str(), d1, U64Str(u1).c_str(), d2, U64Str(u2).c_str(), ulpsDifference);
 	}
-	assert(u1 == u2);
+	mgl_assert(u1 == u2);
 
 	if (d_in_src && strcmp(d_in_src, s.c_str()))// && strlen(d_in_src) < s.length())
 	{
 		LOGE("%.17g to str -> string does not match shortest representation:\nExpected: %s\nReceived: %s!", d1, d_in_src, s.c_str());
-		assert(false);
+		mgl_assert(false);
 	}
 }
 

--- a/tests/SphereTests.cpp
+++ b/tests/SphereTests.cpp
@@ -19,11 +19,11 @@ UNIQUE_TEST(Sphere_RandomPointOnSurface_small)
 {
 	Sphere s(POINT_VEC_SCALAR(10.f), 0.f);
 	vec v = s.RandomPointOnSurface(rng);
-	assert(v.Equals(10.f, 10.f, 10.f, 1.f));
+	mgl_assert(v.Equals(10.f, 10.f, 10.f, 1.f));
 
 	s = Sphere(POINT_VEC_SCALAR(10.f), 0.0001f);
 	v = s.RandomPointOnSurface(rng);
-	assert(v.Distance(POINT_VEC_SCALAR(10.f)) <= 0.0002f);
+	mgl_assert(v.Distance(POINT_VEC_SCALAR(10.f)) <= 0.0002f);
 }
 
 // Implement an alternative method for generating a random point on the surface of a Sphere that uses

--- a/tests/SystemInfoTests.cpp
+++ b/tests/SystemInfoTests.cpp
@@ -10,46 +10,46 @@
 UNIQUE_TEST(GetOSDisplayString)
 {
 	LOGI("OS: %s", GetOSDisplayString().c_str());
-	assert(GetOSDisplayString().length() > 0);
+	mgl_assert(GetOSDisplayString().length() > 0);
 }
 
 UNIQUE_TEST(GetTotalSystemPhysicalMemory)
 {
 	int mbytes = (int)(GetTotalSystemPhysicalMemory() / 1024 / 1024);
 	LOGI("Physical Memory: %d MBytes.", mbytes);
-	assert(mbytes > 0);
-	assert(mbytes < 128 * 1024); // Arbitrary cap on large values.
+	mgl_assert(mbytes > 0);
+	mgl_assert(mbytes < 128 * 1024); // Arbitrary cap on large values.
 }
 
 UNIQUE_TEST(GetProcessorBrandName)
 {
 	LOGI("Processor: %s", GetProcessorBrandName().c_str());
-	assert(GetProcessorBrandName().length() > 0);
+	mgl_assert(GetProcessorBrandName().length() > 0);
 }
 
 UNIQUE_TEST(GetProcessorCPUIDString)
 {
 	LOGI("CPUID: %s", GetProcessorCPUIDString().c_str());
-	assert(GetProcessorCPUIDString().length() > 0);
+	mgl_assert(GetProcessorCPUIDString().length() > 0);
 }
 
 UNIQUE_TEST(GetProcessorExtendedCPUIDInfo)
 {
 	LOGI("Extended CPU Info: %s", GetProcessorExtendedCPUIDInfo().c_str());
-	assert(GetProcessorExtendedCPUIDInfo().length() > 0);
+	mgl_assert(GetProcessorExtendedCPUIDInfo().length() > 0);
 }
 
 UNIQUE_TEST(GetCPUSpeedFromRegistry)
 {
 	LOGI("CPU Speed: %d MHz", (int)GetCPUSpeedFromRegistry(0));
-	assert((int)GetCPUSpeedFromRegistry(0) > 0);
-	assert((int)GetCPUSpeedFromRegistry(0) < 32 * 1024); // Arbitrary cap on large values.
+	mgl_assert((int)GetCPUSpeedFromRegistry(0) > 0);
+	mgl_assert((int)GetCPUSpeedFromRegistry(0) < 32 * 1024); // Arbitrary cap on large values.
 }
 
 UNIQUE_TEST(GetMaxSimultaneousThreads)
 {
 	LOGI("Maximum number of simultaneous threads (number of logical cores): %d", GetMaxSimultaneousThreads());
-	assert(GetMaxSimultaneousThreads() > 0);
+	mgl_assert(GetMaxSimultaneousThreads() > 0);
 }
 
 #ifdef __EMSCRIPTEN__

--- a/tests/TransformTests.cpp
+++ b/tests/TransformTests.cpp
@@ -9,32 +9,32 @@ TEST(TranslateOp)
 	float3x4 tm = float3x4::Translate(1,2,3);
 	float3x4 tm2;
 	tm2 = float3x4::Translate(1,2,3);
-	assert(tm.Equals(tm2));
-	assert(tm.TranslatePart().Equals(1,2,3));
-	assert(tm.Float3x3Part().IsIdentity());
+	mgl_assert(tm.Equals(tm2));
+	mgl_assert(tm.TranslatePart().Equals(1,2,3));
+	mgl_assert(tm.Float3x3Part().IsIdentity());
 
 	float4x4 tm3 = float4x4::Translate(1,2,3);
 	float4x4 tm4;
 	tm4 = float4x4::Translate(1,2,3);
-	assert(tm4.Equals(tm3));
-	assert(tm3.TranslatePart().Equals(1,2,3));
-	assert(tm3.Float3x3Part().IsIdentity());
-	assert(tm3.Row(3).Equals(0,0,0,1));
+	mgl_assert(tm4.Equals(tm3));
+	mgl_assert(tm3.TranslatePart().Equals(1,2,3));
+	mgl_assert(tm3.Float3x3Part().IsIdentity());
+	mgl_assert(tm3.Row(3).Equals(0,0,0,1));
 }
 
 RANDOMIZED_TEST(TranslateOpMul)
 {
 	TranslateOp t = float3x4::Translate(float3::RandomBox(rng, 0.f, 100.f));
 	float4x4 tm = t.ToFloat4x4();
-	assert(tm.TranslatePart().Equals(t.offset.xyz()));
+	mgl_assert(tm.TranslatePart().Equals(t.offset.xyz()));
 	float4x4 m = float4x4::RandomGeneral(rng, -100.f, 100.f);
 	m.SetRow(3, 0.f, 0.f, 0.f, 1.f);
 
 	float4x4 m1 = t * m;
 	float4x4 m2 = tm * m;
-	assert2(m1.Equals(m2), m1, m2);
+	mgl_assert2(m1.Equals(m2), m1, m2);
 
 	m1 = m * t;
 	m2 = m * tm;
-	assert2(m1.Equals(m2), m1, m2);
+	mgl_assert2(m1.Equals(m2), m1, m2);
 }

--- a/tests/TriangleTests.cpp
+++ b/tests/TriangleTests.cpp
@@ -25,7 +25,7 @@ UNIQUE_TEST(Triangle_Intersects_AABB_Case)
 		POINT_VEC(-2.0f, -2.0f, -2.0f),
 		POINT_VEC(2.0f, 2.0f, 2.0f));
 
-	assert(triangle.Intersects(aabb));
+	mgl_assert(triangle.Intersects(aabb));
 }
 
 UNIQUE_TEST(Triangle_Intersects_AABB_Case2)
@@ -41,7 +41,7 @@ UNIQUE_TEST(Triangle_Intersects_AABB_Case2)
 		POINT_VEC(-1.0f, -1.0f, -1.0f),
 		POINT_VEC(0.0f, 0.0f, 0.0f));
 
-	assert(!triangle.Intersects(aabb));
+	mgl_assert(!triangle.Intersects(aabb));
 }
 
 UNIQUE_TEST(Triangle_Intersects_AABB_Case3)
@@ -57,5 +57,5 @@ UNIQUE_TEST(Triangle_Intersects_AABB_Case3)
 		POINT_VEC(-10.0f, -10.0f, -1.0f),
 		POINT_VEC(10.0f, 10.0f, 0.0f));
 
-	assert(!triangle.Intersects(aabb));
+	mgl_assert(!triangle.Intersects(aabb));
 }

--- a/tests/VectorTests.cpp
+++ b/tests/VectorTests.cpp
@@ -19,7 +19,7 @@ TEST(Float4Swizzled)
 	float4 f(float2(1,2),3,4);
 	float4 f2 = f.Swizzled(2,0,1,3);
 	float f3[4] = { 3, 1, 2, 4 };
-	assert(f2.Equals(float4(f3)));
+	mgl_assert(f2.Equals(float4(f3)));
 	MARK_UNUSED(f3);
 }
 
@@ -29,7 +29,7 @@ TEST(vec4_permute)
 	float4 f(float2(1,2),3,4);
 	float4 f2 = vec4_permute(f, 2, 0, 1, 3);
 	float f3[4] = { 3, 1, 2, 4 };
-	assert(f2.Equals(float4(f3)));
+	mgl_assert(f2.Equals(float4(f3)));
 	MARK_UNUSED(f3);
 }
 
@@ -50,57 +50,57 @@ BENCHMARK_END
 TEST(Float4LengthSq3)
 {
 	float4 f(-1.f,2.f,3.f,1000000.f);
-	assert(EqualAbs(f.LengthSq3(), 14.f));
+	mgl_assert(EqualAbs(f.LengthSq3(), 14.f));
 }
 
 TEST(Float4Length3)
 {
 	float4 f(-1.f,2.f,3.f,1000000.f);
-	assert(EqualAbs(f.Length3(), Sqrt(14.f)));
+	mgl_assert(EqualAbs(f.Length3(), Sqrt(14.f)));
 }
 
 TEST(Float4LengthSq4)
 {
 	float4 f(-1.f,2.f,3.f,-4.f);
-	assert(EqualAbs(f.LengthSq4(), 30.f));
+	mgl_assert(EqualAbs(f.LengthSq4(), 30.f));
 }
 
 TEST(Float4Length4)
 {
 	float4 f(-1.f,2.f,3.f,-4.f);
-	assert(EqualAbs(f.Length4(), Sqrt(30.f)));
+	mgl_assert(EqualAbs(f.Length4(), Sqrt(30.f)));
 }
 
 TEST(Float4Normalize3)
 {
 	float4 f(-1.f, 2.f, 3.f, 1000.f);
 	float oldLength = f.Normalize3();
-	assert(oldLength > 0.f);
+	mgl_assert(oldLength > 0.f);
 	MARK_UNUSED(oldLength);
-	assert(EqualAbs(f.x, -1.f / Sqrt(14.f)));
-	assert(EqualAbs(f.y, 2.f / Sqrt(14.f)));
-	assert(EqualAbs(f.z, 3.f / Sqrt(14.f)));
-	assert(EqualAbs(f.w, 1000.f));
+	mgl_assert(EqualAbs(f.x, -1.f / Sqrt(14.f)));
+	mgl_assert(EqualAbs(f.y, 2.f / Sqrt(14.f)));
+	mgl_assert(EqualAbs(f.z, 3.f / Sqrt(14.f)));
+	mgl_assert(EqualAbs(f.w, 1000.f));
 
 	float4 f2(0,0,0, 1000.f);
 	oldLength = f2.Normalize3();
 	MARK_UNUSED(oldLength);
-	assert(oldLength == 0.f);
-	assert(f2.x == 1.f);
-	assert(f2.y == 0.f);
-	assert(f2.z == 0.f);
-	assert(f2.w == 1000.f);
+	mgl_assert(oldLength == 0.f);
+	mgl_assert(f2.x == 1.f);
+	mgl_assert(f2.y == 0.f);
+	mgl_assert(f2.z == 0.f);
+	mgl_assert(f2.w == 1000.f);
 }
 
 TEST(Float4Normalized3)
 {
 	float4 f(-1.f, 2.f, 3.f, 1000.f);
 	float4 f2 = f.Normalized3();
-	assert4(EqualAbs(f2.x, -1.f / Sqrt(14.f)), f, f2, -1.f / Sqrt(14.f), f2.LengthSq3());
-	assert(EqualAbs(f2.y, 2.f / Sqrt(14.f)));
-	assert(EqualAbs(f2.z, 3.f / Sqrt(14.f)));
-	assert(EqualAbs(f2.w, 1000.f));
-	assert1(EqualAbs(f2.LengthSq3(), 1.f), f2.LengthSq3());
+	mgl_assert4(EqualAbs(f2.x, -1.f / Sqrt(14.f)), f, f2, -1.f / Sqrt(14.f), f2.LengthSq3());
+	mgl_assert(EqualAbs(f2.y, 2.f / Sqrt(14.f)));
+	mgl_assert(EqualAbs(f2.z, 3.f / Sqrt(14.f)));
+	mgl_assert(EqualAbs(f2.w, 1000.f));
+	mgl_assert1(EqualAbs(f2.LengthSq3(), 1.f), f2.LengthSq3());
 }
 
 TEST(Float4Normalize4)
@@ -108,44 +108,44 @@ TEST(Float4Normalize4)
 	float4 f(-1.f, 2.f, 3.f, 4.f);
 	float oldLength = f.Normalize4();
 	MARK_UNUSED(oldLength);
-	assertcmp(oldLength, >, 0);
-	assert(EqualAbs(f.x, -1.f / Sqrt(30.f)));
-	assert(EqualAbs(f.y, 2.f / Sqrt(30.f)));
-	assert(EqualAbs(f.z, 3.f / Sqrt(30.f)));
-	assert(EqualAbs(f.w, 4.f / Sqrt(30.f)));
+	mgl_assertcmp(oldLength, >, 0);
+	mgl_assert(EqualAbs(f.x, -1.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(f.y, 2.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(f.z, 3.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(f.w, 4.f / Sqrt(30.f)));
 
 	float4 f2(0,0,0, 0.f);
 	oldLength = f2.Normalize4();
 	MARK_UNUSED(oldLength);
-	assert(oldLength == 0.f);
-	assert(f2.x == 1.f);
-	assert(f2.y == 0.f);
-	assert(f2.z == 0.f);
-	assert(f2.w == 0.f);
+	mgl_assert(oldLength == 0.f);
+	mgl_assert(f2.x == 1.f);
+	mgl_assert(f2.y == 0.f);
+	mgl_assert(f2.z == 0.f);
+	mgl_assert(f2.w == 0.f);
 }
 
 TEST(Float4Normalized4)
 {
 	float4 f(-1.f, 2.f, 3.f, -4.f);
 	float4 f2 = f.Normalized4();
-	assert(EqualAbs(f2.x, -1.f / Sqrt(30.f)));
-	assert(EqualAbs(f2.y, 2.f / Sqrt(30.f)));
-	assert(EqualAbs(f2.z, 3.f / Sqrt(30.f)));
-	assert(EqualAbs(f2.w, -4.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(f2.x, -1.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(f2.y, 2.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(f2.z, 3.f / Sqrt(30.f)));
+	mgl_assert(EqualAbs(f2.w, -4.f / Sqrt(30.f)));
 }
 
 TEST(Float4NormalizeW)
 {
 	float4 f(-2.f, -4.f, 8.f, 2.f);
 	f.NormalizeW();
-	assert(f.Equals(float4(-1.f, -2.f, 4.f, 1.f)));
+	mgl_assert(f.Equals(float4(-1.f, -2.f, 4.f, 1.f)));
 }
 
 TEST(Float4Scale3)
 {
 	float4 f(-2.f, -4.f, 8.f, 1000.f);
 	f.Scale3(100.f);
-	assert(f.Equals(float4(-200.f, -400.f, 800.f, 1000.f)));
+	mgl_assert(f.Equals(float4(-200.f, -400.f, 800.f, 1000.f)));
 }
 
 TEST(Float4ScaleToLength3)
@@ -154,121 +154,121 @@ TEST(Float4ScaleToLength3)
 	float4 f2 = f.ScaledToLength3(10.f);
 	float oldLength = f.ScaleToLength3(10.f);
 	MARK_UNUSED(oldLength);
-	assert(f.Equals(f2));
-	assert(EqualAbs(oldLength, Sqrt(14.f)));
-	assert(EqualAbs(f.x, -1.f * 10.f / oldLength));
-	assert(EqualAbs(f.y, 2.f * 10.f / oldLength));
-	assert(EqualAbs(f.z, 3.f * 10.f / oldLength));
-	assert(EqualAbs(f.w, 1000.f));
+	mgl_assert(f.Equals(f2));
+	mgl_assert(EqualAbs(oldLength, Sqrt(14.f)));
+	mgl_assert(EqualAbs(f.x, -1.f * 10.f / oldLength));
+	mgl_assert(EqualAbs(f.y, 2.f * 10.f / oldLength));
+	mgl_assert(EqualAbs(f.z, 3.f * 10.f / oldLength));
+	mgl_assert(EqualAbs(f.w, 1000.f));
 }
 
 TEST(Float4SumOfElements)
 {
 	float4 f(-1.f, 4.f, 20.f, -100.f);
-	assert(EqualAbs(f.SumOfElements(), -77.f));
+	mgl_assert(EqualAbs(f.SumOfElements(), -77.f));
 }
 
 TEST(Float4ProductOfElements)
 {
 	float4 f(-1.f, 2.f, 4.f, -8.f);
-	assert(EqualAbs(f.ProductOfElements(), 64.f));
+	mgl_assert(EqualAbs(f.ProductOfElements(), 64.f));
 }
 
 TEST(Float4AverageOfElements)
 {
 	float4 f(-2.f, 2.f, 4.f, -8.f);
-	assert(EqualAbs(f.AverageOfElements(), -1.f));
+	mgl_assert(EqualAbs(f.AverageOfElements(), -1.f));
 }
 
 TEST(Float4Abs)
 {
 	float4 f(-2.f, 2.f, 4.f, -8.f);
-	assert(f.Abs().Equals(float4(2.f, 2.f, 4.f, 8.f)));
+	mgl_assert(f.Abs().Equals(float4(2.f, 2.f, 4.f, 8.f)));
 }
 
 TEST(Float4Neg3)
 {
 	float4 f(-2.f, 2.f, 4.f, -8.f);
-	assert(f.Neg3().Equals(float4(2.f, -2.f, -4.f, -8.f)));
+	mgl_assert(f.Neg3().Equals(float4(2.f, -2.f, -4.f, -8.f)));
 }
 
 TEST(Float4Neg4)
 {
 	float4 f(-2.f, 2.f, 4.f, -8.f);
-	assert(f.Neg4().Equals(float4(2.f, -2.f, -4.f, 8.f)));
+	mgl_assert(f.Neg4().Equals(float4(2.f, -2.f, -4.f, 8.f)));
 }
 
 TEST(Float4Recip3)
 {
 	float4 f(-1.f, 2.f, 4.f, -8.f);
-	assert(f.Recip3().Equals(float4(-1.f, 0.5f, 0.25f, -8.f)));
+	mgl_assert(f.Recip3().Equals(float4(-1.f, 0.5f, 0.25f, -8.f)));
 }
 
 TEST(Float4Recip4)
 {
 	float4 f(-1.f, 2.f, 4.f, -8.f);
-	assert(f.Recip4().Equals(float4(-1.f, 0.5f, 0.25f, -0.125f)));
+	mgl_assert(f.Recip4().Equals(float4(-1.f, 0.5f, 0.25f, -0.125f)));
 }
 
 TEST(Float4RecipFast4)
 {
 	float4 f(-1.f, 2.f, 4.f, -8.f);
-	assert(f.RecipFast4().Equals(float4(-1.f, 0.5f, 0.25f, -0.125f)));
+	mgl_assert(f.RecipFast4().Equals(float4(-1.f, 0.5f, 0.25f, -0.125f)));
 }
 
 TEST(Float4Min)
 {
 	float4 f(-1.f, 2.f, 4.f, -8.f);
-	assert(f.Min(-4.f).Equals(float4(-4.f, -4.f, -4.f, -8.f)));
-	assert(f.Min(float4(-3.f, 20.f, -2.f, 9.f)).Equals(-3.f, 2.f, -2.f, -8.f));
+	mgl_assert(f.Min(-4.f).Equals(float4(-4.f, -4.f, -4.f, -8.f)));
+	mgl_assert(f.Min(float4(-3.f, 20.f, -2.f, 9.f)).Equals(-3.f, 2.f, -2.f, -8.f));
 }
 
 TEST(Float4Max)
 {
 	float4 f(-1.f, 2.f, 4.f, -8.f);
-	assert(f.Max(-4.f).Equals(float4(-1.f, 2.f, 4.f, -4.f)));
-	assert(f.Max(float4(-3.f, 20.f, -2.f, 9.f)).Equals(-1.f, 20.f, 4.f, 9.f));
+	mgl_assert(f.Max(-4.f).Equals(float4(-1.f, 2.f, 4.f, -4.f)));
+	mgl_assert(f.Max(float4(-3.f, 20.f, -2.f, 9.f)).Equals(-1.f, 20.f, 4.f, 9.f));
 }
 
 TEST(Float4Clamp)
 {
 	float4 f(-1.f, 2.f, 4.f, -8.f);
-	assert(f.Clamp(-2.f, 2.f).Equals(float4(-1.f, 2.f, 2.f, -2.f)));
-	assert(f.Clamp(float4(0.f, -1.f, -10.f, -8.f), float4(10.f, 0.f, 10.f, -8.f)).Equals(float4(0.f, 0.f, 4.f, -8.f)));
+	mgl_assert(f.Clamp(-2.f, 2.f).Equals(float4(-1.f, 2.f, 2.f, -2.f)));
+	mgl_assert(f.Clamp(float4(0.f, -1.f, -10.f, -8.f), float4(10.f, 0.f, 10.f, -8.f)).Equals(float4(0.f, 0.f, 4.f, -8.f)));
 }
 
 TEST(Float4Clamp01)
 {
 	float4 f(-1.f, 0.f, 0.5f, 2.f);
-	assert(f.Clamp01().Equals(float4(0.f, 0.f, 0.5f, 1.f)));
+	mgl_assert(f.Clamp01().Equals(float4(0.f, 0.f, 0.5f, 1.f)));
 }
 
 TEST(Float4DistanceSq3)
 {
 	float4 f(1.f, 2.f, 3.f, 4.f);
 	float4 f2(-1.f, -2.f, -3.f, -4.f);
-	assert(EqualAbs(f.Distance3Sq(f2), 56.f));
+	mgl_assert(EqualAbs(f.Distance3Sq(f2), 56.f));
 }
 
 TEST(Float4Distance3)
 {
 	float4 f(1.f, 2.f, 3.f, 4.f);
 	float4 f2(-1.f, -2.f, -3.f, -4.f);
-	assert(EqualAbs(f.Distance3(f2), Sqrt(56.f)));
+	mgl_assert(EqualAbs(f.Distance3(f2), Sqrt(56.f)));
 }
 
 TEST(Float4DistanceSq4)
 {
 	float4 f(1.f, 2.f, 3.f, 4.f);
 	float4 f2(-1.f, -2.f, -3.f, -4.f);
-	assert(EqualAbs(f.Distance4Sq(f2), 120.f));
+	mgl_assert(EqualAbs(f.Distance4Sq(f2), 120.f));
 }
 
 TEST(Float4Distance4)
 {
 	float4 f(1.f, 2.f, 3.f, 4.f);
 	float4 f2(-1.f, -2.f, -3.f, -4.f);
-	assert(EqualAbs(f.Distance4(f2), Sqrt(120.f)));
+	mgl_assert(EqualAbs(f.Distance4(f2), Sqrt(120.f)));
 }
 
 TEST(Float4Dot3)
@@ -276,51 +276,51 @@ TEST(Float4Dot3)
 	float4 f(-1.f, 2.f, 3.f, -4.f);
 	float3 f2(2.f, -1.f, -3.f);
 	float4 f3(2.f, -1.f, 0.f, 4.f);
-	assert(EqualAbs(f.Dot3(f2), -13.f));
-	assert(EqualAbs(f.Dot3(f3), -4.f));
+	mgl_assert(EqualAbs(f.Dot3(f2), -13.f));
+	mgl_assert(EqualAbs(f.Dot3(f3), -4.f));
 }
 
 TEST(Float4Dot4)
 {
 	float4 f(-1.f, 2.f, 3.f, -4.f);
 	float4 f2(2.f, -1.f, 0.f, 4.f);
-	assert(EqualAbs(f.Dot4(f2), -20.f));
+	mgl_assert(EqualAbs(f.Dot4(f2), -20.f));
 }
 
 TEST(Float4Cross3)
 {
 	float4 f(-1.f, 2.f, 3.f, -4.f);
 	float4 f2(2.f, -1.f, 0.f, 4.f);
-	assert(f.Cross3(f2).Equals(f.Cross3(f2.xyz())));
+	mgl_assert(f.Cross3(f2).Equals(f.Cross3(f2.xyz())));
 
 	float4 f3 = f.Cross3(f2);
-	assert(f3.Equals(float4(3.f, 6.f, -3.f, 0.f)));
+	mgl_assert(f3.Equals(float4(3.f, 6.f, -3.f, 0.f)));
 
 	float4 z = float4::unitX.Cross3(float4::unitY);
 	float4 y = float4::unitZ.Cross3(float4::unitX);
 	float4 x = float4::unitY.Cross3(float4::unitZ);
-	assert(x.Equals(float4(1,0,0,0)));
-	assert(y.Equals(float4(0,1,0,0)));
-	assert(z.Equals(float4(0,0,1,0)));
+	mgl_assert(x.Equals(float4(1,0,0,0)));
+	mgl_assert(y.Equals(float4(0,1,0,0)));
+	mgl_assert(z.Equals(float4(0,0,1,0)));
 }
 
 TEST(Float4FromScalar)
 {
 	float4 f = float4::FromScalar(1.f);
-	assert(f.Equals(float4(1,1,1,1)));
+	mgl_assert(f.Equals(float4(1,1,1,1)));
 	f.SetFromScalar(-1.f);
-	assert(f.Equals(float4(-1,-1,-1,-1)));
+	mgl_assert(f.Equals(float4(-1,-1,-1,-1)));
 
 	float4 f2(3.f, 3.f, 3.f, -9.f);
 	f.SetFromScalar(3.f, -9.f);
-	assert(f.Equals(f2));
+	mgl_assert(f.Equals(f2));
 }
 
 TEST(Float4Set)
 {
 	float4 f = float4(1,2,3,4);
 	f.Set(5,6,7,8);
-	assert(f.Equals(float4(5,6,7,8)));
+	mgl_assert(f.Equals(float4(5,6,7,8)));
 }
 
 TEST(Float4OpAdd)
@@ -328,28 +328,28 @@ TEST(Float4OpAdd)
 	float4 f = float4(1,2,3,4);
 	float4 f2 = float4(-5.f, -6.f, -7.f, -8.f);
 	float4 f3 = f + f2;
-	assert(f3.Equals(float4(-4.f, -4.f, -4.f, -4.f)));
+	mgl_assert(f3.Equals(float4(-4.f, -4.f, -4.f, -4.f)));
 }
 
 TEST(Float2OpAddUnary)
 {
 	float2 f(1,2);
 	float2 g = +f;
-	assert(f.Equals(g));
+	mgl_assert(f.Equals(g));
 }
 
 TEST(Float3OpAddUnary)
 {
 	float3 f(1,2,3);
 	float3 g = +f;
-	assert(f.Equals(g));
+	mgl_assert(f.Equals(g));
 }
 
 TEST(Float4OpAddUnary)
 {
 	float4 f(1,2,3,4);
 	float4 g = +f;
-	assert(f.Equals(g));
+	mgl_assert(f.Equals(g));
 }
 
 TEST(Float4OpSub)
@@ -357,35 +357,35 @@ TEST(Float4OpSub)
 	float4 f = float4(1,2,3,4);
 	float4 f2 = float4(-5.f, -6.f, -7.f, -8.f);
 	float4 f3 = f - f2;
-	assert(f3.Equals(float4(6.f, 8.f, 10.f, 12.f)));
+	mgl_assert(f3.Equals(float4(6.f, 8.f, 10.f, 12.f)));
 }
 
 TEST(Float4OpNeg)
 {
 	float4 f = float4(1,2,3,4);
 	float4 f3 = -f;
-	assert(f3.Equals(float4(-1.f, -2.f, -3.f, -4.f)));
+	mgl_assert(f3.Equals(float4(-1.f, -2.f, -3.f, -4.f)));
 }
 
 TEST(Float4OpMul)
 {
 	float4 f = float4(1,2,3,4);
 	float scalar = -2.f;
-	
+
 	float4 f2 = f * scalar;
 	float4 f3 = scalar * f;
-	assert(f2.Equals(f3));
+	mgl_assert(f2.Equals(f3));
 
-	assert(f2.Equals(float4(-2.f, -4.f, -6.f, -8.f)));
+	mgl_assert(f2.Equals(float4(-2.f, -4.f, -6.f, -8.f)));
 }
 
 TEST(Float4OpDiv)
 {
 	float4 f = float4(1,2,4,8);
 	float scalar = -2.f;
-	
+
 	float4 f2 = f / scalar;
-	assert(f2.Equals(float4(-0.5f, -1.f, -2.f, -4.f)));
+	mgl_assert(f2.Equals(float4(-0.5f, -1.f, -2.f, -4.f)));
 }
 
 TEST(Float4OpAddAssign)
@@ -394,7 +394,7 @@ TEST(Float4OpAddAssign)
 	float4 f2 = float4(-5.f, -6.f, -7.f, -8.f);
 	float4 f3 = f;
 	f3 += f2;
-	assert(f3.Equals(float4(-4.f, -4.f, -4.f, -4.f)));
+	mgl_assert(f3.Equals(float4(-4.f, -4.f, -4.f, -4.f)));
 }
 
 TEST(Float4OpSubAssign)
@@ -403,27 +403,27 @@ TEST(Float4OpSubAssign)
 	float4 f2 = float4(-5.f, -6.f, -7.f, -8.f);
 	float4 f3 = f;
 	f3 -= f2;
-	assert(f3.Equals(float4(6.f, 8.f, 10.f, 12.f)));
+	mgl_assert(f3.Equals(float4(6.f, 8.f, 10.f, 12.f)));
 }
 
 TEST(Float4OpMulAssign)
 {
 	float4 f = float4(1,2,3,4);
 	float scalar = -2.f;
-	
+
 	float4 f2 = f;
 	f2 *= scalar;
-	assert(f2.Equals(float4(-2.f, -4.f, -6.f, -8.f)));
+	mgl_assert(f2.Equals(float4(-2.f, -4.f, -6.f, -8.f)));
 }
 
 TEST(Float4OpDivAssign)
 {
 	float4 f = float4(1,2,4,8);
 	float scalar = -2.f;
-	
+
 	float4 f2 = f;
 	f2 /= scalar;
-	assert(f2.Equals(float4(-0.5f, -1.f, -2.f, -4.f)));
+	mgl_assert(f2.Equals(float4(-0.5f, -1.f, -2.f, -4.f)));
 }
 
 TEST(Float4Add)
@@ -431,7 +431,7 @@ TEST(Float4Add)
 	float4 f = float4(1,2,3,4);
 	float scalar = 5.f;
 	float4 f2 = f.Add(scalar);
-	assert(f2.Equals(float4(6.f, 7.f, 8.f, 9.f)));
+	mgl_assert(f2.Equals(float4(6.f, 7.f, 8.f, 9.f)));
 }
 
 TEST(Float4Sub)
@@ -439,7 +439,7 @@ TEST(Float4Sub)
 	float4 f = float4(1,2,3,4);
 	float scalar = 5.f;
 	float4 f2 = f.Sub(scalar);
-	assert(f2.Equals(float4(-4.f, -3.f, -2.f, -1.f)));
+	mgl_assert(f2.Equals(float4(-4.f, -3.f, -2.f, -1.f)));
 }
 
 TEST(Float4SubLeft)
@@ -447,7 +447,7 @@ TEST(Float4SubLeft)
 	float4 f = float4(1,2,3,4);
 	float scalar = 5.f;
 	float4 f2 = f.SubLeft(scalar);
-	assert(f2.Equals(float4(4.f, 3.f, 2.f, 1.f)));
+	mgl_assert(f2.Equals(float4(4.f, 3.f, 2.f, 1.f)));
 }
 
 TEST(Float4DivLeft)
@@ -455,28 +455,28 @@ TEST(Float4DivLeft)
 	float4 f = float4(-1,2,4,8);
 	float scalar = -8.f;
 	float4 f2 = f.DivLeft(scalar);
-	assert(f2.Equals(float4(8.f, -4.f, -2.f, -1.f)));
+	mgl_assert(f2.Equals(float4(8.f, -4.f, -2.f, -1.f)));
 }
 
 TEST(Float4Mul)
 {
 	float4 f = float4(1,2,3,4);
 	float4 f2 = float4(-2.f, -4.f, 2.f, 1.f);
-	assert(f.Mul(f2).Equals(float4(-2.f, -8.f, 6.f, 4.f)));
+	mgl_assert(f.Mul(f2).Equals(float4(-2.f, -8.f, 6.f, 4.f)));
 }
 
 TEST(Float4Div)
 {
 	float4 f = float4(1,1,4,8);
 	float4 f2 = float4(-2.f, -4.f, 2.f, 1.f);
-	assert(f.Div(f2).Equals(float4(-0.5f, -0.25f, 2.f, 8.f)));
+	mgl_assert(f.Div(f2).Equals(float4(-0.5f, -0.25f, 2.f, 8.f)));
 }
 
 #ifdef MATH_SSE
 
 // Testing various strategies for loading a single 'float' scalar to a __m128.
 
-/* 	VS2010 with AVX generates, BAD! 
+/* 	VS2010 with AVX generates, BAD!
 	vmovss	xmm1, DWORD PTR [edx+eax*4]
 	vxorps	xmm0, xmm0, xmm0
 	vmovss	xmm0, xmm0, xmm1
@@ -893,7 +893,7 @@ RANDOMIZED_TEST(vec4_lerp)
 	float t = rng.Float();
 	float4 correct = f.Lerp(f2, t);
 	float4 f3 = vec4_lerp(f, f2, t);
-	assert(f3.Equals(correct));
+	mgl_assert(f3.Equals(correct));
 }
 
 #endif
@@ -902,9 +902,9 @@ TEST(float4_Lerp)
 {
 	float4 a(2,2,2,1);
 	float4 b(10,10,10,1);
-	assert(a.Lerp(b, 0.f).Equals(2,2,2,1));
-	assert(a.Lerp(b, 1.f).Equals(10,10,10,1));
-	assert(a.Lerp(b, 0.5f).Equals(6,6,6,1));
+	mgl_assert(a.Lerp(b, 0.f).Equals(2,2,2,1));
+	mgl_assert(a.Lerp(b, 1.f).Equals(10,10,10,1));
+	mgl_assert(a.Lerp(b, 0.5f).Equals(6,6,6,1));
 }
 
 // Test that copying uninitialized memory around is ok in the sense that it doesn't crash or assert:
@@ -1026,15 +1026,15 @@ RANDOMIZED_TEST(vec_PerpendicularBasis)
 		vec b, c;
 
 		a.PerpendicularBasis(b, c);
-		assert2(a.IsPerpendicular(b), a, b);
-		assert2(a.IsPerpendicular(c), a, c);
+		mgl_assert2(a.IsPerpendicular(b), a, b);
+		mgl_assert2(a.IsPerpendicular(c), a, c);
 
 		a.Normalize();
 		a.PerpendicularBasis(b, c);
-		assert2(a.IsPerpendicular(b), a, b);
-		assert2(a.IsPerpendicular(c), a, c);
-		assert1(b.IsNormalized(), b.Length());
-		assert1(c.IsNormalized(), c.Length());
+		mgl_assert2(a.IsPerpendicular(b), a, b);
+		mgl_assert2(a.IsPerpendicular(c), a, c);
+		mgl_assert1(b.IsNormalized(), b.Length());
+		mgl_assert1(c.IsNormalized(), c.Length());
 	}
 }
 
@@ -1172,13 +1172,13 @@ UNIQUE_TEST(float2_ConvexHull_Case)
 	float2 p[4] = { float2(-1, 0), float2(1,0), float2(0,1), float2(0,-1) };
 	float2 h[4] = { float2(-1, 0), float2(1,0), float2(0,1), float2(0,-1) };
 	int numPointsInConvexHull = float2::ConvexHullInPlace(h, 4);
-	assert(numPointsInConvexHull == 4);
+	mgl_assert(numPointsInConvexHull == 4);
 	MARK_UNUSED(numPointsInConvexHull);
 
 	for(int i = 0; i < numPointsInConvexHull; ++i)
-		assert(float2::ConvexHullContains(h, numPointsInConvexHull, p[i]));
+		mgl_assert(float2::ConvexHullContains(h, numPointsInConvexHull, p[i]));
 	MARK_UNUSED(p);
-	assert(float2::ConvexHullContains(h, numPointsInConvexHull, float2(0,0)));
+	mgl_assert(float2::ConvexHullContains(h, numPointsInConvexHull, float2(0,0)));
 }
 
 UNIQUE_TEST(float2_ConvexHull_Case2)
@@ -1189,11 +1189,11 @@ UNIQUE_TEST(float2_ConvexHull_Case2)
 	pts.push_back(float2(-44.626469, 113.405243));
 	pts.push_back(float2(-72.140152, 192.883652));
 	int numPointsInConvexHull = float2::ConvexHullInPlace(&pts[0], pts.size());
-	assert(numPointsInConvexHull == 4);
+	mgl_assert(numPointsInConvexHull == 4);
 	MARK_UNUSED(numPointsInConvexHull);
 
 	for(int i = 0; i < numPointsInConvexHull; ++i)
-		assert(float2::ConvexHullContains(&pts[0], numPointsInConvexHull, pts[i]));
+		mgl_assert(float2::ConvexHullContains(&pts[0], numPointsInConvexHull, pts[i]));
 }
 
 UNIQUE_TEST(float2_ConvexHull_Case3)
@@ -1204,11 +1204,11 @@ UNIQUE_TEST(float2_ConvexHull_Case3)
 	pts.push_back(float2(60.997635, -17.011709));
 	pts.push_back(float2(61.076935, -16.866882));
 	int numPointsInConvexHull = float2::ConvexHullInPlace(&pts[0], pts.size());
-	assert(numPointsInConvexHull == 3);
+	mgl_assert(numPointsInConvexHull == 3);
 	MARK_UNUSED(numPointsInConvexHull);
 
 	for(int i = 0; i < numPointsInConvexHull; ++i)
-		assert(float2::ConvexHullContains(&pts[0], numPointsInConvexHull, pts[i]));
+		mgl_assert(float2::ConvexHullContains(&pts[0], numPointsInConvexHull, pts[i]));
 }
 
 RANDOMIZED_TEST(float2_ConvexHull)
@@ -1220,11 +1220,11 @@ RANDOMIZED_TEST(float2_ConvexHull)
 		h[i] = p[i] = float2::RandomBox(rng, -100.f, 100.f);
 
 	int numPointsInConvexHull = float2::ConvexHullInPlace(h, n);
-	assert(numPointsInConvexHull >= 3);
+	mgl_assert(numPointsInConvexHull >= 3);
 	MARK_UNUSED(numPointsInConvexHull);
 
 	for(int i = 0; i < n; ++i)
-		assert(float2::ConvexHullContains(h, numPointsInConvexHull, p[i]));
+		mgl_assert(float2::ConvexHullContains(h, numPointsInConvexHull, p[i]));
 }
 
 BENCHMARK(float2_ConvexHull, "float2_ConvexHull")
@@ -1254,16 +1254,16 @@ UNIQUE_TEST(float2_MinAreaRect_Case)
 		float x = d.Dot(uDir);
 		diffUMin = MATH_NS::Min(diffUMin, x - minU);
 		diffUMax = MATH_NS::Min(diffUMax, maxU - x);
-		assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
+		mgl_assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
 		float y = d.Dot(vDir);
 		diffVMin = MATH_NS::Min(diffVMin, y - minV);
 		diffVMax = MATH_NS::Min(diffVMax, maxV - y);
-		assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
+		mgl_assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
 	}
-	assert1(diffUMin <= 1e-5f, diffUMin);
-	assert1(diffUMax <= 1e-5f, diffUMax);
-	assert1(diffVMin <= 1e-5f, diffVMin);
-	assert1(diffVMax <= 1e-5f, diffVMax);
+	mgl_assert1(diffUMin <= 1e-5f, diffUMin);
+	mgl_assert1(diffUMax <= 1e-5f, diffUMax);
+	mgl_assert1(diffVMin <= 1e-5f, diffVMin);
+	mgl_assert1(diffVMax <= 1e-5f, diffVMax);
 }
 
 UNIQUE_TEST(float2_MinAreaRect_Case_2)
@@ -1282,16 +1282,16 @@ UNIQUE_TEST(float2_MinAreaRect_Case_2)
 		float x = d.Dot(uDir);
 		diffUMin = MATH_NS::Min(diffUMin, x - minU);
 		diffUMax = MATH_NS::Min(diffUMax, maxU - x);
-		assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
+		mgl_assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
 		float y = d.Dot(vDir);
 		diffVMin = MATH_NS::Min(diffVMin, y - minV);
 		diffVMax = MATH_NS::Min(diffVMax, maxV - y);
-		assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
+		mgl_assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
 	}
-	assert1(diffUMin <= 1e-5f, diffUMin);
-	assert1(diffUMax <= 1e-5f, diffUMax);
-	assert1(diffVMin <= 1e-5f, diffVMin);
-	assert1(diffVMax <= 1e-5f, diffVMax);
+	mgl_assert1(diffUMin <= 1e-5f, diffUMin);
+	mgl_assert1(diffUMax <= 1e-5f, diffUMax);
+	mgl_assert1(diffVMin <= 1e-5f, diffVMin);
+	mgl_assert1(diffVMax <= 1e-5f, diffVMax);
 }
 
 UNIQUE_TEST(float2_MinAreaRect_Case_3)
@@ -1311,16 +1311,16 @@ UNIQUE_TEST(float2_MinAreaRect_Case_3)
 		float x = d.Dot(uDir);
 		diffUMin = MATH_NS::Min(diffUMin, x - minU);
 		diffUMax = MATH_NS::Min(diffUMax, maxU - x);
-		assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
+		mgl_assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
 		float y = d.Dot(vDir);
 		diffVMin = MATH_NS::Min(diffVMin, y - minV);
 		diffVMax = MATH_NS::Min(diffVMax, maxV - y);
-		assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
+		mgl_assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
 	}
-	assert1(diffUMin <= 1e-5f, diffUMin);
-	assert1(diffUMax <= 1e-5f, diffUMax);
-	assert1(diffVMin <= 1e-5f, diffVMin);
-	assert1(diffVMax <= 1e-5f, diffVMax);
+	mgl_assert1(diffUMin <= 1e-5f, diffUMin);
+	mgl_assert1(diffUMax <= 1e-5f, diffUMax);
+	mgl_assert1(diffVMin <= 1e-5f, diffVMin);
+	mgl_assert1(diffVMax <= 1e-5f, diffVMax);
 }
 
 UNIQUE_TEST(float2_MinAreaRect_Case_4)
@@ -1343,7 +1343,7 @@ UNIQUE_TEST(float2_MinAreaRect_Case_4)
 	int numPointsInConvexHull = float2::ConvexHullInPlace(c, n);
 
 	for(int i = 0; i < n; ++i)
-		assert(float2::ConvexHullContains(c, numPointsInConvexHull, p[i]));
+		mgl_assert(float2::ConvexHullContains(c, numPointsInConvexHull, p[i]));
 	MARK_UNUSED(numPointsInConvexHull);
 
 	float2 center, uDir, vDir;
@@ -1358,16 +1358,16 @@ UNIQUE_TEST(float2_MinAreaRect_Case_4)
 		float x = d.Dot(uDir);
 		diffUMin = MATH_NS::Min(diffUMin, x - minU);
 		diffUMax = MATH_NS::Min(diffUMax, maxU - x);
-		assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
+		mgl_assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
 		float y = d.Dot(vDir);
 		diffVMin = MATH_NS::Min(diffVMin, y - minV);
 		diffVMax = MATH_NS::Min(diffVMax, maxV - y);
-		assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
+		mgl_assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
 	}
-	assert1(diffUMin <= 1e-5f, diffUMin);
-	assert1(diffUMax <= 1e-5f, diffUMax);
-	assert1(diffVMin <= 1e-5f, diffVMin);
-	assert1(diffVMax <= 1e-5f, diffVMax);
+	mgl_assert1(diffUMin <= 1e-5f, diffUMin);
+	mgl_assert1(diffUMax <= 1e-5f, diffUMax);
+	mgl_assert1(diffVMin <= 1e-5f, diffVMin);
+	mgl_assert1(diffVMax <= 1e-5f, diffVMax);
 }
 
 
@@ -1399,7 +1399,7 @@ UNIQUE_TEST(float2_MinAreaRect_Case_5)
 	int numPointsInConvexHull = float2::ConvexHullInPlace(c, n);
 
 	for(int i = 0; i < n; ++i)
-		assert(float2::ConvexHullContains(c, numPointsInConvexHull, p[i]));
+		mgl_assert(float2::ConvexHullContains(c, numPointsInConvexHull, p[i]));
 	MARK_UNUSED(numPointsInConvexHull);
 
 	float2 center, uDir, vDir;
@@ -1414,16 +1414,16 @@ UNIQUE_TEST(float2_MinAreaRect_Case_5)
 		float x = d.Dot(uDir);
 		diffUMin = MATH_NS::Min(diffUMin, x - minU);
 		diffUMax = MATH_NS::Min(diffUMax, maxU - x);
-		assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
+		mgl_assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
 		float y = d.Dot(vDir);
 		diffVMin = MATH_NS::Min(diffVMin, y - minV);
 		diffVMax = MATH_NS::Min(diffVMax, maxV - y);
-		assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
+		mgl_assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
 	}
-	assert1(diffUMin <= 1e-5f, diffUMin);
-	assert1(diffUMax <= 1e-5f, diffUMax);
-	assert1(diffVMin <= 1e-5f, diffVMin);
-	assert1(diffVMax <= 1e-5f, diffVMax);
+	mgl_assert1(diffUMin <= 1e-5f, diffUMin);
+	mgl_assert1(diffUMax <= 1e-5f, diffUMax);
+	mgl_assert1(diffVMin <= 1e-5f, diffVMin);
+	mgl_assert1(diffVMax <= 1e-5f, diffVMax);
 }
 
 
@@ -1478,7 +1478,7 @@ p[13] = float2(-4.599999904632568,-2.510286331176758);
 	int numPointsInConvexHull = float2::ConvexHullInPlace(c, n);
 
 	for(int i = 0; i < n; ++i)
-		assert(float2::ConvexHullContains(c, numPointsInConvexHull, p[i]));
+		mgl_assert(float2::ConvexHullContains(c, numPointsInConvexHull, p[i]));
 	MARK_UNUSED(numPointsInConvexHull);
 
 	float2 center, uDir, vDir;
@@ -1493,16 +1493,16 @@ p[13] = float2(-4.599999904632568,-2.510286331176758);
 		float x = d.Dot(uDir);
 		diffUMin = MATH_NS::Min(diffUMin, x - minU);
 		diffUMax = MATH_NS::Min(diffUMax, maxU - x);
-		assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
+		mgl_assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
 		float y = d.Dot(vDir);
 		diffVMin = MATH_NS::Min(diffVMin, y - minV);
 		diffVMax = MATH_NS::Min(diffVMax, maxV - y);
-		assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
+		mgl_assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
 	}
-	assert1(diffUMin <= 1e-5f, diffUMin);
-	assert1(diffUMax <= 1e-5f, diffUMax);
-	assert1(diffVMin <= 1e-5f, diffVMin);
-	assert1(diffVMax <= 1e-5f, diffVMax);
+	mgl_assert1(diffUMin <= 1e-5f, diffUMin);
+	mgl_assert1(diffUMax <= 1e-5f, diffUMax);
+	mgl_assert1(diffVMin <= 1e-5f, diffVMin);
+	mgl_assert1(diffVMax <= 1e-5f, diffVMax);
 }
 RANDOMIZED_TEST(float2_MinAreaRect)
 {
@@ -1525,16 +1525,16 @@ RANDOMIZED_TEST(float2_MinAreaRect)
 		float x = d.Dot(uDir);
 		diffUMin = MATH_NS::Min(diffUMin, x - minU);
 		diffUMax = MATH_NS::Min(diffUMax, maxU - x);
-		assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
+		mgl_assert3(x >= minU-epsilon && x <= maxU+epsilon, x, minU, maxU);
 		float y = d.Dot(vDir);
 		diffVMin = MATH_NS::Min(diffVMin, y - minV);
 		diffVMax = MATH_NS::Min(diffVMax, maxV - y);
-		assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
+		mgl_assert3(y >= minV-epsilon && y <= maxV+epsilon, y, minV, maxV);
 	}
-	assert1(diffUMin <= 1e-5f, diffUMin);
-	assert1(diffUMax <= 1e-5f, diffUMax);
-	assert1(diffVMin <= 1e-5f, diffVMin);
-	assert1(diffVMax <= 1e-5f, diffVMax);
+	mgl_assert1(diffUMin <= 1e-5f, diffUMin);
+	mgl_assert1(diffUMax <= 1e-5f, diffUMax);
+	mgl_assert1(diffVMin <= 1e-5f, diffVMin);
+	mgl_assert1(diffVMax <= 1e-5f, diffVMax);
 }
 
 BENCHMARK(float2_MinAreaRect, "float2::MinAreaRect")
@@ -1557,12 +1557,12 @@ UNIQUE_TEST(MatrixTranspose)
 	simd4f b = set_ps(5.f,6.f,7.f,8.f);
 	simd4f c = set_ps(9.f,10.f,11.f,12.f);
 	simd4f d = set_ps(13.f,14.f,15.f,16.f);
-	
+
 	_MM_TRANSPOSE4_PS(a, b, c, d);
-	assert(float4(a).Equals(float4(4.f, 8.f, 12.f, 16.f)));
-	assert(float4(b).Equals(float4(3.f, 7.f, 11.f, 15.f)));
-	assert(float4(c).Equals(float4(2.f, 6.f, 10.f, 14.f)));
-	assert(float4(d).Equals(float4(1.f, 5.f, 9.f, 13.f)));
+	mgl_assert(float4(a).Equals(float4(4.f, 8.f, 12.f, 16.f)));
+	mgl_assert(float4(b).Equals(float4(3.f, 7.f, 11.f, 15.f)));
+	mgl_assert(float4(c).Equals(float4(2.f, 6.f, 10.f, 14.f)));
+	mgl_assert(float4(d).Equals(float4(1.f, 5.f, 9.f, 13.f)));
 }
 #endif
 
@@ -1576,11 +1576,11 @@ UNIQUE_TEST(float2_pointwise)
 	c *= b;
 	float2 d = a;
 	d /= b;
-	assert((a*b).Equals(float2(36.f, 32.f)));
-	assert((a/b).Equals(float2(4.f, 2.f)));
-	assert(c.Equals(float2(36.f, 32.f)));
-	assert(d.Equals(float2(4.f, 2.f)));
-	assert((12.f / b).Equals(float2(4.f, 3.f)));
+	mgl_assert((a*b).Equals(float2(36.f, 32.f)));
+	mgl_assert((a/b).Equals(float2(4.f, 2.f)));
+	mgl_assert(c.Equals(float2(36.f, 32.f)));
+	mgl_assert(d.Equals(float2(4.f, 2.f)));
+	mgl_assert((12.f / b).Equals(float2(4.f, 3.f)));
 }
 
 UNIQUE_TEST(float3_pointwise)
@@ -1591,11 +1591,11 @@ UNIQUE_TEST(float3_pointwise)
 	c *= b;
 	float3 d = a;
 	d /= b;
-	assert((a*b).Equals(float3(36.f, 32.f, 2700.f)));
-	assert((a/b).Equals(float3(4.f, 2.f, 3.f)));
-	assert(c.Equals(float3(36.f, 32.f, 2700.f)));
-	assert(d.Equals(float3(4.f, 2.f, 3.f)));
-	assert((360.f / b).Equals(float3(120.f, 90.f, 12.f)));
+	mgl_assert((a*b).Equals(float3(36.f, 32.f, 2700.f)));
+	mgl_assert((a/b).Equals(float3(4.f, 2.f, 3.f)));
+	mgl_assert(c.Equals(float3(36.f, 32.f, 2700.f)));
+	mgl_assert(d.Equals(float3(4.f, 2.f, 3.f)));
+	mgl_assert((360.f / b).Equals(float3(120.f, 90.f, 12.f)));
 }
 
 UNIQUE_TEST(float4_pointwise)
@@ -1606,11 +1606,11 @@ UNIQUE_TEST(float4_pointwise)
 	c *= b;
 	float4 d = a;
 	d /= b;
-	assert((a*b).Equals(float4(36.f, 32.f, 2700.f, -200.f)));
-	assert((a/b).Equals(float4(4.f, 2.f, 3.f, -2.f)));
-	assert(c.Equals(float4(36.f, 32.f, 2700.f, -200.f)));
-	assert(d.Equals(float4(4.f, 2.f, 3.f, -2.f)));
-	assert((3600.f / b).Equals(float4(1200.f, 900.f, 120.f, 360.f)));
+	mgl_assert((a*b).Equals(float4(36.f, 32.f, 2700.f, -200.f)));
+	mgl_assert((a/b).Equals(float4(4.f, 2.f, 3.f, -2.f)));
+	mgl_assert(c.Equals(float4(36.f, 32.f, 2700.f, -200.f)));
+	mgl_assert(d.Equals(float4(4.f, 2.f, 3.f, -2.f)));
+	mgl_assert((3600.f / b).Equals(float4(1200.f, 900.f, 120.f, 360.f)));
 }
 
 #endif


### PR DESCRIPTION
Hi @juj 

We use MathGeoLib alongside other libraries and recently suffered unexpected compilation errors whose cause took a bit of time to track. In the end, we found out it was actually due to MathGeoLib redefining `assume`, which broke other dependencies also using this common name (for instance, fmt: https://github.com/fmtlib/fmt/blob/739055ae7b08f8d5dffee9552334ede92e50b17b/include/fmt/format.h#L354)

This commit prefixes `assume` (as well as `assert` and `mathassert` for consistency) with "mgl_" to prevent that issue.
If you prefer, I could use another prefix.