### PR TITLE
Remove control character

### DIFF
--- a/src/Math/grisu3.c
+++ b/src/Math/grisu3.c
@@ -409,7 +409,7 @@ int dtoa_grisu3(double v, char *dst)
 	}
 
     // We now have an integer string of form "151324135" and a base-10 exponent for that number.
-    // Next, decide the best presentation for that string by whether to use a decimal point, or the scientific exponent notation 'e'.
+    // Next, decide the best presentation for that string by whether to use a decimal point, or the scientific exponent notation 'e'.
     // We don't pick the absolute shortest representation, but pick a balance between readability and shortness, e.g.
     // 1.545056189557677e-308 could be represented in a shorter form
     // 1545056189557677e-323 but that would be somewhat unreadable.


### PR DESCRIPTION
We use this grisu implementation in an R package (https://github.com/tidyverse/vroom/blob/main/src/grisu3.c) and recently noticed this file contains a control character that can make some editors refuse to open it (although emacs and vim, for example, don't seem to mind). I assume it's not here intentionally (?).

```
% head -n 412 src/Math/grisu3.c | tail -n 1 | xxd -s +111 -l 11       
0000006f: 6578 706f 6e65 6e74 1020 6e              exponent. n
          e x  p o  n e  n t  ^^   n                       ^

% file src/Math/grisu3.c
src/Math/grisu3.c: data
```

After this PR `file` correctly reports that this is ASCII text.

```
% file src/Math/grisu3.c                           
src/Math/grisu3.c: c program text, ASCII text
```

(thx @jmcphers for the detective work)