### PR TITLE
Add Windows ARM64/ARM64EC support fixes for NEON, callstack, and timing

### DIFF
--- a/src/Math/Callstack.cpp
+++ b/src/Math/Callstack.cpp
@@ -101,6 +101,11 @@ StringT NOINLINE GetCallstack(const char *indent, const char *ignoreFilter)
 	stack.AddrStack.Offset    = context.Rsp;
 	stack.AddrFrame.Offset    = context.Rbp;
 	const DWORD machineType = IMAGE_FILE_MACHINE_AMD64;
+#elif defined(_M_ARM64)
+	stack.AddrPC.Offset       = context.Pc;
+	stack.AddrStack.Offset    = context.Sp;
+	stack.AddrFrame.Offset    = context.Fp;
+	const DWORD machineType   = IMAGE_FILE_MACHINE_ARM64;
 #else
 	stack.AddrPC.Offset       = context.Eip;
 	stack.AddrStack.Offset    = context.Esp;

--- a/src/Math/MathFunc.h
+++ b/src/Math/MathFunc.h
@@ -213,9 +213,13 @@ float Frac(float x);
 FORCE_INLINE float Sqrt(float x)
 {
 #ifdef MATH_NEON
-	float result;
-	asm("vsqrt.f32 %0, %1" : "=w"(result) : "w"(x));
-	return result;
+	#if defined(_M_ARM64) || defined(_M_ARM64EC)
+		return vget_lane_f32(vsqrt_f32(vdup_n_f32(x)), 0);
+	#else
+		float result;
+		asm("vsqrt.f32 %0, %1" : "=w"(result) : "w"(x));
+		return result;
+	#endif
 #elif defined(MATH_SSE)
 	return s4f_x(_mm_sqrt_ss(setx_ps(x)));
 #else
@@ -227,9 +231,13 @@ FORCE_INLINE float Sqrt(float x)
 FORCE_INLINE float SqrtFast(float x)
 {
 #ifdef MATH_NEON
-	float result;
-	asm("vsqrt.f32 %0, %1" : "=w"(result) : "w"(x));
-	return result;
+	#if defined(_M_ARM64) || defined(_M_ARM64EC)
+		return vget_lane_f32(vsqrt_f32(vdup_n_f32(x)), 0);
+	#else
+		float result;
+		asm("vsqrt.f32 %0, %1" : "=w"(result) : "w"(x));
+		return result;
+	#endif
 #elif defined(MATH_SSE)
 	simd4f X = setx_ps(x);
 	return s4f_x(_mm_mul_ss(X, _mm_rsqrt_ss(X)));

--- a/src/Math/float4_neon.h
+++ b/src/Math/float4_neon.h
@@ -53,6 +53,7 @@ FORCE_INLINE simd4f cross_ps(simd4f a, simd4f b)
 }
 
 FORCE_INLINE simd4f dot4_ps(simd4f a, simd4f b);
+FORCE_INLINE simd4f dot3_ps(simd4f a, simd4f b);
 
 FORCE_INLINE void basis_ps(simd4f v, simd4f *outB, simd4f *outC)
 {

--- a/src/Math/simd.h
+++ b/src/Math/simd.h
@@ -665,7 +665,12 @@ FORCE_INLINE simd4f pos_from_scalar_ps(float scalar)
 FORCE_INLINE simd4f load_vec3(const float *ptr, float w)
 {
 	float32x2_t low = vld1_f32(ptr); // [y x]
-	float32x2_t high = (float32x2_t) { ptr[2], w }; // [w z]
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
+	float32x2_t high = vdup_n_f32(ptr[2]);
+	high = vset_lane_f32(w, high, 1);
+#else
+	float32x2_t high = (float32x2_t){ ptr[2], w }; // [w z]
+#endif
 	return vcombine_f32(low, high); // [w z y x]
 }
 

--- a/src/Time/Clock.cpp
+++ b/src/Time/Clock.cpp
@@ -275,7 +275,7 @@ tick_t Clock::TicksPerSec()
 
 unsigned long long Clock::Rdtsc()
 {
-#if defined(_MSC_VER) && !defined(WIN8PHONE)
+#if defined(_MSC_VER) && !defined(WIN8PHONE) && !defined(_M_ARM64)
 	return __rdtsc();
 #elif defined(__x86_64__)
 	unsigned hi, lo;


### PR DESCRIPTION
Add Windows ARM64 / ARM64EC support fixes for NEON, callstack, and timing

**### Summary**
---------------------------------
This PR improves Windows ARM64 and ARM64EC support by fixing several architecture-specific issues across math, SIMD, callstack, and timing code paths.

**### Key Changes**
-------------------------------
**Callstack**
  - Added correct ARM64 `CONTEXT` register mapping (`Pc`, `Sp`, `Fp`)
  - Use `IMAGE_FILE_MACHINE_ARM64` for proper stack walking on Windows ARM64

**Math / NEON**
  - Replace inline ARM assembly (`vsqrt.f32`) with ARM64-compatible NEON intrinsics
  - Explicitly handle MSVC ARM64 and ARM64EC builds

**SIMD**
  - Fix non-portable NEON vector initialization rejected by MSVC ARM64
  - Use `vdup_n_f32` + `vset_lane_f32` for standards-compliant code

**Build Fixes**
  - Add missing forward declaration for `dot3_ps`
  - Disable `__rdtsc()` on ARM64 to avoid invalid instruction usage

**### Impact**
-------------------------------
- Improves portability and correctness on Windows ARM64
- No functional changes on existing x86/x64 platforms
- Low risk, architecture-gated changes only

**###Build & Test**
----------------------------------
- Environment: Windows 11 on ARM64; MSVC (VS 2022 v143 toolset).
- Result: ARM64 and ARM64EC configurations compile cleanly; x86/x64 unchanged.
